### PR TITLE
ctxdoc: 补充丢失的展开类型

### DIFF
--- a/support/ctxdoc.cls
+++ b/support/ctxdoc.cls
@@ -28,7 +28,7 @@
 \DeclareOption*{\PassOptionsToClass{\CurrentOption}{l3doc}}
 \PassOptionsToClass{a4paper,full}{l3doc}
 \ProcessOptions
-\LoadClass{l3doc}
+\LoadClass{l3doc}[2023-10-10]
 \RequirePackage[UTF8, punct=kaiming, heading, linespread=1.2, sub3section]{ctex}
 \ctexset{
   abstractname   = 简介,
@@ -295,8 +295,8 @@
       { \use:n }
       {
         \tl_set:Nn \l__codedoc_tmpa_tl {#1}
-        \tl_replace_all:Non \l__codedoc_tmpa_tl
-          { \c_catcode_other_space_tl }
+        \tl_replace_all:NVn \l__codedoc_tmpa_tl
+          \c_catcode_other_space_tl 
           { \fontspec_visible_space: }
         \__codedoc_macroname_prefix:o \l__codedoc_tmpa_tl
         \__codedoc_macroname_suffix:N #2


### PR DESCRIPTION
今天编译文档时发现 `\tl_replace_all:Non` 的定义也消失了，粗略翻了一圈没能追溯到 `l3kernel` 中的修改时间，先凑合提交了一个补丁来让代码跑起来。

此外，关于 #678，为了向后兼容性还是把 `e` 型展开手动补上了。

如果有更好的改法请不吝赐教！