### PR TITLE
upzhm-{h,v}.pl: sync with texjporg/uptex-fonts/2018-03-28

### DIFF
--- a/zhmetrics-uptex/makemetrics.lua
+++ b/zhmetrics-uptex/makemetrics.lua
@@ -5,7 +5,7 @@
 
 local fonts = {'serif', 'serifit', 'serifb', 'sans', 'sansb', 'mono'}
 local pltopf = 'uppltotf -kanji=uptex'
-local makejvf = 'makejvf -i -u gb'
+local makejvf = 'makejvf -e -3 -i -u gb'
 
 for _, hv in pairs({'h', 'v'}) do
 	for _, fnt in pairs(fonts) do

--- a/zhmetrics-uptex/upzhm-h.pl
+++ b/zhmetrics-uptex/upzhm-h.pl
@@ -56,17 +56,20 @@
    ‘ “ （ 〔 ［ ｛ 〈 《 「 『
    【
    UFF5F U3018 U3016 U301D
+   U2329 U301A
    )
 (CHARSINTYPE O 2
-   、 ， ’ ” ） 〕 ］ ｝ 〉 》
+   、 ， ： ； ’ ” ） 〕 ］ ｝ 〉 》
    」 』 】
    UFF60 U3019 U3017 U301F
+   U232A U301B U301E
    )
 (CHARSINTYPE O 3
-   ・ ： ；
+   ・
+   U00B7
    )
 (CHARSINTYPE O 4
-   。 ．
+   。 ． ？ ！
    )
 (CHARSINTYPE O 5
    — ― … ‥

--- a/zhmetrics-uptex/upzhm-v.pl
+++ b/zhmetrics-uptex/upzhm-v.pl
@@ -56,14 +56,17 @@
    ‘ “ （ 〔 ［ ｛ 〈 《 「 『
    【
    UFF5F U3018 U3016 U301D
+   U2329 U301A
    )
 (CHARSINTYPE O 2
    、 ， ’ ” ） 〕 ］ ｝ 〉 》
    」 』 】
    UFF60 U3019 U3017 U301F
+   U232A U301B U301E
    )
 (CHARSINTYPE O 3
    ・ ： ；
+   U00B7
    )
 (CHARSINTYPE O 4
    。 ．


### PR DESCRIPTION
Based on #292, we (texjporg) refined characterizations of Chinese punctuations, upschr-{h,v}.{pl,tfm,vf}. This pull request is to adopt these changes into zhmetrics-uptex. To build these TFM/VF, latest versions of uppltotf and makejvf are required (TeX Live 2018 supplies them), so makemetrics.lua is also updated.