### PR TITLE
ctex: 更新宏包依赖情况

### DIFF
--- a/ctex/ctex.dtx
+++ b/ctex/ctex.dtx
@@ -2866,30 +2866,32 @@ Copyright and Licence
 %   \item \pkg{zhmCJK} 宏包，它还依赖 \pkg{oberdiek} 宏集。
 %   \item[\ding{229}] 以上是使用 \pdfLaTeX{} 或 \LaTeX{} + \dvipdfmx{} 的编译方式所需要
 %   的依赖项，其中 \pkg{zhmCJK} 是可选的。
-%   \item \pkg{xeCJK} 宏包，它还依赖
+%   \item \pkg{xeCJK} 宏集，它还依赖
 %   \begin{itemize}
-%     \item \pkg{fontspec} 宏包，它还依赖
-%     \begin{itemize}
-%       \item \pkg{euenc} 宏包。
-%       \item \pkg{xunicode} 宏包，它还依赖
-%       \begin{itemize}
-%         \item \pkg{graphics} 宏集。
-%         \item \pkg{graphics-cfg} 宏包。
-%         \item \pkg{graphics-def} 宏包。
-%       \end{itemize}
-%     \end{itemize}
+%     \item \pkg{xtemplate} 宏包，它属于 \pkg{l3packages} 宏集。
+%     \item \pkg{fontspec} 宏包。
 %   \end{itemize}
 %   \item \pkg{environ} 宏包，它还依赖 \pkg{trimspaces} 宏包。
 %   \item[\ding{229}] 以上是使用 \XeLaTeX{} 编译时的依赖项。
-%   \item \pkg{LuaTeX-ja} 宏集，它还依赖
+%   \item \pkg{luatexja} 宏包，它还依赖
 %   \begin{itemize}
 %     \item \pkg{adobemapping} 宏包。
-%     \item \pkg{fontspec} 宏包。
 %     \item \pkg{lualibs} 宏包。
 %     \item \pkg{luaotfload} 宏包。
 %     \item \pkg{luatexbase} 宏包，它还依赖 \pkg{ctablestack} 宏包。
 %     \item \pkg{oberdiek} 宏集。
 %     \item \pkg{xkeyval} 宏包。
+%     \item \pkg{etoolbox} 宏包。
+%   \end{itemize}
+%   \item \pkg{fontspec} 宏包。
+%   \item \pkg{xunicode-addon} 宏包，属于 \pkg{xeCJK} 宏集，它还依赖
+%   \begin{itemize}
+%     \item \pkg{xunicode} 宏包，它还依赖
+%     \begin{itemize}
+%       \item \pkg{graphics} 宏集。
+%       \item \pkg{graphics-cfg} 宏包。
+%       \item \pkg{graphics-def} 宏包。
+%     \end{itemize}
 %   \end{itemize}
 %   \item[\ding{229}] 以上是使用 \LuaLaTeX{} 编译时的依赖项。
 %   \item \pkg{pxeverysel} 宏包，属于 \pkg{platex-tools} 宏集。


### PR DESCRIPTION
`fontspec` 宏包之前做过修改，不再依赖 `xunicode`，但用 luatex 编译时仍然需要 `xunicode-addon`。