### PR TITLE
修改用户手册的字体配置

### DIFF
--- a/zhlineskip/zhlineskip.tex
+++ b/zhlineskip/zhlineskip.tex
@@ -1,23 +1,30 @@
 % !TeX program = XeLaTeX
 % !TeX encoding = UTF-8 Unicode
 %
-% 为了得到最佳的排版结果，可以考虑安装免费的思源宋体、思源黑体与 M+ 字体
+% 为了得到最佳的排版结果，可以考虑安装免费的思源宋体、思源黑体、等距更纱黑体与 M+ 字体
 % - 思源字库可以前往
 %   https://github.com/adobe-fonts/source-han-serif/tree/release
 %   https://github.com/adobe-fonts/source-han-sans/tree/release
 % 下载，请安装 Language-specific OTFs 的简体中文版本
+% - 等距更纱黑体可以前往
+%   https://github.com/be5invis/Sarasa-Gothic/releases
+% 下载
 % - M+ 字体可以前往
 %   https://osdn.net/projects/mplus-fonts/releases/
 % 下载
 %
-% 如果已经安装了思源、M+ 字体，请在导言区启用 \SourceHanSCandMplustrue
+% 如果已经安装了思源、等距更纱黑体、M+ 字体，请在导言区启用 \SourceHanSCandMplustrue
 %
-\documentclass[zihao=5,a4paper]{ctexart}
-\XeTeXgenerateactualtext=1 %
 \newif\ifSourceHanSCandMplus
 \SourceHanSCandMplusfalse
 % 如果已经安装了思源、M+ 字体，请启用 \SourceHanSCandMplustrue
-%\SourceHanSCandMplustrue
+% \SourceHanSCandMplustrue
+\ifSourceHanSCandMplus
+\documentclass[zihao=5,a4paper,fontset=none]{ctexart}
+\else
+\documentclass[zihao=5,a4paper]{ctexart}
+\fi
+\XeTeXgenerateactualtext=1 %
 \frenchspacing
 \ctexset{
   section={
@@ -35,7 +42,12 @@
   }%
 }
 \usepackage{mathtools}
-\usepackage[math-style=ISO]{unicode-math}
+\usepackage[math-style=ISO,warnings-off={mathtools-colon,mathtools-overbracket}]{unicode-math}
+\DeclareEmphSequence
+  {
+    \bfseries,
+    \mdseries,
+  }
 \ifSourceHanSCandMplus
   \setmainfont{texgyrepagella}[
     Extension=.otf,
@@ -54,24 +66,28 @@
     BoldItalicFont=*-bolditalic,
     Scale=1.00685871056241427
   ]
-  \setmonofont{mplus-1m-regular.ttf}[
-    BoldFont=mplus-1m-bold.ttf
+  \setmonofont{sarasa-mono-sc-regular.ttf}[
+    BoldFont=sarasa-mono-sc-bold.ttf,
+    ItalicFont=sarasa-mono-sc-italic.ttf,
+    BoldItalicFont=sarasa-mono-sc-bolditalic.ttf
   ]
   \setmathfont{texgyrepagella-math.otf}[
     Scale=1.05924855491329480
   ]
-  \setCJKmainfont{SourceHanSerifSC-Medium.otf}[
-    ItalicFont=SourceHanSerifSC-Heavy.otf,
+  \setCJKmainfont{SourceHanSerifSC-Regular.otf}[
+    ItalicFont=FandolKai-Regular.otf,
     BoldFont=SourceHanSerifSC-Bold.otf,
+    SmallCapsFont=SourceHanSerifSC-Regular.otf,
     Language=Chinese Simplified
   ]
   \setCJKsansfont{SourceHanSansSC-Regular.otf}[
     BoldFont=SourceHanSansSC-Bold.otf,
     Language=Chinese Simplified
   ]
-  \setCJKmonofont{SourceHanSansSC-Regular.otf}[
-    BoldFont=SourceHanSansSC-Bold.otf,
-    Language=Chinese Simplified
+  \setCJKmonofont{sarasa-mono-sc-regular.ttf}[
+    BoldFont=sarasa-mono-sc-bold.ttf,
+    ItalicFont=sarasa-mono-sc-italic.ttf,
+    BoldItalicFont=sarasa-mono-sc-bolditalic.ttf
   ]
   \makeatletter
   \def\setCJKecglue@nnn#1#2#3{%
@@ -194,7 +210,7 @@
       \meta@hyphen@restore
      }\ensuremath\rangle
 }
-\def\meta@font@select{\itshape}
+\def\meta@font@select{\ttfamily\itshape}
 % From `ltxdoc.dtx'
 \newcommand*\cmd[1]{\cs{\expandafter\cmd@to@cs\string#1}}
 \def\cmd@to@cs#1#2{\char\number`#2\relax}
@@ -286,7 +302,7 @@ $1.5$ 至 $1.67$ 之间），以及脚注行距相比于脚注字号的倍数。
 size）的 $1.2$ 至 $1.45$\nobreak\CJKecglue 倍\footnote{参见
 \url{https://practicaltypography.com/line-spacing.html}。}。
 
-\begin{figure}[h]
+\begin{figure}[ht]
 \centering
 \includegraphics{Latinmetrics}
 \caption[西文字体]{西文字体。绿色方框即为 em-box，它在纸上的实际边长就是西文字号。}
@@ -302,7 +318,7 @@ gap），这与西文里插入铅条的高度是一致的。由于汉字四周�
 《方正飞腾4.0实用培训教程》，第\nobreak\CJKecglue6.1.1\nobreak\CJKecglue 节。}，即行距约为字号的
 $1.5$ 至 $1.67$\nobreak\CJKecglue 倍。
 
-\begin{figure}[h]
+\begin{figure}[ht]
 \centering
 \includegraphics{CJKmetrics}
 \caption[中文字体]{中文字体。汉字字面几乎占满整个字框，字框的边长即为中文字号。}
@@ -318,7 +334,7 @@ $1.2$\nobreak\CJKecglue 倍，而 $1.2 \times 1.3
 排版效果，文本、数学看似一紧、一松；右边是配合用\CJKecglue\pkg{zhlineskip} 的效果，
 视觉密度比较均匀。\pkg{zhlineskip} 宏包还允许用户调整数学行距的大小。
 
-\begin{figure}[h]
+\begin{figure}[ht]
 \sbox0{%
 \begin{minipage}[t]{162pt}
 \fontsize{9}{10.8}\linespread{1.3}\selectfont
@@ -409,7 +425,7 @@ Microsoft Word 排的行距相同。硬要用 \TeX\ 模仿 Microsoft Word 是没
 相比字号的倍数（详见表\nobreak\CJKecglue\ref{tab:default-leading-ratio}），再通过用户指定的
 倍数来计算所需的行伸展因子。因此，不论是中日韩文还是西文的横排文档，都是可以使用
 本宏包的。本宏包的缺省设置更适合中日韩文文档。
-\begin{table}[h]
+\begin{table}[ht]
 \centering
 \caption[基础行距倍数]{\cls{ctexart} 与\CJKecglue\cls{article} 各个文档类选项
   设置的基础行距倍数。}
@@ -679,7 +695,7 @@ Microsoft Word 中“单倍行距”的设置，其行距值相比字号的倍�
 表\nobreak\CJKecglue\ref{tab:word-line-height}\CJKecglue 列出
 几种常见字体对应的单倍行距倍数。正是因为“单倍行距”本身随字体、操作系统而变化，
 所以请尽量避免使用“多倍行距”的概念！
-\begin{table}[h]
+\begin{table}[ht]
 \centering
 \caption[单倍行距倍数]{在 Microsoft Word 中设置“单倍行距”后，实际的行距
   依赖于字体。}


### PR DESCRIPTION
- 修改 `\emph` 的行为
- 修改字体配置，使用等距更纱黑体作为等宽字体
- 消除警告

这是编译好的用户手册 [zhlineskip.pdf](https://github.com/CTeX-org/ctex-kit/files/7827325/zhlineskip.pdf)，我认为比原来的看着舒服
