### PR TITLE
xeCJK: 修复拼错的命令名，源自 hyperref

### DIFF
--- a/xeCJK/xeCJK.dtx
+++ b/xeCJK/xeCJK.dtx
@@ -12277,6 +12277,9 @@ Copyright and Licence
 % {增加 \file{xunicode-extra.def} 中，用于加入 \file{puenc.def} 中的符号定义。}
 %
 % 以下定义取自 \pkg{hyperref} 的 \file{puenc.def}。
+% \changes{v3.9.2}{2023/11/10}{修复拼错的命令名，
+%   \tn{cyreref} -> \tn{cyrerev} 和
+%   \tn{textDiamandSolid} -> \tn{textDiamondSolid}。}
 %    \begin{macrocode}
 \DeclareUTFEncodedAccent\textinvbreve{"0311}{"0311}
 \DeclareUTFEncodedSymbol\textsubbreve{"032E}{"203F}
@@ -12629,7 +12632,7 @@ Copyright and Licence
 \DeclareUTFCompositeSymbol\"{\CYROTLD}{"04EA}
 \DeclareUTFCompositeSymbol\"{\cyrotld}{"04EB}
 \DeclareUTFCompositeSymbol\"{\CYREREV}{"04EC}
-\DeclareUTFCompositeSymbol\"{\cyreref}{"04ED}
+\DeclareUTFCompositeSymbol\"{\cyrerev}{"04ED}
 \DeclareUTFCompositeSymbol\={\CYRU}{"04EE}
 \DeclareUTFCompositeSymbol\={\cyru}{"04EF}
 \DeclareUTFCompositeSymbol\"{\CYRU}{"04F0}
@@ -13291,7 +13294,7 @@ Copyright and Licence
 \DeclareUTFSymbol\textSquareTopRight{"2750}
 \DeclareUTFSymbol\textSquareCastShadowBottomRight{"2751}
 \DeclareUTFSymbol\textSquareCastShadowTopRight{"2752}
-\DeclareUTFSymbol\textDiamandSolid{"2756}
+\DeclareUTFSymbol\textDiamondSolid{"2756}
 \DeclareUTFSymbol\textRectangleThin{"2758}
 \DeclareUTFSymbol\textRectangle{"2759}
 \DeclareUTFSymbol\textRectangleBold{"275A}


### PR DESCRIPTION
见 latex3/hyperref#307 和 latex3/hyperref#310

- [x] 先作为 draft PR，我想等 hyperref 确认后再合并（latex3/hyperref#307 尚未被确认）。
- [x] `\changes` entry