### PR TITLE
ctex: fix a typo

### DIFF
--- a/ctex/ctex.dtx
+++ b/ctex/ctex.dtx
@@ -4863,7 +4863,7 @@ Copyright and Licence
 %    \end{macrocode}
 % \end{macro}
 %
-% \begin{macro}[int,TF]{\ctex_ltj_family_if_exist:n}
+% \begin{macro}[int,TF]{\ctex_ltj_family_if_exist:xN}
 % 判断 CJK 字体族 |#1| 是否存在，若存在则把实际族名保存到 |#2| 中。
 %    \begin{macrocode}
 \prg_new_protected_conditional:Npnn \ctex_ltj_family_if_exist:xN #1#2 { T , F , TF }


### PR DESCRIPTION
`\ctex_ltj_family_if_exist:nTF` 的描述应该是漏了一个 `N`。不知道第一个参数要不要改成 `n` 呢？