### PR TITLE
xeCJK: 弃用 \xeCJKsetcharclass 并在调用时报错

### DIFF
--- a/xeCJK/xeCJK.dtx
+++ b/xeCJK/xeCJK.dtx
@@ -8443,9 +8443,19 @@ Copyright and Licence
 % \end{macro}
 %
 % \begin{macro}[int]{\xeCJKsetcharclass}
+% \changes{v3.9.0}{2026/04/24}{\textbf{Deprecated:}
+%   \tn{xeCJKsetcharclass} 已弃用，
+%   调用时报错并提示改用 \tn{xeCJKDeclareCharClass}（\#709）。}
 %    \begin{macrocode}
+\@@_msg_new:nn { xeCJKsetcharclass-deprecated }
+  {
+    \token_to_str:N \xeCJKsetcharclass\ is~deprecated~and~
+    does~not~update~CJKmath~char~lists.\\\\
+    Use~\token_to_str:N \xeCJKDeclareCharClass\ instead.
+  }
 \NewDocumentCommand \xeCJKsetcharclass { m m m }
   {
+    \@@_error:n { xeCJKsetcharclass-deprecated }
     \xeCJK_set_char_class:nnn {#1} {#2} {#3}
     \xeCJKResetPunctClass
   }


### PR DESCRIPTION
Closes #709

## Summary

- `\xeCJKsetcharclass` 自 2012 年 (28cc09b) 起不再被 `\xeCJKDeclareCharClass` 内部使用
- 它没有用户文档，仓库内无任何引用
- 它只操作 XeTeX 底层字符类，不更新 `\g_xeCJK_<class>_range_clist`，导致与 CJKmath 不兼容
- 由于参数类型不匹配（数字编号 vs 类名字符串），无法简单适配到现代 clist 体系

标记为 Deprecated，调用时发出 `\msg_error`，提示用户改用 `\xeCJKDeclareCharClass`。原有功能仍在 error 后执行，保证现有文档不会完全无法编译。

## Test plan

- [x] `xeCJK/` 全量 `l3build check -q` 通过（3/3 tests passed）
- [x] 仓库内无 `\xeCJKsetcharclass` 的调用，确认无内部影响