### PR TITLE
ctex: 修复错误的常量赋值

### DIFF
--- a/ctex/ctex.dtx
+++ b/ctex/ctex.dtx
@@ -7683,17 +7683,17 @@ Copyright and Licence
 % \end{variable}
 %
 % \begin{variable}{\c_@@_headings_seq}
+% 保存各级标题名字。
 %    \begin{macrocode}
+%<article|book|report|beamer>\seq_const_from_clist:Nn \c_@@_headings_seq
 %<*article|book|report>
-\seq_new:N \c_@@_headings_seq
-\seq_gset_eq:NN \c_@@_headings_seq \c_@@_section_headings_seq
-%<book|report>\seq_gput_left:Nn \c_@@_headings_seq { chapter }
-\seq_gput_left:Nn \c_@@_headings_seq { part }
+  { 
+    part ,
+%<book|report>    chapter ,
+    section , subsection , subsubsection , paragraph , subparagraph
+  }
 %</article|book|report>
-%<*beamer>
-\seq_const_from_clist:Nn \c_@@_headings_seq
-  { part , section , subsection }
-%</beamer>
+%<beamer>  { part , section , subsection }
 %    \end{macrocode}
 % \end{variable}
 %

--- a/ctex/ctex.dtx
+++ b/ctex/ctex.dtx
@@ -9968,40 +9968,45 @@ Copyright and Licence
 % 要比简单的 |1.2\dimexpr| 精确^^A
 % \footnote{\url{http://thread.gmane.org/gmane.comp.tex.latex.latex3/3190}}。
 %    \begin{macrocode}
-\prop_new:N \c_@@_font_size_prop
-\seq_new:N \c_@@_font_size_seq
+\prop_new:N \l_@@_font_size_temp_prop
+\seq_new:N  \l_@@_font_size_temp_seq
 \cs_new_protected:Npn \@@_save_font_size:nn #1#2
   {
-    \use:e
+    \prop_put:Nne \l_@@_font_size_temp_prop {#1}
       {
-        \prop_gput:Nnn \exp_not:N \c_@@_font_size_prop {#1}
-          {
-            { \dim_to_decimal:n {#2} }
-            { \dim_to_decimal:n { (#2) * 6 / 5 } }
-          }
+        { \dim_to_decimal:n {#2} }
+        { \dim_to_decimal:n { (#2) * 6 / 5 } }
       }
-    \seq_gput_right:Nn \c_@@_font_size_seq {#1}
+    \seq_put_right:Nn \l_@@_font_size_temp_seq {#1}
   }
-\clist_map_inline:nn
-  {
-    {  8 } { 5    bp } ,
-    {  7 } { 5.5  bp } ,
-    { -6 } { 6.5  bp } ,
-    {  6 } { 7.5  bp } ,
-    { -5 } { 9    bp } ,
-    {  5 } { 10.5 bp } ,
-    { -4 } { 12   bp } ,
-    {  4 } { 14   bp } ,
-    { -3 } { 15   bp } ,
-    {  3 } { 16   bp } ,
-    { -2 } { 18   bp } ,
-    {  2 } { 22   bp } ,
-    { -1 } { 24   bp } ,
-    {  1 } { 26   bp } ,
-    { -0 } { 36   bp } ,
-    {  0 } { 42   bp }
-  }
-  { \@@_save_font_size:nn #1 }
+\group_begin:
+  \prop_clear:N \l_@@_font_size_temp_prop
+  \seq_clear:N  \l_@@_font_size_temp_seq
+  \clist_map_inline:nn
+    {
+      {  8 } { 5    bp } ,
+      {  7 } { 5.5  bp } ,
+      { -6 } { 6.5  bp } ,
+      {  6 } { 7.5  bp } ,
+      { -5 } { 9    bp } ,
+      {  5 } { 10.5 bp } ,
+      { -4 } { 12   bp } ,
+      {  4 } { 14   bp } ,
+      { -3 } { 15   bp } ,
+      {  3 } { 16   bp } ,
+      { -2 } { 18   bp } ,
+      {  2 } { 22   bp } ,
+      { -1 } { 24   bp } ,
+      {  1 } { 26   bp } ,
+      { -0 } { 36   bp } ,
+      {  0 } { 42   bp }
+    }
+    { \@@_save_font_size:nn #1 }
+  \exp_args:NNe \prop_const_from_keyval:Nn \c_@@_font_size_prop
+    { \prop_to_keyval:N \l_@@_font_size_temp_prop }
+  \exp_args:NNe \seq_const_from_clist:Nn \c_@@_font_size_seq
+    { \seq_use:Nn \l_@@_font_size_temp_seq { , } }
+\group_end:
 %    \end{macrocode}
 % \end{macro}
 % \end{variable}


### PR DESCRIPTION
近期用 `check-declarations` 模式检查了 `ctex`，发现了两处主要的赋值问题，具体来说是 `Global assignment to a constant variable`。

- 第一处在章节题名的定义，我改为直接用 DocStrip 特性做分流，而不是动态定义。
- 第二处在字号的定义。为了保留原本的动态计算过程，使用了临时变量做计算，最后传递给常量，并用分组来保证临时变量不可被外界使用。