### PR TITLE
ci: diff l3build testfiles using `git diff`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -156,7 +156,7 @@ jobs:
           font-dir: /usr/share/fonts/truetype
           shell: bash
           tl-pkgs: ""
-        - runs-on: macos-14
+        - runs-on: macos-latest
           font-dir: /Library/Fonts
           shell: bash
           tl-pkgs: ""


### PR DESCRIPTION
Also
- Use different artifact name for matrix jobs\
  `actions/upload-artifact@v4` dropped support for uploading to the same named Artifact multiple times, see "[Breaking Changes](https://github.com/actions/upload-artifact/blob/2848b2cda0e5190984587ec6bb1f36730ca78d50/README.md#breaking-changes)".
- Run on `macos-latest`