### PR TITLE
jiazhu: 添加垂向对齐功能

### DIFF
--- a/jiazhu/jiazhu.dtx
+++ b/jiazhu/jiazhu.dtx
@@ -141,7 +141,7 @@ Copyright and Licence
 %</driver>
 % \fi
 %
-% \CheckSum{899}
+% \CheckSum{971}
 % \GetFileId{jiazhu.sty}
 %
 % \title{\bfseries\pkg{jiazhu} 宏包}
@@ -317,7 +317,7 @@ Copyright and Licence
 %     opening = \Arg{前置内容}
 %   \end{syntax}
 %   指定前置于夹注的括弧。默认不添加。例如，
-%   \begin{SideBySideExample}[frame=single,numbers=left,xrightmargin=.25\linewidth,gobble=5]
+%   \begin{SideBySideExample}[frame=single,numbers=left,xrightmargin=.3\linewidth,gobble=5]
 %     正文\jiazhu[opening=〖]{夹注前置了左空心括号}正文
 %   \end{SideBySideExample}
 % \end{function}
@@ -327,7 +327,7 @@ Copyright and Licence
 %     closing = \Arg{后置内容}
 %   \end{syntax}
 %   指定后置于夹注的括弧。默认不添加。例如，
-%   \begin{SideBySideExample}[frame=single,numbers=left,xrightmargin=.25\linewidth,gobble=5]
+%   \begin{SideBySideExample}[frame=single,numbers=left,xrightmargin=.3\linewidth,gobble=5]
 %     正文\jiazhu[closing=】]{夹注后置了右实心括号}正文
 %   \end{SideBySideExample}
 % \end{function}
@@ -382,18 +382,18 @@ Copyright and Licence
 %   \end{SideBySideExample}
 % \end{function}
 %
-% \begin{function}{alignment}
+% \begin{function}{halign}
 %   \begin{syntax}
-%     alignment = <(justified)|left|right|centered|distributed>
+%     halign = <(justified)|left|right|centered|distributed>
 %   \end{syntax}
-%   指定夹注内容的对齐样式。默认值是 \opt{justified}。
+%   指定夹注内容的横向对齐样式。默认值是 \opt{justified}。
 %   其中，\opt{left}、\opt{right}、\opt{centered}
 %   分别为“左对齐”、“右对齐”、“居中对齐”。例如，
-%   \begin{SideBySideExample}[frame=single,numbers=left,xrightmargin=.2\linewidth,gobble=5]
+%   \begin{SideBySideExample}[frame=single,numbers=left,xrightmargin=.22\linewidth,gobble=5]
 %     \jiazhuset{lines=3,ratio=0.5}
-%     正文\jiazhu[alignment=left]{This is a three-line example}正文\\[5pt]
-%     正文\jiazhu[alignment=right]{This is a three-line example}正文\\[5pt]
-%     正文\jiazhu[alignment=centered]{This is a three-line example}正文
+%     正文\jiazhu[halign=left]{This is a three-line example}正文\\[5pt]
+%     正文\jiazhu[halign=right]{This is a three-line example}正文\\[5pt]
+%     正文\jiazhu[halign=centered]{This is a three-line example}正文
 %   \end{SideBySideExample}
 %
 %   \medskip
@@ -403,14 +403,29 @@ Copyright and Licence
 %   在 \opt{distributed} 样式下，末行仍然两端对齐。
 %   例如，
 %   \begin{SideBySideExample}[frame=single,numbers=left,xrightmargin=.25\linewidth,gobble=5]
-%     正文\jiazhu[alignment=justified]{㈠㈡㈢㈣㈤㈥㈦㈧㈨}正文\\
-%     正文\jiazhu[alignment=distributed]{㈠㈡㈢㈣㈤㈥㈦㈧㈨}正文
+%     正文\jiazhu[halign=justified]{㈠㈡㈢㈣㈤㈥㈦㈧㈨}正文\\
+%     正文\jiazhu[halign=distributed]{㈠㈡㈢㈣㈤㈥㈦㈧㈨}正文
 %   \end{SideBySideExample}
 %
 %   \medskip
 %
 %   \emph{传统排印一般只使用 \opt{justified}，不使用
 %   \opt{left}、\opt{right}、\opt{centered} 或 \opt{distributed}。}
+% \end{function}
+%
+% \begin{function}{valign}
+%   \begin{syntax}
+%     valign = <(middle)|bottom|top>
+%   \end{syntax}
+%   与 \opt{halign} 类似，\opt{valign} 指定夹注内容的纵向对齐样式。
+%   默认值是 \opt{middle}，即中线对齐。
+%   其中，\opt{bottom}、\opt{top}
+%   分别为“底线对齐”、“顶线对齐”。例如，
+%   \begin{SideBySideExample}[frame=single,numbers=left,xrightmargin=.25\linewidth,gobble=5]
+%     \jiazhuset{lines=1,ratio=0.5}
+%     正文\jiazhu[valign=bottom]{夹注现在底线对齐}正文\\
+%     正文\jiazhu[valign=top]{夹注现在顶线对齐}正文
+%   \end{SideBySideExample}
 % \end{function}
 %
 % \begin{function}{shortcut}
@@ -785,60 +800,143 @@ Copyright and Licence
 % 其中正文为~$r_{\mathrm{outer}}$、夹注为~$r_{\mathrm{inner}}$；
 % 又设 $s_{\mathrm{outer}}$ 与 $s_{\mathrm{inner}}$ 分别为正文字号与
 % 夹注字号；记夹注的行距为~$b$（夹注的行间距即为 $b-s_{\mathrm{inner}}$）；
-% 最后设夹注有 $n$~行。为了实现在正文汉字的中线处对齐，夹注需要向下平移，
-% 该平移量的计算公式为
-% \[
-%    (r_{\mathrm{inner}}-0.5) \cdot s_{\mathrm{inner}} + \frac{(n-1) \cdot b}{2}
-%  - (r_{\mathrm{outer}}-0.5) \cdot s_{\mathrm{outer}}, \quad n\ge 1.
-% \]
+% 最后设夹注有 $n$~行。
+%
+% 为了实现在正文汉字的各处对齐，夹注需要向下平移，平移量各不相同。
+% \begin{itemize}
+%   \item 底线对齐时，不需要考虑多行情况，平移量计算公式为
+%         \[
+%            s_{\mathrm{outer}} \cdot (1 - r_{\mathrm{outer}})
+%          - s_{\mathrm{inner}} \cdot (1 - r_{\mathrm{inner}}) .
+%         \]
+%   \item 中线对齐时，平移量的计算公式为
+%         \[
+%            (r_{\mathrm{inner}} - 0.5) \cdot s_{\mathrm{inner}}
+%          + \frac{(n - 1) \cdot b}{2} - (r_{\mathrm{outer}} - 0.5)
+%          \cdot s_{\mathrm{outer}} , \quad n \ge 1.
+%         \]
+%   \item 顶线对齐时，平移量的计算公式为
+%         \[
+%            r_{\mathrm{inner}} \cdot s_{\mathrm{inner}} + (n - 1) \cdot b
+%          - r_{\mathrm{outer}} \cdot s_{\mathrm{outer}} , \quad n \ge 1.
+%         \]
+% \end{itemize}
+% 
 %    \begin{macrocode}
+\cs_new_protected:Npn \@@_set_valign:n #1
+  { \cs_set_eq:Nc \@@_valign: { @@_valign_ #1 : } }
 \cs_new_protected:Npn \@@_calc_box_offset:
   {
+    \tl_if_eq:NNT \@@_valign: \@@_valign_middle:
+      {
 %    \end{macrocode}
-% 这里提前展开 $r-0.5$ 的计算结果，避免后续的重复计算。
+% 中线对齐时，提前展开 $r-0.5$ 的计算结果，避免后续重复计算。
 %    \begin{macrocode}
-    \exp_args:Nxx \@@_calc_box_offset_aux:nn
+        \exp_args:Nxx \@@_calc_box_offset_aux:nn
 %    \end{macrocode}
 % 首先是 $r_{\mathrm{inner}}-0.5$ 的计算结果。
 %    \begin{macrocode}
-      {
-        \fp_compare:nNnTF \l_@@_jzideoht_fp = \c_zero_fp
-          { \fp_eval:n { \l_@@_ideoht_fp   - 0.5 } }
-          { \fp_eval:n { \l_@@_jzideoht_fp - 0.5 } }
-      }
+          {
+            \fp_compare:nNnTF \l_@@_jzideoht_fp = \c_zero_fp
+              { \fp_eval:n { \l_@@_ideoht_fp   - 0.5 } }
+              { \fp_eval:n { \l_@@_jzideoht_fp - 0.5 } }
+          }
 %    \end{macrocode}
 % 其次是 $r_{\mathrm{outer}}-0.5$ 的计算结果。
 %    \begin{macrocode}
-      { \fp_eval:n { \l_@@_ideoht_fp - 0.5 } }
+          { \fp_eval:n { \l_@@_ideoht_fp - 0.5 } }
+      }
+    \tl_if_eq:NNT \@@_valign: \@@_valign_bottom:
+%    \end{macrocode}
+% 底线对齐时，则展开 $1-r_{\mathrm{outer}}$ 的计算结果。
+%    \begin{macrocode}
+      {
+        \exp_args:Nxx \@@_calc_box_offset_aux:nn
+          {
+            \fp_compare:nNnTF \l_@@_jzideoht_fp = \c_zero_fp
+              { \fp_eval:n { 1 -   \l_@@_ideoht_fp } }
+              { \fp_eval:n { 1 - \l_@@_jzideoht_fp } }
+          }
+          { \fp_eval:n { 1 - \l_@@_ideoht_fp } }
+      }
+    \tl_if_eq:NNT \@@_valign: \@@_valign_top:
+      {
+%    \end{macrocode}
+% 顶线对齐时
+%    \begin{macrocode}
+        \exp_args:Nxx \@@_calc_box_offset_aux:nn
+          {
+            \fp_compare:nNnTF \l_@@_jzideoht_fp = \c_zero_fp
+              { \fp_eval:n { \l_@@_ideoht_fp   } }
+              { \fp_eval:n { \l_@@_jzideoht_fp } }
+          }
+          { \fp_eval:n { \l_@@_ideoht_fp } }
+      }
   }
 \cs_new_protected:Npn \@@_calc_box_offset_aux:nn #1#2
   {
-%    \end{macrocode}
-% 对于夹注内容盒子的下移量，我们直接套用公式。
-%    \begin{macrocode}
-    \dim_set:Nn \l_@@_box_offset_dim
+    \tl_if_eq:NNT \@@_valign: \@@_valign_middle:
       {
-          #1 \l_@@_unit_dim
-        + \int_eval:n { \l_@@_lines_int - 1 } \tex_baselineskip:D / 2
-        - #2 \l_@@_outer_unit_dim
-      }
+%    \end{macrocode}
+% 中线对齐时，对于夹注内容盒子的下移量，我们直接套用公式。
+%    \begin{macrocode}
+        \dim_set:Nn \l_@@_box_offset_dim
+          {
+              #1 \l_@@_unit_dim
+            + \int_eval:n { \l_@@_lines_int - 1 } \tex_baselineskip:D / 2
+            - #2 \l_@@_outer_unit_dim
+          }
 %    \end{macrocode}
 % 对于夹注两端括弧盒子的下移量，我们修改 $s_{\mathrm{inner}}$ 为括弧字号，
 % 并取 $n=1$ 即可。
 %    \begin{macrocode}
-    \dim_set:Nn \l_@@_mark_offset_dim
+        \dim_set:Nn \l_@@_mark_offset_dim
+          {
+              \fp_eval:n { #1 * \l_@@_bracket_ratio_fp } \l_@@_unit_dim
+            - #2 \l_@@_outer_unit_dim
+          }
+      }
+    \tl_if_eq:NNT \__jiazhu_valign: \__jiazhu_valign_bottom:
       {
-          \fp_eval:n { #1 * \l_@@_bracket_ratio_fp } \l_@@_unit_dim
-        - #2 \l_@@_outer_unit_dim
+%    \end{macrocode}
+% 底线对齐时
+%    \begin{macrocode}
+        \dim_set:Nn \l_@@_box_offset_dim
+          {
+            #2 \l_@@_outer_unit_dim - #1 \l_@@_unit_dim
+          }
+        \dim_set:Nn \l_@@_mark_offset_dim
+          {
+              #2 \l_@@_outer_unit_dim
+            - \fp_eval:n { #1 * \l_@@_bracket_ratio_fp } \l_@@_unit_dim
+          }
+      }
+    \tl_if_eq:NNT \@@_valign: \@@_valign_top:
+      {
+%    \end{macrocode}
+% 顶线对齐时
+%    \begin{macrocode}
+        \dim_set:Nn \l_@@_box_offset_dim
+          {
+              #1 \l_@@_unit_dim
+            + \int_eval:n { \l_@@_lines_int - 1 } \tex_baselineskip:D
+            - #2 \l_@@_outer_unit_dim
+          }
+        \dim_set:Nn \l_@@_mark_offset_dim
+          {
+              \fp_eval:n { #1 * \l_@@_bracket_ratio_fp } \l_@@_unit_dim
+            - #2 \l_@@_outer_unit_dim
+          }
       }
   }
+\cs_new_eq:NN \@@_valign: \@@_valign_middle:
 \dim_new:N \l_@@_box_offset_dim
 \dim_new:N \l_@@_mark_offset_dim
 %    \end{macrocode}
 % \end{macro}
-%
+% 
 % \begin{macro}{\@@_put_box:N, \@@_put_mark_box:N}
-% 输出夹注盒子，并适当下移保证与正文中线对齐。
+% 输出夹注盒子，并适当下移保证对齐。
 %    \begin{macrocode}
 \cs_new_protected:Npn \@@_put_box:N #1
   {
@@ -911,45 +1009,45 @@ Copyright and Licence
 %    \end{macrocode}
 % \end{macro}
 %
-% \begin{macro}{\@@_set_alignment:n, \@@_alignment:}
+% \begin{macro}{\@@_set_halign:n, \@@_halign:}
 %    \begin{macrocode}
-\cs_new_protected:Npn \@@_set_alignment:n #1
-  { \cs_set_eq:Nc \@@_alignment: { @@_alignment_ #1 : } }
-\cs_new_protected:Npn \@@_alignment_justified:
+\cs_new_protected:Npn \@@_set_halign:n #1
+  { \cs_set_eq:Nc \@@_halign: { @@_halign_ #1 : } }
+\cs_new_protected:Npn \@@_halign_justified:
   {
     \skip_zero:N \tex_leftskip:D
     \skip_zero:N \tex_rightskip:D
     \skip_set_eq:NN \tex_parfillskip:D \c_@@_fil_skip
   }
-\cs_new_protected:Npn \@@_alignment_left:
+\cs_new_protected:Npn \@@_halign_left:
   {
     \skip_zero:N \tex_leftskip:D
-    \skip_set_eq:NN \tex_rightskip:D \l_@@_alignment_skip
+    \skip_set_eq:NN \tex_rightskip:D \l_@@_halign_skip
     \skip_set_eq:NN \tex_parfillskip:D \c_@@_fil_skip
   }
-\cs_new_protected:Npn \@@_alignment_right:
+\cs_new_protected:Npn \@@_halign_right:
   {
-    \skip_set_eq:NN \tex_leftskip:D \l_@@_alignment_skip
+    \skip_set_eq:NN \tex_leftskip:D \l_@@_halign_skip
     \skip_zero:N \tex_rightskip:D
     \skip_zero:N \tex_parfillskip:D
   }
-\cs_new_protected:Npn \@@_alignment_centered:
+\cs_new_protected:Npn \@@_halign_centered:
   {
-    \skip_set_eq:NN \tex_leftskip:D \l_@@_alignment_skip
-    \skip_set_eq:NN \tex_rightskip:D \l_@@_alignment_skip
+    \skip_set_eq:NN \tex_leftskip:D \l_@@_halign_skip
+    \skip_set_eq:NN \tex_rightskip:D \l_@@_halign_skip
     \skip_zero:N \tex_parfillskip:D
   }
-\cs_new_protected:Npn \@@_alignment_distributed:
+\cs_new_protected:Npn \@@_halign_distributed:
   {
     \skip_zero:N \tex_leftskip:D
     \skip_zero:N \tex_rightskip:D
     \skip_zero:N \tex_parfillskip:D
     \int_set_eq:NN \tex_tolerance:D \c_max_int
   }
-\skip_new:N \l_@@_alignment_skip
-\cs_new_eq:NN \@@_alignment: \@@_alignment_justified:
+\skip_new:N \l_@@_halign_skip
+\cs_new_eq:NN \@@_halign: \@@_halign_justified:
 \skip_const:Nn \c_@@_fil_skip { \c_zero_dim plus 1fil }
-\skip_set_eq:NN \l_@@_alignment_skip \c_@@_fil_skip
+\skip_set_eq:NN \l_@@_halign_skip \c_@@_fil_skip
 %    \end{macrocode}
 % \end{macro}
 %
@@ -1113,14 +1211,14 @@ Copyright and Licence
     \@@_dim_normalize:N \l_@@_width_dim
     \dim_set:Nn \l_@@_step_dim
       { \l_@@_unit_dim / \l_@@_lines_int }
-    \skip_set_eq:NN \l_@@_alignment_skip \l_@@_unit_stretch_skip
+    \skip_set_eq:NN \l_@@_halign_skip \l_@@_unit_stretch_skip
     \@@_typeset_remaining_auxi:
   }
 \cs_new_protected:Npn \@@_typeset_remaining_auxi:
   {
     \vbox_set:Nn \l_@@_typeset_box
       {
-        \@@_alignment:
+        \@@_halign:
         \dim_set_eq:NN \tex_hsize:D \l_@@_width_dim
         \hbox_unpack:N \l_@@_text_box \par
         \int_gset_eq:NN \g_@@_lines_int \tex_prevgraf:D
@@ -1346,11 +1444,15 @@ Copyright and Licence
     lines                  .code:n = \@@_set_lines:n {#1} ,
     shortcut               .code:n = \@@_add_shortcut:n {#1} ,
     shortcut-              .code:n = \@@_remove_shortcuts:n {#1} ,
-    alignment          .choices:nn =
+    halign             .choices:nn =
       { justified , left , right , centered , distributed }
-      { \@@_set_alignment:n { \l_keys_choice_tl } } ,
+      { \@@_set_halign:n { \l_keys_choice_tl } } ,
+    valign             .choices:nn = 
+      { middle , top , bottom }
+      { \@@_set_valign:n { \l_keys_choice_tl } } ,
     lines        .value_required:n = true ,
-    alignment    .value_required:n = true ,
+    halign       .value_required:n = true ,
+    valign       .value_required:n = true ,
     shortcut     .value_required:n = true ,
     shortcut-    .value_required:n = true ,
     beforeskip          .initial:n = \smallskipamount ,
@@ -1364,7 +1466,8 @@ Copyright and Licence
     ratio               .initial:n = 2 / 3 ,
     bracketratio        .initial:n = 2 ,
     lines               .initial:n = 2 ,
-    alignment           .initial:n = justified
+    halign              .initial:n = justified ,
+    valign              .initial:n = middle
   }
 %    \end{macrocode}
 % \end{macro}

--- a/jiazhu/jiazhu.dtx
+++ b/jiazhu/jiazhu.dtx
@@ -141,7 +141,7 @@ Copyright and Licence
 %</driver>
 % \fi
 %
-% \CheckSum{971}
+% \CheckSum{961}
 % \GetFileId{jiazhu.sty}
 %
 % \title{\bfseries\pkg{jiazhu} 宏包}
@@ -670,7 +670,7 @@ Copyright and Licence
       { \c_zero_dim plus 0.5\l_@@_outer_unit_dim }
     \skip_set:Nn \l_@@_unit_stretch_skip
       { \c_zero_dim plus \l_@@_unit_dim }
-    \@@_calc_box_offset:
+    \@@_set_valign:
     \@@_set_before_skip:
     \@@_processing:
   }
@@ -778,7 +778,7 @@ Copyright and Licence
 %    \end{macrocode}
 % \end{macro}
 %
-% \begin{macro}{\@@_calc_box_offset:}
+% \begin{macro}{\@@_set_valign:}
 % \TeX 排放夹注的位置，是以西文基线为准的：
 % \begin{center}
 % \footnotesize
@@ -824,112 +824,103 @@ Copyright and Licence
 % 
 %    \begin{macrocode}
 \cs_new_protected:Npn \@@_set_valign:n #1
-  { \cs_set_eq:Nc \@@_valign: { @@_valign_ #1 : } }
-\cs_new_protected:Npn \@@_calc_box_offset:
+  { \cs_set_eq:Nc \@@_set_valign: { @@_set_valign_ #1 : } }
+\cs_new_protected:Npn \@@_set_valign_middle:
   {
-    \tl_if_eq:NNT \@@_valign: \@@_valign_middle:
-      {
 %    \end{macrocode}
-% 中线对齐时，提前展开 $r-0.5$ 的计算结果，避免后续重复计算。
+% 中线对齐时，提前展开 $r-0.5$ 的计算结果，避免后续的重复计算。
 %    \begin{macrocode}
-        \exp_args:Nxx \@@_calc_box_offset_aux:nn
+    \exp_args:Nxx \@@_set_valign_middle_aux:nn
 %    \end{macrocode}
 % 首先是 $r_{\mathrm{inner}}-0.5$ 的计算结果。
 %    \begin{macrocode}
-          {
-            \fp_compare:nNnTF \l_@@_jzideoht_fp = \c_zero_fp
-              { \fp_eval:n { \l_@@_ideoht_fp   - 0.5 } }
-              { \fp_eval:n { \l_@@_jzideoht_fp - 0.5 } }
-          }
+      {
+        \fp_compare:nNnTF \l_@@_jzideoht_fp = \c_zero_fp
+          { \fp_eval:n { \l_@@_ideoht_fp   - 0.5 } }
+          { \fp_eval:n { \l_@@_jzideoht_fp - 0.5 } }
+      }
 %    \end{macrocode}
 % 其次是 $r_{\mathrm{outer}}-0.5$ 的计算结果。
 %    \begin{macrocode}
-          { \fp_eval:n { \l_@@_ideoht_fp - 0.5 } }
-      }
-    \tl_if_eq:NNT \@@_valign: \@@_valign_bottom:
-%    \end{macrocode}
-% 底线对齐时，则展开 $1-r_{\mathrm{outer}}$ 的计算结果。
-%    \begin{macrocode}
-      {
-        \exp_args:Nxx \@@_calc_box_offset_aux:nn
-          {
-            \fp_compare:nNnTF \l_@@_jzideoht_fp = \c_zero_fp
-              { \fp_eval:n { 1 -   \l_@@_ideoht_fp } }
-              { \fp_eval:n { 1 - \l_@@_jzideoht_fp } }
-          }
-          { \fp_eval:n { 1 - \l_@@_ideoht_fp } }
-      }
-    \tl_if_eq:NNT \@@_valign: \@@_valign_top:
-      {
-%    \end{macrocode}
-% 顶线对齐时
-%    \begin{macrocode}
-        \exp_args:Nxx \@@_calc_box_offset_aux:nn
-          {
-            \fp_compare:nNnTF \l_@@_jzideoht_fp = \c_zero_fp
-              { \fp_eval:n { \l_@@_ideoht_fp   } }
-              { \fp_eval:n { \l_@@_jzideoht_fp } }
-          }
-          { \fp_eval:n { \l_@@_ideoht_fp } }
-      }
+      { \fp_eval:n { \l_@@_ideoht_fp - 0.5 } }
   }
-\cs_new_protected:Npn \@@_calc_box_offset_aux:nn #1#2
+\cs_new_protected:Npn \@@_set_valign_middle_aux:nn #1#2
   {
-    \tl_if_eq:NNT \@@_valign: \@@_valign_middle:
-      {
 %    \end{macrocode}
-% 中线对齐时，对于夹注内容盒子的下移量，我们直接套用公式。
+% 对于夹注内容盒子的下移量，我们直接套用公式。
 %    \begin{macrocode}
-        \dim_set:Nn \l_@@_box_offset_dim
-          {
-              #1 \l_@@_unit_dim
-            + \int_eval:n { \l_@@_lines_int - 1 } \tex_baselineskip:D / 2
-            - #2 \l_@@_outer_unit_dim
-          }
+    \dim_set:Nn \l_@@_box_offset_dim
+      {
+          #1 \l_@@_unit_dim
+        + \int_eval:n { \l_@@_lines_int - 1 } \tex_baselineskip:D / 2
+        - #2 \l_@@_outer_unit_dim
+      }
 %    \end{macrocode}
 % 对于夹注两端括弧盒子的下移量，我们修改 $s_{\mathrm{inner}}$ 为括弧字号，
 % 并取 $n=1$ 即可。
 %    \begin{macrocode}
-        \dim_set:Nn \l_@@_mark_offset_dim
-          {
-              \fp_eval:n { #1 * \l_@@_bracket_ratio_fp } \l_@@_unit_dim
-            - #2 \l_@@_outer_unit_dim
-          }
-      }
-    \tl_if_eq:NNT \__jiazhu_valign: \__jiazhu_valign_bottom:
+    \dim_set:Nn \l_@@_mark_offset_dim
       {
+          \fp_eval:n { #1 * \l_@@_bracket_ratio_fp } \l_@@_unit_dim
+        - #2 \l_@@_outer_unit_dim
+      }
+  }
+\cs_new_protected:Npn \@@_set_valign_bottom:
+  {
 %    \end{macrocode}
-% 底线对齐时
+% 底线对齐时，则展开 $1-r_{\mathrm{outer}}$ 的计算结果。
 %    \begin{macrocode}
-        \dim_set:Nn \l_@@_box_offset_dim
-          {
-            #2 \l_@@_outer_unit_dim - #1 \l_@@_unit_dim
-          }
-        \dim_set:Nn \l_@@_mark_offset_dim
-          {
-              #2 \l_@@_outer_unit_dim
-            - \fp_eval:n { #1 * \l_@@_bracket_ratio_fp } \l_@@_unit_dim
-          }
-      }
-    \tl_if_eq:NNT \@@_valign: \@@_valign_top:
+    \exp_args:Nxx \@@_set_valign_bottom_aux:nn
       {
+        \fp_compare:nNnTF \l_@@_jzideoht_fp = \c_zero_fp
+          { \fp_eval:n { 1 -   \l_@@_ideoht_fp } }
+          { \fp_eval:n { 1 - \l_@@_jzideoht_fp } }
+      }
+      { \fp_eval:n { 1 - \l_@@_ideoht_fp } }
+  }
+\cs_new_protected:Npn \@@_set_valign_bottom_aux:nn #1#2
+  {
+%    \end{macrocode}
+% 夹注内容盒子的下移量
+%    \begin{macrocode}
+    \dim_set:Nn \l_@@_box_offset_dim
+      {
+        #2 \l_@@_outer_unit_dim - #1 \l_@@_unit_dim
+      }
+    \dim_set:Nn \l_@@_mark_offset_dim
+      {
+          #2 \l_@@_outer_unit_dim
+        - \fp_eval:n { #1 * \l_@@_bracket_ratio_fp } \l_@@_unit_dim
+      }
+  }
 %    \end{macrocode}
 % 顶线对齐时
 %    \begin{macrocode}
-        \dim_set:Nn \l_@@_box_offset_dim
-          {
-              #1 \l_@@_unit_dim
-            + \int_eval:n { \l_@@_lines_int - 1 } \tex_baselineskip:D
-            - #2 \l_@@_outer_unit_dim
-          }
-        \dim_set:Nn \l_@@_mark_offset_dim
-          {
-              \fp_eval:n { #1 * \l_@@_bracket_ratio_fp } \l_@@_unit_dim
-            - #2 \l_@@_outer_unit_dim
-          }
+\cs_new_protected:Npn \@@_set_valign_top:
+  {
+    \exp_args:Nxx \@@_set_valign_top_aux:nn
+      {
+        \fp_compare:nNnTF \l_@@_jzideoht_fp = \c_zero_fp
+          { \fp_eval:n { \l_@@_ideoht_fp   } }
+          { \fp_eval:n { \l_@@_jzideoht_fp } }
+      }
+      { \fp_eval:n { \l_@@_ideoht_fp } }
+  }
+\cs_new_protected:Npn \@@_set_valign_top_aux:nn #1#2
+  {
+    \dim_set:Nn \l_@@_box_offset_dim
+      {
+          #1 \l_@@_unit_dim
+        + \int_eval:n { \l_@@_lines_int - 1 } \tex_baselineskip:D
+        - #2 \l_@@_outer_unit_dim
+      }
+    \dim_set:Nn \l_@@_mark_offset_dim
+      {
+          \fp_eval:n { #1 * \l_@@_bracket_ratio_fp } \l_@@_unit_dim
+        - #2 \l_@@_outer_unit_dim
       }
   }
-\cs_new_eq:NN \@@_valign: \@@_valign_middle:
+\cs_new_eq:NN \@@_set_valign: \@@_set_valign_middle:
 \dim_new:N \l_@@_box_offset_dim
 \dim_new:N \l_@@_mark_offset_dim
 %    \end{macrocode}


### PR DESCRIPTION
添加 `valign` 垂向对齐功能，可以使夹注与正文在顶线、中线、底线处对齐。同时将原有的 `alignment` 改为 `halign`，并添加文档说明。fix #535 。