### PR TITLE
Fix broken CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -198,7 +198,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: Install TeX Live
       run: |
-        ${env:PATH} = "${{ github.workspace }}\tmp\texlive\bin\win32;" + ${env:PATH}
+        ${env:PATH} = "${{ github.workspace }}\tmp\texlive\bin\windows;" + ${env:PATH}
         Invoke-WebRequest -Uri ${{ env.CTAN_URL }}/systems/texlive/tlnet/install-tl.zip -OutFile install-tl.zip
         Expand-Archive install-tl.zip -DestinationPath .
         Set-Location install-tl-*
@@ -207,14 +207,14 @@ jobs:
         tlmgr update --self --all --no-auto-install --repository=${{ env.CTAN_URL }}/systems/texlive/tlnet/
     - name: Install Noto fonts
       run: |
-        ${env:PATH} = "${{ github.workspace }}\tmp\texlive\bin\win32;" + ${env:PATH}
+        ${env:PATH} = "${{ github.workspace }}\tmp\texlive\bin\windows;" + ${env:PATH}
         Invoke-WebRequest -Uri ${{ env.NOTO_SANS_URL }}  -OutFile NotoSansCJK-OTC.zip
         Invoke-WebRequest -Uri ${{ env.NOTO_SERIF_URL }} -OutFile NotoSerifCJK-OTC.zip
         unzip -ojd C:\Windows\Fonts\ "*OTC.zip" "*.ttc"
     - name: Test ctex
       working-directory: ./ctex
       run: |
-        ${env:PATH} = "${{ github.workspace }}\tmp\texlive\bin\win32;" + ${env:PATH}
+        ${env:PATH} = "${{ github.workspace }}\tmp\texlive\bin\windows;" + ${env:PATH}
         l3build check -q -H
         l3build check -c test/config-cmap -q -H
         l3build check -c test/config-contrib -q -H


### PR DESCRIPTION
最近的一次定时 [workflow run #4515016685](https://github.com/CTeX-org/ctex-kit/actions/runs/4515016685)，测试在所有三个操作系统下都不通过。其中，
- win 的错误发生得很早：找不到程序 `tlmgr`。
  2023 开始，TeX Live 也为 win 提供 64 位程序，对应的路径名也改了，`bin/win32` -> `bin/windows`。见 https://tug.org/texlive/doc/texlive-en/texlive-en.html#x1-920009.2 。
- ubuntu 和 macOS 的错误在跑第一个测试时产生，这是 `l3build` 2023-03-22 引入的一个 bug 导致的，见 https://github.com/latex3/l3build/pull/294 。

本 PR 解决了 win 的问题，剩余问题等 `l3build` 发版即可自动解决。我开这个 PR 是想通过说明原因而减少「测试通通失败啦」的恐慌，也避免其他项目成员的重复劳动。

我想让这个 PR 在合并后能通过所有三个系统下的测试，所以暂时标记为 draft。