### PR TITLE
xeCJK: 在 \Pifont 中先进入水平模式以防止状态泄漏

### DIFF
--- a/llmdoc/architecture/package-architecture.md
+++ b/llmdoc/architecture/package-architecture.md
@@ -102,6 +102,12 @@
 
 优先去 `xeCJK/xeCJK.dtx` 查找，而不是从 `ctex` 入手。
 
+## 第三方包兼容 hook
+
+xeCJK 在 `xeCJK.dtx` 中通过 `\@@_package_hook:nn` 为多个第三方包（如 `pifont`、`listings`、`ulem` 等）注册兼容 hook。这些 hook 在目标包加载后执行，通常重定义目标包的关键命令以避免与 xeCJK 的 interchar token 机制冲突。
+
+典型模式是在命令中临时调用 `\makexeCJKinactive`（将 `\XeTeXinterchartokenstate` 设为 0），执行目标操作后由 TeX 分组恢复状态。但在垂直模式下调用这些命令时，需要先进入水平模式（`\mode_leave_vertical:`），否则分页可能导致局部赋值泄漏到输出例程。
+
 ## TECkit 映射
 
 `xeCJK/build.lua` 在标准 l3build 配置之外，还在 `unpack_posthook()` 中调用 `make_teckit_mapping()`，动态生成并编译 `.map`/`.tec` 文件。其输入来自 Unicode `Unihan.zip` 中的变体数据，并额外生成全角句号/句点映射。见 `xeCJK/build.lua:28-149`。

--- a/llmdoc/index.md
+++ b/llmdoc/index.md
@@ -22,3 +22,4 @@
 
 - `llmdoc/memory/decisions/725-cleveref-patch-toggle.md` — 决策: 不在 ctex 侧修复 cleveref appendix 语义问题，改为提供 `patch/cleveref` 开关。
 - `llmdoc/memory/decisions/751-newCJKfontfamily-scope.md` — 记录 #751 / PR #773 中 `\newCJKfontfamily` 从全局命令定义改为局部定义的原因、决策与影响范围。
+- `llmdoc/memory/decisions/688-pifont-interchartokenstate-leak.md` — 决策: pifont hook 中先进入水平模式防止 interchartokenstate 泄漏到输出例程。

--- a/llmdoc/memory/decisions/688-pifont-interchartokenstate-leak.md
+++ b/llmdoc/memory/decisions/688-pifont-interchartokenstate-leak.md
@@ -1,0 +1,51 @@
+---
+name: "688-pifont-interchartokenstate-leak"
+description: "决策: pifont hook 中 \\Pifont 在 \\makexeCJKinactive 前先进入水平模式，防止垂直模式下局部赋值通过分页泄漏到输出例程"
+type: decision
+---
+
+## 问题
+
+Issue #688: 使用 `\ding` 等 pifont 命令时，特定分页组合下页眉页脚中文不显示。
+
+## 根因
+
+xeCJK 对 pifont 的兼容 hook 中，`\Pifont` 被重定义为：
+
+```tex
+\RenewDocumentCommand \Pifont { m }
+  { \makexeCJKinactive \usefont { U } {#1} { m } { n } }
+```
+
+`\makexeCJKinactive` 执行 `\XeTeXinterchartokenstate = 0`（局部赋值）。当 `\ding` 位于段首（仍处于垂直模式）时：
+
+1. `\makexeCJKinactive` 在垂直模式下将 interchartokenstate 设为 0
+2. `\usefont` 选择字体但不进入水平模式
+3. `\char"B7` 触发隐式 `\leavevmode` 进入水平模式
+4. 若此时发生分页，输出例程在 `\XeTeXinterchartokenstate = 0` 下运行
+5. 页眉页脚中的 CJK 字符失去 interchar token 处理，导致中文不显示
+
+## 决策
+
+在 `\makexeCJKinactive` 前插入 `\mode_leave_vertical:`：
+
+```tex
+\RenewDocumentCommand \Pifont { m }
+  { \mode_leave_vertical: \makexeCJKinactive \usefont { U } {#1} { m } { n } }
+```
+
+**Why:** 先进入水平模式可确保任何由 `\leavevmode` 触发的分页发生在 `\XeTeXinterchartokenstate` 被修改之前，输出例程始终在 state=1 下运行。
+
+**How to apply:** xeCJK 中所有在垂直模式可能被调用且包含 `\makexeCJKinactive` 的命令，都应在禁用 xeCJK 前先确保进入水平模式。
+
+## 回归测试
+
+`xeCJK/testfiles/pifont01.lvt`:
+- TEST 1-2: 验证 `\ding` / `\Pisymbol` 前后 `\XeTeXinterchartokenstate` 恢复为 1
+- TEST 3: 拦截 `\makexeCJKinactive`，验证在垂直模式起始的 `\ding` 调用中，`\makexeCJKinactive` 被调用时已处于水平模式（旧代码返回 vmode，修复后返回 hmode）
+
+## 影响范围
+
+- 仅影响 xeCJK（XeTeX 路径）
+- 改动位于 `xeCJK/xeCJK.dtx` 的 pifont hook 区段
+- 不影响 ctex 的其他引擎路径

--- a/xeCJK/testfiles/pifont01.lvt
+++ b/xeCJK/testfiles/pifont01.lvt
@@ -1,0 +1,47 @@
+\input{regression-test}
+
+\documentclass{article}
+
+\usepackage{xeCJK}
+\setCJKmainfont{FandolSong-Regular.otf}
+\usepackage{pifont}
+
+\begin{document}
+
+\START
+
+\ExplSyntaxOn
+
+\TEST{XeTeXinterchartokenstate~preserved~after~\ding}{
+  \TYPE { before:~ \int_use:N \tex_XeTeXinterchartokenstate:D }
+  \ding{"B7}
+  \TYPE { after:~ \int_use:N \tex_XeTeXinterchartokenstate:D }
+}
+
+\TEST{XeTeXinterchartokenstate~preserved~after~\Pisymbol}{
+  \TYPE { before:~ \int_use:N \tex_XeTeXinterchartokenstate:D }
+  \Pisymbol{pzd}{"B7}
+  \TYPE { after:~ \int_use:N \tex_XeTeXinterchartokenstate:D }
+}
+
+\bool_new:N \g__test_hmode_at_disable_bool
+
+\TEST{Pifont~enters~hmode~before~disabling~xeCJK~(vmode~start)}{
+  \bool_gset_false:N \g__test_hmode_at_disable_bool
+  \cs_set_protected:Npn \makexeCJKinactive
+    {
+      \mode_if_horizontal:T
+        { \bool_gset_true:N \g__test_hmode_at_disable_bool }
+      \tex_XeTeXinterchartokenstate:D = \c_zero_int
+    }
+  some~text \par
+  \ding{"B7}
+  \TYPE { hmode-at-disable:~
+    \bool_if:NTF \g__test_hmode_at_disable_bool { yes } { no } }
+}
+
+\ExplSyntaxOff
+
+\END
+
+\end{document}

--- a/xeCJK/testfiles/pifont01.tlg
+++ b/xeCJK/testfiles/pifont01.tlg
@@ -1,0 +1,19 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+============================================================
+TEST 1: XeTeXinterchartokenstate preserved after \ding 
+============================================================
+before: 1
+after: 1
+============================================================
+============================================================
+TEST 2: XeTeXinterchartokenstate preserved after \Pisymbol 
+============================================================
+before: 1
+after: 1
+============================================================
+============================================================
+TEST 3: Pifont enters hmode before disabling xeCJK (vmode start)
+============================================================
+hmode-at-disable: yes
+============================================================

--- a/xeCJK/xeCJK.dtx
+++ b/xeCJK/xeCJK.dtx
@@ -9043,11 +9043,13 @@ Copyright and Licence
   }
 %    \end{macrocode}
 % \pkg{pifont} 宏包的符号 |\ding{183}| 也有冲突。
+% \changes{v3.9.0}{2026/04/24}{在 \tn{Pifont} 中先进入水平模式，
+%   防止 \tn{makexeCJKinactive} 在垂直模式下通过分页泄漏到输出例程（\#688）。}
 %    \begin{macrocode}
 \@@_package_hook:nn { pifont }
   {
     \RenewDocumentCommand \Pifont { m }
-      { \makexeCJKinactive \usefont { U } {#1} { m } { n } }
+      { \mode_leave_vertical: \makexeCJKinactive \usefont { U } {#1} { m } { n } }
   }
 %    \end{macrocode}
 % \end{variable}


### PR DESCRIPTION
## Summary

- 修复 #688：pifont 兼容 hook 中的 `\Pifont` 在垂直模式下调用 `\makexeCJKinactive` 会导致 `\XeTeXinterchartokenstate = 0` 在分页时泄漏到输出例程，使页眉页脚中文不显示
- 在 `\makexeCJKinactive` 前插入 `\mode_leave_vertical:`，确保分页发生在状态修改之前
- 新增回归测试 `pifont01`，包含状态保持验证和垂直模式行为验证

## Root cause

```
\ding{"B7}
  → \Pisymbol{pzd}{"B7}
    → {{\Pifont{pzd}\char"B7}}
      → \makexeCJKinactive \usefont{U}{pzd}{m}{n}
        → \XeTeXinterchartokenstate = 0 （在垂直模式下！）
```

当 `\ding` 位于段首时，`\makexeCJKinactive` 在垂直模式下执行局部赋值。随后 `\char` 触发隐式 `\leavevmode` 进入水平模式，若此时发生分页，输出例程在 `\XeTeXinterchartokenstate = 0` 下运行。

## Test plan

- [x] `pifont01` TEST 1-2: `\XeTeXinterchartokenstate` 在 `\ding`/`\Pisymbol` 前后恢复
- [x] `pifont01` TEST 3: 垂直模式起始的 `\ding` 调用中，`\makexeCJKinactive` 被调用时已处于水平模式
- [x] 旧代码 TEST 3 返回 `hmode-at-disable: no`（vmode），修复后返回 `yes`（hmode）
- [x] xeCJK 全量 `l3build check -q` 通过（5/5）

Closes #688