### PR TITLE
ctxdoc: update patch for `\MakeUppercase ` [ci skip]

### DIFF
--- a/support/ctxdoc.cls
+++ b/support/ctxdoc.cls
@@ -851,7 +851,13 @@
 \pdfstringdefDisableCommands{%
   \let\path\meta
   \let\opt\@firstofone}
-\preto\@thehead{\cslet{MakeUppercase\space}{\@iden}}
+% full expansion of \MakeUppercase is changed in LaTeX2e 2022-11-01,
+% see latex3/latex2e repo, commit 7447e931820114aa459e66b1a7937cdc9aebb0f4
+\ifcsdef{MakeUppercase\space\space\space}
+  {\preto\@thehead
+    {\protected\long\csdef{MakeUppercase\space\space\space}[#1]#2{{#2}}}}
+  {\preto\@thehead
+    {\protected\long\csdef{MakeUppercase\space}#1{{#1}}}}
 \def\orbar{\textup{\textbar}}
 \def\defaultval#1{\textbf{\textup{#1}}}
 \def\defaultvalaux#1){\defaultval{#1}}


### PR DESCRIPTION
Since LaTeX2e 2022-11-01, full expansion of `\MakeUppercase{<text>}` has been
changed from `\MakeUppercase {<text>}` (single space in csname) to
`\MakeUppercase   []{<text>}` (three spaces in csname).

Then LaTeX2e 2023-06-01 improved it to be `\MakeUppercase   []{{... <text> ...}}`.

The macro prefixes are kept and the extra group is restored for both versions.

See
- https://github.com/latex3/latex2e/commit/7447e931820114aa459e66b1a7937cdc9aebb0f4
- https://github.com/latex3/latex2e/commit/17ab93ac05095000ff43a79dd50f5ede994da0e6

------
`ctxdoc.cls` skips `\MakeUppercase` applied to section marks by letting (the full expansion form of) `\MakeUppercase` to the identity macro locally in `\@thehead`, so one can safely use
```tex
% \def\LuaLaTeX{\hologo{LuaLaTeX}}
\section{\LuaLaTeX{} ...}
```
But since LaTeX2e 2022-11-01, the full expansion form of `\MakeUppercase` has changed. This makes the existing patch no longer in effect, which resulting in the problem mentioned in #668: building `ctex.pdf` from `ctex.dtx` throws error(s)
```
! Package hologo Error: Unknown logo `LUALATEX'.
```

This PR extends the patch for `\MakeUppercase ` to make the doc compile again.