### PR TITLE
替换废弃的 l3kernel 命令

### DIFF
--- a/ctex/ctex.dtx
+++ b/ctex/ctex.dtx
@@ -548,10 +548,10 @@ Copyright and Licence
 %<backend>\ProvidesFile{ctexbackend.cfg}%
 %<dict&theorem&GBK>\ProvidesDictionary{translator-theorem-dictionary}{ChineseGBK}%
 %<dict&theorem&UTF8>\ProvidesDictionary{translator-theorem-dictionary}{ChineseUTF8}%
-%<fd>  [2022/07/14 v2.5.10 Chinese font definition (CTEX)]
-%<ctexspa>  [2022/07/14 v2.5.10 Space info for CJKpunct (CTEX)]
-%<backend>  [2022/07/14 v2.5.10 Backend configuration file (CTEX)]
-%<dict&theorem>  [2022/07/14 v2.5.10 Chinese translation for theorem name (CTEX)]
+%<fd>  [2024/03/20 v2.5.11 Chinese font definition (CTEX)]
+%<ctexspa>  [2024/03/20 v2.5.11 Space info for CJKpunct (CTEX)]
+%<backend>  [2024/03/20 v2.5.11 Backend configuration file (CTEX)]
+%<dict&theorem>  [2024/03/20 v2.5.11 Chinese translation for theorem name (CTEX)]
 %</!(driver|readme|install|zhmap|spa|docstrip)>
 %<*driver>
 \documentclass{ctxdoc}
@@ -3318,6 +3318,7 @@ Copyright and Licence
 % \changes{v2.4.10}{2017/07/19}{常数 \cs{c_minus_one} 已过时。}
 % \changes{v2.4.10}{2017/07/22}{使用 \texttt{lazy} 函数对 Boolean 表达式
 % 进行最小化运算（\LaTeXiii{} 2017/07/19）。}
+% \changes{v2.5.11}{2024/04/20}{提升 \LaTeXiii{} 版本至 2022/10/09。}
 %
 % 检查 \pkg{expl3} 的版本。
 %    \begin{macrocode}
@@ -3328,7 +3329,7 @@ Copyright and Licence
     `l3kernel'~and~`l3packages'\\\\
     using~your~TeX~package~manager~or~from~CTAN.
   }
-\@ifpackagelater { expl3 } { 2021/02/10 } { }
+\@ifpackagelater { expl3 } { 2022/10/09 } { }
   { \msg_error:nnn { ctex } { l3-too-old } { expl3 } }
 %    \end{macrocode}
 %
@@ -4258,25 +4259,14 @@ Copyright and Licence
 %
 % \changes{v2.5.10}{2022/06/10}{取消 \LaTeX\ 2022-06-01 对书名号的定义。}
 %
-% \begin{macro}{\ctex_undeclare_unicode_character:n,\ctex_utfviii_char:n}
+% \begin{macro}{\ctex_undeclare_unicode_character:n}
+% \changes{v2.5.11}{2024/04/20}{替换废弃命令 \cs{char_to_utfviii_bytes:n}。}
 % \LaTeX\ 2022-06-01 将通常用作中文书名号的 U+3008 和 U+3009 分别定义为
-% \tn{textlangle} 和 \tn{textrangle}，这个定义会被 \pkg{CJKutf8} 包会优先使用。
+% \tn{textlangle} 和 \tn{textrangle}，这个定义会被 \pkg{CJKutf8} 包优先使用。
 % 我们总是使用中文书名号，需要取消 \LaTeX\ 的定义，作用是局部的，不使用 \cs{cs_undefine:N}。
 %    \begin{macrocode}
 \cs_new_protected:Npn \ctex_undeclare_unicode_character:n #1
-  { \cs_set_eq:cN { u8 : \ctex_utfviii_char:n {#1} } \tex_undefined:D }
-\cs_new:Npn \ctex_utfviii_char:n #1
-  {
-    \exp_last_unbraced:Ne \@@_utfviii_char_aux:nnnn
-      { \char_to_utfviii_bytes:n {#1} }
-  }
-\cs_new:Npn \@@_utfviii_char_aux:nnnn #1#2#3#4
-  {
-    \char_generate:nn {#1} { 12 }
-    \tl_if_empty:nF {#2} { \char_generate:nn {#2} { 12 } }
-    \tl_if_empty:nF {#3} { \char_generate:nn {#3} { 12 } }
-    \tl_if_empty:nF {#4} { \char_generate:nn {#4} { 12 } }
-  }
+  { \cs_set_eq:cN { u8 : \codepoint_str_generate:n {#1} } \tex_undefined:D }
 \CJKaddEncHook { UTF8 }
   {
     \ctex_undeclare_unicode_character:n { "3008 }

--- a/ctex/test/testfiles/zhnumber.lvt
+++ b/ctex/test/testfiles/zhnumber.lvt
@@ -1,4 +1,7 @@
 \input{regression-test}
+\ExplSyntaxOn
+\debug_on:n { deprecation }
+\ExplSyntaxOff
 
 \documentclass{article}
 \usepackage[fontset=fandol]{ctex}

--- a/zhnumber/zhnumber.dtx
+++ b/zhnumber/zhnumber.dtx
@@ -150,7 +150,7 @@ Copyright and Licence
 %<config&utf8>\ProvidesExplFile{\ExplFileName-utf8.cfg}
 %<config&big5>\ProvidesExplFile{\ExplFileName-big5.cfg}
 %<config&gbk>\ProvidesExplFile{\ExplFileName-gbk.cfg}
-%<package|config>  {\ExplFileDate}{3.0}{\ExplFileDescription}
+%<package|config>  {\ExplFileDate}{3.1}{\ExplFileDescription}
 %<*driver>
 \documentclass{ctxdoc}
 \SideBySideExampleSet{xrightmargin=.6\linewidth}
@@ -1464,7 +1464,15 @@ Copyright and Licence
       FE3 .tl_set:N = \exp_not:c { l_@@_financial_ 1000 _tl } ,
       E44 .tl_set:N = \exp_not:c { l_@@_ s11 _tl }
     }
-  \tl_build_get:NN \l_@@_kv_tl \l_@@_tmp_tl
+%    \end{macrocode}
+% \pkg{expl3} 2023-12-14 起，\cs{tl_build_get:NN} 是废弃命令。当 \pkg{l3debug}
+% 的 \texttt{deprecation} 开启，废弃命令被重定义为 \cs{outer} 的，无法在其他命令
+% 的参数中使用，所以这里用 \cs{use:c} 绕过。
+%    \begin{macrocode}
+  \cs_if_exist:NTF \tl_build_get_intermediate:NN
+    { \tl_build_get_intermediate:NN }
+    { \use:c { tl_build_get:NN } }
+      \l_@@_kv_tl \l_@@_tmp_tl
   \cs_set:Npn \@@_tmp:w #1 . #2 \q_stop
     { , #1 .groups:n = { user } }
   \clist_map_inline:Nn \l_@@_tmp_tl


### PR DESCRIPTION
- 废弃的 `\char_to_utfviii_bytes:n` 改写为 `\codepoint_str_generate:n`，后者需要 l3kernel 2022-10-09
- 废弃的 `\tl_build_get:NN` 简单替换为 `\tl_build_get_intermediate:NN`，后者需要 l3kernel 2023-12-14

需要兼容旧版 l3kernel 吗？