### PR TITLE
ctxdoc: 匹配 l3doc 命令更改

### DIFF
--- a/support/ctxdoc.cls
+++ b/support/ctxdoc.cls
@@ -298,8 +298,8 @@
         \tl_replace_all:NVn \l__codedoc_tmpa_tl
           \c_catcode_other_space_tl 
           { \fontspec_visible_space: }
-        \__codedoc_macroname_prefix:o \l__codedoc_tmpa_tl
-        \__codedoc_macroname_suffix:N #2
+        \__codedoc_print_macroname_aux:on
+          \l__codedoc_tmpa_tl { \bool_if:NT #2 { \__codedoc_typeset_TF: } }
       }
   }
 \AtBeginEnvironment { syntax }


### PR DESCRIPTION
更新了一下包发现 `ctxdoc` 又挂了，这一回的差异来自 latex3/latex3@27ae326。原本 `ctxdoc` 是用一种很脆弱的方式做了 patch，但我也没本事大修，只能照搬过来 orz