### PR TITLE
避免使用过长的行

### DIFF
--- a/ctex/ctex.dtx
+++ b/ctex/ctex.dtx
@@ -8185,7 +8185,8 @@ Copyright and Licence
 \defbeamertemplate*{part page}{CTEX}[1][]{
   \begingroup
 %    \centering
-%    {\usebeamerfont{part name}\usebeamercolor[fg]{part name}\partname~\insertromanpartnumber}
+%    {\usebeamerfont{part name}%
+%     \usebeamercolor[fg]{part name}\partname~\insertromanpartnumber}
 %    \vskip1em\par
     \par \addvspace{\glueexpr\CTEX@part@beforeskip\relax}%
     \parindent \dimexpr \CTEX@part@indent \relax
@@ -8207,7 +8208,8 @@ Copyright and Licence
 \defbeamertemplate*{section page}{CTEX}[1][]{
   \begingroup
 %    \centering
-%    {\usebeamerfont{section name}\usebeamercolor[fg]{section name}\sectionname~\insertsectionnumber}
+%    {\usebeamerfont{section name}%
+%     \usebeamercolor[fg]{section name}\sectionname~\insertsectionnumber}
 %    \vskip1em\par
     \par \addvspace{\glueexpr\CTEX@section@beforeskip\relax}%
     \parindent \dimexpr \CTEX@section@indent \relax
@@ -8229,7 +8231,8 @@ Copyright and Licence
 \defbeamertemplate*{subsection page}{CTEX}[1][]{
   \begingroup
 %    \centering
-%    {\usebeamerfont{subsection name}\usebeamercolor[fg]{subsection name}\subsectionname~\insertsubsectionnumber}
+%    {\usebeamerfont{subsection name}%
+%     \usebeamercolor[fg]{subsection name}\subsectionname~\insertsubsectionnumber}
 %    \vskip1em\par
     \par \addvspace{\glueexpr\CTEX@subsection@beforeskip\relax}%
     \parindent \dimexpr \CTEX@subsection@indent \relax
@@ -9419,8 +9422,7 @@ Copyright and Licence
 %<*fontset>
 %    \end{macrocode}
 %
-% \subsubsection{\pkg{ctex-fontset-windows.def},
-% \pkg{ctex-fontset-windowsnew.def}, \pkg{ctex-fontset-windowsold.def}}
+% \subsubsection{\pkg{ctex-fontset-windows.def} 等}
 %
 % \changes{v2.4.1}{2016/05/14}{使用 \file{bootfont.bin} 判断 Windows XP 以避免
 % 权限问题。}
@@ -9462,7 +9464,8 @@ Copyright and Licence
         \ctex_punct_map_family:nn { \CJKsfdefault } { zhhei }
 %</windowsold>
 %<*windowsnew>
-        \setCJKsansfont [ BoldFont = msyhbd\l_@@_msyh_suffix_tl ] { msyh\l_@@_msyh_suffix_tl }
+        \setCJKsansfont
+          [ BoldFont = msyhbd\l_@@_msyh_suffix_tl ] { msyh\l_@@_msyh_suffix_tl }
         \setCJKfamilyfont { zhyahei }
           [ BoldFont = msyhbd\l_@@_msyh_suffix_tl ] { msyh\l_@@_msyh_suffix_tl }
         \ctex_punct_map_family:nn { \CJKsfdefault } { zhyahei }
@@ -9692,9 +9695,13 @@ Copyright and Licence
       }
       {
         \setCJKmainfont
-          [ Extension = .otf , BoldFont = FandolSong-Bold , ItalicFont = FandolKai-Regular ]
+          [
+            Extension = .otf ,
+            BoldFont = FandolSong-Bold , ItalicFont = FandolKai-Regular
+          ]
           { FandolSong-Regular }
-        \setCJKsansfont [ Extension = .otf , BoldFont = FandolHei-Bold ] { FandolHei-Regular }
+        \setCJKsansfont
+          [ Extension = .otf , BoldFont = FandolHei-Bold ] { FandolHei-Regular }
         \setCJKmonofont [ Extension = .otf ] { FandolFang-Regular }
         \setCJKfamilyfont { zhsong }
           [ Extension = .otf , BoldFont = FandolSong-Bold ] { FandolSong-Regular }

--- a/xeCJK/xeCJK.dtx
+++ b/xeCJK/xeCJK.dtx
@@ -9678,7 +9678,6 @@ Copyright and Licence
       }
     \@@_listings_append:nN
   }
-\bool_new:N \l_@@_listings_letter_bool
 \cs_new_protected_nopar:Npn \@@_listings_process_other:nN #1#2
   {
     \lst@whitespacefalse


### PR DESCRIPTION
`ctex` 有几行代码比较长，文档中会超出纸面。

另外 `xeCJK` 里面 `\l__xeCJK_listings_letter_bool` 的定义往前放了一点。（应该是无所谓的）