### PR TITLE
ctex: 修正 guard 问题

### DIFF
--- a/ctex/ctex.dtx
+++ b/ctex/ctex.dtx
@@ -6463,14 +6463,13 @@ Copyright and Licence
 %
 %    \begin{macrocode}
 %</pdftex|xetex|luatex|uptex|aptex>
-%<*class|ctex>
 %    \end{macrocode}
 %
 % \subsubsection{载入引擎定义文件}
 %
 % 最后载入各个编译引擎的定义文件。
 %    \begin{macrocode}
-\ctex_file_input:n { \c_@@_engine_file_str }
+%<class|ctex>\ctex_file_input:n { \c_@@_engine_file_str }
 %    \end{macrocode}
 %
 % \subsection{用户设置接口}
@@ -6502,7 +6501,6 @@ Copyright and Licence
       { \ctexset~ {~ #1~ }~ is~ set. }
     \IfNoValueF {#1} { \keys_set:nn { ctex } {#1} }
   }
-%</class|ctex>
 %    \end{macrocode}
 % \end{macro}
 %


### PR DESCRIPTION
似乎是 guard 写得不太对，导致 `ctexheading` 包里面 `\ctexset` 未定义。不过这边最好还是要再仔细检查一下。