### PR TITLE
docs(xeCJK): fix typo

### DIFF
--- a/xeCJK/xeCJK.dtx
+++ b/xeCJK/xeCJK.dtx
@@ -7060,7 +7060,7 @@ Copyright and Licence
 %
 % \begin{macro}{\setCJKfamilyfont, \newCJKfontfamily, \CJKfontspec}
 % \changes{v3.4.3}{2016/11/18}{允许字体属性可选项在后的新语法。}
-% 分别用于预声明 CJK 字体和声明并随即调用 CJK 字体。
+% 分别用于预声明 CJK 字体族和声明并马上调用 CJK 字体族。
 %    \begin{macrocode}
 \NewDocumentCommand \setCJKfamilyfont { m o m }
   {

--- a/xeCJK/xeCJK.dtx
+++ b/xeCJK/xeCJK.dtx
@@ -773,7 +773,7 @@ Copyright and Licence
 %     \tn{CJKfontspec} \Arg{font name}\oarg{font features} 或\\
 %     \tn{CJKfontspec} \oarg{font features} \Arg{font name}
 %   \end{syntax}
-%   在文档中随机定义新的 CJK 字体族，并马上使用它。
+%   在文档中定义新的 CJK 字体族，并马上使用它。
 % \end{function}
 %
 % \begin{function}[rEXP]{\defaultCJKfontfeatures}
@@ -7060,7 +7060,7 @@ Copyright and Licence
 %
 % \begin{macro}{\setCJKfamilyfont, \newCJKfontfamily, \CJKfontspec}
 % \changes{v3.4.3}{2016/11/18}{允许字体属性可选项在后的新语法。}
-% 分别用于预声明 CJK 字体和随机调用 CJK 字体。
+% 分别用于预声明 CJK 字体和声明并随即调用 CJK 字体。
 %    \begin{macrocode}
 \NewDocumentCommand \setCJKfamilyfont { m o m }
   {


### PR DESCRIPTION
 * 原文将「随即」错写为「随机」
 * 现统一改为「马上」，并统一使用「CJK 字体族」名词