### PR TITLE
Track expl3 updates

### DIFF
--- a/ctex/ctex.dtx
+++ b/ctex/ctex.dtx
@@ -4435,7 +4435,7 @@ This package consists of the file ctex.dtx, and the derived files
 %    \begin{macrocode}
 \prg_new_conditional:Npnn \ctex_ltj_if_alternate_shape_exist:n #1 { T , F , TF }
   {
-    \lua_now_x:n { luatexja.jfont.does_alt_set ('\luatexluaescapestring {#1}') }
+    \lua_now_x:n { luatexja.jfont.does_alt_set ('\lua_escape_x:n {#1}') }
       \prg_return_true: \else: \prg_return_false: \fi:
   }
 %    \end{macrocode}
@@ -4468,7 +4468,7 @@ This package consists of the file ctex.dtx, and the derived files
         \lua_now_x:n
           {
             luatexja.jfont.output_alt_font_cmd
-              ('y', '\luatexluaescapestring { \l_@@_current_shape_tl }')
+              ('y', '\lua_escape_x:n { \l_@@_current_shape_tl }')
           }
         \lua_now_x:n { luatexja.jfont.pickup_alt_font_a ('\f@size') }
       }
@@ -4511,7 +4511,7 @@ This package consists of the file ctex.dtx, and the derived files
     \lua_now_x:n
       {
         luatexja.jfont.pickup_alt_font_b
-          ( \the\ltj@tempcntc, '\luatexluaescapestring {#2}' )
+          ( \the\ltj@tempcntc, '\lua_escape_x:n {#2}' )
       }
   }
 %    \end{macrocode}
@@ -4525,7 +4525,7 @@ This package consists of the file ctex.dtx, and the derived files
 %    \begin{macrocode}
 \def\ltj@@IsFontJapanese#1{%
   \directlua{luatexja.jfont.is_kenc(string.match(
-      '\luatexluaescapestring{#1}', '[^/]+'))}}
+      '\lua_escape_x:n{#1}', '[^/]+'))}}
 {\catcode`M=12%
 \gdef\ltj@@mathJapaneseFonts#1M#2#3\relax{\ltj@@IsFontJapanese{#3}}}
 \let\ltj@@al@getanddefine@fonts=\getanddefine@fonts
@@ -5243,7 +5243,7 @@ This package consists of the file ctex.dtx, and the derived files
     \@@_save_alternate_shape:cnn
       { \@@_alternate_cs:n { clear / \l_@@_base_CJKfamily_tl } }
       { luatexja.jfont.clear_alt_font_latex }
-      { '\luatexluaescapestring { \CJK@encoding/#2/#3/#4 }' }
+      { '\lua_escape_x:n { \CJK@encoding/#2/#3/#4 }' }
   }
 %    \end{macrocode}
 % \end{macro}
@@ -5267,8 +5267,8 @@ This package consists of the file ctex.dtx, and the derived files
             \int_eval:n { \tl_if_blank:nTF {#3} { "80 } {#3} } ,
             \int_eval:n { \tl_if_blank:nTF {#4} { "10FFFF } {#4} } ,
           }
-        '\luatexluaescapestring { \CJK@encoding/#2 }' ,
-        '\luatexluaescapestring { \CJK@encoding/#1 }'
+        '\lua_escape_x:n { \CJK@encoding/#2 }' ,
+        '\lua_escape_x:n { \CJK@encoding/#1 }'
       }
   }
 \cs_new_protected_nopar:Npn \ctex_ltj_set_alternate_shape:n #1
@@ -5291,8 +5291,8 @@ This package consists of the file ctex.dtx, and the derived files
         \ctex_ltj_set_alternate_shape:n
           {
             ##1 ,
-            '\luatexluaescapestring { \CJK@encoding/#2 }' ,
-            '\luatexluaescapestring { \CJK@encoding/#1 }'
+            '\lua_escape_x:n { \CJK@encoding/#2 }' ,
+            '\lua_escape_x:n { \CJK@encoding/#1 }'
           }
       }
   }
@@ -5309,7 +5309,7 @@ This package consists of the file ctex.dtx, and the derived files
     \group_begin:
     \cs_if_exist:NF #1 { \cs_set_eq:NN #1 \prg_do_nothing: }
     \cs_set_eq:NN \l_@@_base_family_tl \scan_stop:
-    \cs_set_eq:NN \luatexluaescapestring \scan_stop:
+    \cs_set_eq:NN \lua_escape_x:n \scan_stop:
     \cs_gset_protected_nopar:Npx #1
       { \exp_not:o {#1} \exp_not:N \lua_now_x:n { #2 ( #3 ) } }
     \group_end:

--- a/ctex/ctex.dtx
+++ b/ctex/ctex.dtx
@@ -2629,7 +2629,7 @@ This package consists of the file ctex.dtx, and the derived files
 %       \xeCJKsetup { CheckSingle }
 %     }
 %   % 在使用 LuaTeX 编译时，设置 LuaTeX-ja 的 jcharwidowpenalty 参数。
-%   \luatex_if_engine:T
+%   \sys_if_engine_luatex:T
 %     {
 %       \ltjsetparameter { jcharwidowpenalty = 10000 }
 %     }

--- a/ctex/ctex.dtx
+++ b/ctex/ctex.dtx
@@ -3114,13 +3114,6 @@ This package consists of the file ctex.dtx, and the derived files
   }
 %    \end{macrocode}
 %
-% \begin{macro}[int]{\ctex_lua_now_x:n}
-% 最新的 \pkg{expl3} 去掉了 \pkg{l3luatex} 模块，因而 \cs{lua_now_x:n} 不再有定义。
-%    \begin{macrocode}
-\cs_new_eq:NN \ctex_lua_now_x:n \luatex_directlua:D
-%    \end{macrocode}
-% \end{macro}
-%
 % \changes{v2.1}{2015/05/25}{不依赖 \pkg{ifpdf} 宏包。}
 %
 % \begin{macro}[int]{\ctex_if_pdfmode:TF}
@@ -4232,7 +4225,7 @@ This package consists of the file ctex.dtx, and the derived files
 \AtBeginUTFCommand
   {
     \group_begin:
-    \ctex_lua_now_x:n { tex.globaldefs = 0 }
+    \lua_now_x:n { tex.globaldefs = 0 }
     \ltj@allalchar
   }
 \AtEndUTFCommand { \group_end: }
@@ -4257,7 +4250,7 @@ This package consists of the file ctex.dtx, and the derived files
             {
               \mode_if_math:TF { ^^@ }
                 { {
-                    \ctex_lua_now_x:n { tex.globaldefs = 0 }
+                    \lua_now_x:n { tex.globaldefs = 0 }
                     \ltj@allalchar ^^@
                 } }
             }
@@ -4390,7 +4383,7 @@ This package consists of the file ctex.dtx, and the derived files
 % 赋值总是全局的，不会受到分组的影响。
 %    \begin{macrocode}
     \font@name
-    \ctex_lua_now_x:n { font.current(tex.getattribute('ltj@curjfnt')) }
+    \lua_now_x:n { font.current(tex.getattribute('ltj@curjfnt')) }
     \use:c { \f@encoding + \f@family }
     \use:c { \curr@fontshape }
   }
@@ -4442,7 +4435,7 @@ This package consists of the file ctex.dtx, and the derived files
 %    \begin{macrocode}
 \prg_new_conditional:Npnn \ctex_ltj_if_alternate_shape_exist:n #1 { T , F , TF }
   {
-    \ctex_lua_now_x:n { luatexja.jfont.does_alt_set ('\luatexluaescapestring {#1}') }
+    \lua_now_x:n { luatexja.jfont.does_alt_set ('\luatexluaescapestring {#1}') }
       \prg_return_true: \else: \prg_return_false: \fi:
   }
 %    \end{macrocode}
@@ -4461,7 +4454,7 @@ This package consists of the file ctex.dtx, and the derived files
 % \texttt{font.id} 唯一。
 %    \begin{macrocode}
 \cs_new_nopar:Npn \@@_patch_external_font:w #1 ~ at
-  { #1 \ctex_lua_now_x:n { luatexja.jfont.print_aftl_address() } ~ at }
+  { #1 \lua_now_x:n { luatexja.jfont.print_aftl_address() } ~ at }
 %    \end{macrocode}
 % \end{macro}
 %
@@ -4472,12 +4465,12 @@ This package consists of the file ctex.dtx, and the derived files
   {
     \ctex_ltj_if_alternate_shape_exist:nT { \l_@@_current_shape_tl }
       {
-        \ctex_lua_now_x:n
+        \lua_now_x:n
           {
             luatexja.jfont.output_alt_font_cmd
               ('y', '\luatexluaescapestring { \l_@@_current_shape_tl }')
           }
-        \ctex_lua_now_x:n { luatexja.jfont.pickup_alt_font_a ('\f@size') }
+        \lua_now_x:n { luatexja.jfont.pickup_alt_font_a ('\f@size') }
       }
   }
 \tl_new:N \l_@@_current_shape_tl
@@ -4515,7 +4508,7 @@ This package consists of the file ctex.dtx, and the derived files
 \cs_new_protected_nopar:Npn \ltj@pickup@altfont@copy #1#2
   {
     \ltj@@getjfontnumber #1
-    \ctex_lua_now_x:n
+    \lua_now_x:n
       {
         luatexja.jfont.pickup_alt_font_b
           ( \the\ltj@tempcntc, '\luatexluaescapestring {#2}' )
@@ -4599,7 +4592,7 @@ This package consists of the file ctex.dtx, and the derived files
 \tl_const:Nn \CJK@encoding { LTJY3 }
 \DeclareFontEncoding { \CJK@encoding } { } { }
 \DeclareFontSubstitution { LTJY3 } { song } { \mddefault } { \updefault }
-\ctex_lua_now_x:n { luatexja.jfont.add_kyenc_list('\CJK@encoding') }
+\lua_now_x:n { luatexja.jfont.add_kyenc_list('\CJK@encoding') }
 \cs_new_protected_nopar:Npn \@@_change_encoding:
   { \tl_set_eq:NN \g_fontspec_encoding_tl \CJK@encoding }
 \DeclareFontFamily { \CJK@encoding } { song } { }
@@ -5280,7 +5273,7 @@ This package consists of the file ctex.dtx, and the derived files
   }
 \cs_new_protected_nopar:Npn \ctex_ltj_set_alternate_shape:n #1
   {
-    \ctex_lua_now_x:n { luatexja.jfont.set_alt_font_latex ( #1 ) }
+    \lua_now_x:n { luatexja.jfont.set_alt_font_latex ( #1 ) }
     \@@_save_alternate_shape:cnn
       { \@@_alternate_cs:n { reset / \l_@@_base_CJKfamily_tl } }
       { luatexja.jfont.set_alt_font_latex } {#1}
@@ -5318,7 +5311,7 @@ This package consists of the file ctex.dtx, and the derived files
     \cs_set_eq:NN \l_@@_base_family_tl \scan_stop:
     \cs_set_eq:NN \luatexluaescapestring \scan_stop:
     \cs_gset_protected_nopar:Npx #1
-      { \exp_not:o {#1} \exp_not:N \ctex_lua_now_x:n { #2 ( #3 ) } }
+      { \exp_not:o {#1} \exp_not:N \lua_now_x:n { #2 ( #3 ) } }
     \group_end:
   }
 \cs_generate_variant:Nn \@@_save_alternate_shape:Nnn { c }
@@ -5604,7 +5597,7 @@ This package consists of the file ctex.dtx, and the derived files
   {
     \tl_gset:Nx \g_@@_fontset_tl
       {
-        \ctex_lua_now_x:n
+        \lua_now_x:n
           {
             if ~ os.name == 'windows' then ~
               tex.sprint ( 'windows' )

--- a/xCJK2uni/xCJK2uni.dtx
+++ b/xCJK2uni/xCJK2uni.dtx
@@ -756,7 +756,7 @@ and some specific Chinese Simplified fonts.
   {
     \tl_gset:Nx \g_@@_path_str
       {
-        \luatex_directlua:D
+        \lua_now_x:n
           {
             kpse.set_program_name("luatex") ~
             local ~ sfd = kpse.find_file("UGBK.sfd", "subfont~definition~files") ~

--- a/xCJK2uni/xCJK2uni.dtx
+++ b/xCJK2uni/xCJK2uni.dtx
@@ -752,7 +752,7 @@ and some specific Chinese Simplified fonts.
 %    \begin{macrocode}
 \ior_new:N \g_@@_sfd_ior
 \tl_new:N \g_@@_path_str
-\luatex_if_engine:TF
+\sys_if_engine_luatex:TF
   {
     \tl_gset:Nx \g_@@_path_str
       {

--- a/xpinyin/xpinyin.dtx
+++ b/xpinyin/xpinyin.dtx
@@ -551,7 +551,7 @@ and some specific Chinese Simplified fonts (TrueType or OpenType).
     You~must~change~your~typesetting~engine~to\\
     "xelatex"~or~"pdflatex"~or~"latex"~instead~of~"lualatex".
   }
-\luatex_if_engine:T { \msg_critical:nn { xpinyin } { no-LuaTeX } }
+\sys_if_engine_luatex:T { \msg_critical:nn { xpinyin } { no-LuaTeX } }
 %    \end{macrocode}
 %
 %    \begin{macrocode}


### PR DESCRIPTION
Three changes here:
 - `\luatex_if_engine:(TF)` is being replaced by `\sys_if_engine_luatex:(TF)`
 - We've re-introduced `\lua_now_x:n`
 - We've re-introduced `\lua_escape_x:n`, and this avoids having to worry about the name
   of `\(luatex)luaescapestring` (to be shortened to `\luaescapestring` in an upcoming 
  kernel update)