### PR TITLE
夹注包： 修改文档字体名称为 Harano Aji Mincho

### DIFF
--- a/jiazhu/jiazhu.dtx
+++ b/jiazhu/jiazhu.dtx
@@ -135,7 +135,7 @@ Copyright and Licence
   { \jiazhuset { ideohtratio = 0.8 } }
 \ExplSyntaxOff
 \jiazhuset { opening = 〔 , closing = 〕 }
-\newCJKfontfamily\mincho{HaranoAjiMincho}
+\newCJKfontfamily\mincho{Harano Aji Mincho}
 \SideBySideExampleSet{xrightmargin=.25\linewidth}
 \begin{document}
   \DocInput{\jobname.dtx}


### PR DESCRIPTION
l3build 错误，构建文档时提示缺少 HaranoAjiMincho 字体，经查验 HaranoAjiMincho-*.otf 系列字体名称为 Harano Aji Mincho