### PR TITLE
ctex, xeCJK: remove legacy \@rmfamilyhook fallback code

### DIFF
--- a/ctex/ctex.dtx
+++ b/ctex/ctex.dtx
@@ -6680,10 +6680,12 @@ Copyright and Licence
 %
 % \changes{v2.5.2}{2020/05/06}{兼容 \LaTeX\ 2020-02-02 之前的版本。}
 % \changes{v2.5.4}{2020/06/07}{修正主要字体命令补丁。}
+% \changes{v2.6.0}{2026/04/24}{\textbf{Breaking:}
+%   移除对 \LaTeX\ 2020/10/01 之前版本的字体钩子兼容代码。
+%   现在需要 \LaTeX\ 2020/10/01 或更新版本（\#746）。}
 %
 % 修改 \tn{rmfamily} 等主要字体命令，使得中文字体能随西文主要字体更新。
-% \LaTeX\ 2020-02-02 以后的版本可以直接使用 \tn{@rmfamilyhook} 等钩子。
-% 我们暂时需要处理旧内核的情况，以保持兼容性。
+% 使用 \LaTeX\ 2020/10/01 提供的 \texttt{rmfamily} 等 \pkg{NFSS} 钩子。
 %
 % \pkg{xeCJK} 和 \pkg{zhmCJK} 已经有相同的工作，本段代码不需要对他们使用。
 %    \begin{macrocode}
@@ -6701,27 +6703,10 @@ Copyright and Licence
     \exp_args:Nc \@@_provide_font_hook_aux:NNNN
       { CTEX \cs_to_str:N #2 } #1#2
   }
-\cs_if_exist:NTF \ctex_gadd_ltxhook:nn
+\cs_new_protected:Npn \@@_provide_font_hook_aux:NNNN #1#2#3#4
   {
-    \cs_new_protected:Npn \@@_provide_font_hook_aux:NNNN #1#2#3#4
-      {
-        \tl_new:N #1
-        \exp_args:Nx \ctex_gadd_ltxhook:nn { \cs_to_str:N #2 } {#1}
-      }
-  }
-  {
-    \cs_new_protected:Npn \@@_provide_font_hook_aux:NNNN #1#2#3#4
-      {
-        \tl_new:N #1
-        \cs_if_exist:NTF #3
-          { \tl_gput_right:Nn #3 {#1} }
-%    \end{macrocode}
-% 注意此处不能用 \cs{ctex_patch_cmd:Nnn} 来打补丁，因其会关闭 \LaTeXiii 语法，
-% 但 \pkg{fontspec} 会在 \tn{rmfamily} 的命令中相应加入
-% \cs{l__fontspec_rmfamily_encoding_tl} 等，导致补丁失败。
-%    \begin{macrocode}
-          { \ctex_parse_name:NN \tl_replace_once:Nnn #2 {#4} { #1#4 } }
-      }
+    \tl_new:N #1
+    \exp_args:Nx \ctex_gadd_ltxhook:nn { \cs_to_str:N #2 } {#1}
   }
 \ctex_provide_font_hook:NNN \rmfamily \@rmfamilyhook \selectfont
 \ctex_provide_font_hook:NNN \sffamily \@sffamilyhook \selectfont

--- a/llmdoc/index.md
+++ b/llmdoc/index.md
@@ -22,3 +22,4 @@
 
 - `llmdoc/memory/decisions/725-cleveref-patch-toggle.md` — 决策: 不在 ctex 侧修复 cleveref appendix 语义问题，改为提供 `patch/cleveref` 开关。
 - `llmdoc/memory/decisions/751-newCJKfontfamily-scope.md` — 记录 #751 / PR #773 中 `\newCJKfontfamily` 从全局命令定义改为局部定义的原因、决策与影响范围。
+- `llmdoc/memory/decisions/746-remove-legacy-font-hooks.md` — 决策: 移除对 LaTeX < 2020/10/01 的字体钩子兼容代码，响应上游移除 `\@rmfamilyhook`。

--- a/llmdoc/memory/decisions/746-remove-legacy-font-hooks.md
+++ b/llmdoc/memory/decisions/746-remove-legacy-font-hooks.md
@@ -1,0 +1,36 @@
+---
+name: "746-remove-legacy-font-hooks"
+description: "决策: 移除 ctex 和 xeCJK 中对 LaTeX < 2020/10/01 的字体钩子兼容代码，响应上游移除 \\@rmfamilyhook"
+type: decision
+---
+
+## 问题
+
+Issue #746: LaTeX 团队（Frank Mittelbach）通知即将移除 `\@rmfamilyhook`、`\@sffamilyhook`、`\@ttfamilyhook` 和 `\@defaultfamilyhook` 的兼容定义。
+
+## 现状分析
+
+ctex 和 xeCJK 已通过版本检测在 LaTeX >= 2020/10/01 下走新钩子路径，旧代码路径不会被触发：
+
+- **ctex**: `\cs_if_exist:NTF \ctex_gadd_ltxhook:nn` 门控，新路径使用 `\hook_gput_code:nnn`
+- **xeCJK**: `\ctex_if_format_at_least:nTF { 2020/10/01 }` 门控，新路径使用 `\ctex_gadd_ltxhook:nn`
+
+**Why:** 旧代码虽不影响运行，但作为死代码会误导维护者，且随上游变更可能引发困惑。
+
+## 决策
+
+移除旧兼容代码，仅保留新钩子路径。
+
+**Breaking change**: 不再支持 LaTeX < 2020/10/01。
+
+### ctex 侧
+
+- 移除 `\@@_provide_font_hook_aux:NNNN` 的旧回退分支（直接操作 `\@rmfamilyhook` 或 patch `\rmfamily`）
+- 保留 `\ctex_provide_font_hook:NNN` 接口不变（`\@rmfamilyhook` 参数仍用于构造 `\CTEX@rmfamilyhook` 名称）
+
+### xeCJK 侧
+
+- 移除 `\ctex_if_format_at_least:nTF { 2020/10/01 }` 的 false 分支（含 `\@rmfamilyhook` 路径和 `\fontfamily` 重定义路径约 40 行）
+- 移除不再需要的 `\xeCJK@fontfamily` 和 `\@@_update_family_aux:`
+
+**How to apply:** 后续涉及 LaTeX 内核钩子变更时，可直接引用新 hook API，无需考虑旧回退路径。

--- a/xeCJK/xeCJK.dtx
+++ b/xeCJK/xeCJK.dtx
@@ -8637,63 +8637,22 @@ Copyright and Licence
 % \changes{v3.8.6}{2020/10/17}{兼容 \LaTeX\ 2020/10/01 的 \pkg{NFSS} 钩子机制。}
 %
 % \begin{macro}[int]{\fontfamily}
-% \begin{macro}[int]{\xeCJK@fontfamily,\xeCJK@family}
+% \begin{macro}[int]{\xeCJK@family}
 % \changes{v3.1.1}{2012/12/06}{修改主要 \texttt{CJK} 字体族的自动更新方式。}
 % \changes{v3.1.2}{2013/01/01}{不将参数完全展开。}
 % \changes{v3.4.6}{2017/02/23}
 %   {将族名参数完全展开，以解决与 \pkg{fontspec} 2017/01/24 v2.5d 的兼容问题。}
-% 对于 \LaTeXe\ 2020/02/02 之前的版本，修改 \tn{fontfamily}，
-% 使主要 |CJK| 字体族能随西文主要字体更新，之后的版本可以使用 \tn{@rmfamilyhook} 等新钩子处理。
-% \LaTeXe\ 2020/10/01 提供了新的的 \pkg{NFSS} 钩子。
+% \changes{v3.9.0}{2026/04/24}{\textbf{Breaking:}
+%   移除对 \LaTeXe\ 2020/10/01 之前版本的字体钩子兼容代码（\#746）。}
+% 使用 \LaTeXe\ 2020/10/01 提供的 \pkg{NFSS} 钩子，
+% 使主要 |CJK| 字体族能随西文主要字体更新。
 %    \begin{macrocode}
-\ctex_if_format_at_least:nTF { 2020/10/01 }
-  {
-    \cs_set_eq:NN \xeCJK@family \xeCJK_switch_family:e
-    \ctex_gadd_ltxhook:nn { rmfamily }   { \xeCJK@family { \CJKrmdefault } }
-    \ctex_gadd_ltxhook:nn { sffamily }   { \xeCJK@family { \CJKsfdefault } }
-    \ctex_gadd_ltxhook:nn { ttfamily }   { \xeCJK@family { \CJKttdefault } }
-    \ctex_gadd_ltxhook:nn { normalfont } { \xeCJK@family { \CJKfamilydefault } }
-  }
-  {
-    \cs_if_exist:NTF \@rmfamilyhook
-      {
-        \cs_set_eq:NN \xeCJK@family \xeCJK_switch_family:e
-        \g@addto@macro \@rmfamilyhook { \xeCJK@family { \CJKrmdefault } }
-        \g@addto@macro \@sffamilyhook { \xeCJK@family { \CJKsfdefault } }
-        \g@addto@macro \@ttfamilyhook { \xeCJK@family { \CJKttdefault } }
-        \exp_args:Nc \g@addto@macro
-          {
-            \cs_if_exist:NTF \@defaultfamilyhook
-              { @defaultfamilyhook } { normalfont ~ }
-          }
-          { \xeCJK@family { \CJKfamilydefault } }
-      }
-      {
-        \RenewDocumentCommand \fontfamily { m }
-          {
-            \tl_set:Nx \f@family {#1}
-            \xeCJK@fontfamily {#1}
-          }
-        \cs_new_protected:Npn \xeCJK@fontfamily #1
-          {
-            \str_if_eq:nnTF {#1} { \familydefault }
-              { \xeCJK_switch_family:e { \CJKfamilydefault } }
-              { \@@_update_family_aux: }
-          }
-        \cs_new_protected:Npn \@@_update_family_aux:
-          {
-            \str_case_e:nn { \f@family }
-              {
-                { \rmdefault }     { \xeCJK_switch_family:e { \CJKrmdefault } }
-                { \sfdefault }     { \xeCJK_switch_family:e { \CJKsfdefault } }
-                { \ttdefault }     { \xeCJK_switch_family:e { \CJKttdefault } }
-                { \familydefault } { \xeCJK_switch_family:e { \CJKfamilydefault } }
-              }
-          }
-      }
-  }
+\cs_set_eq:NN \xeCJK@family \xeCJK_switch_family:e
+\ctex_gadd_ltxhook:nn { rmfamily }   { \xeCJK@family { \CJKrmdefault } }
+\ctex_gadd_ltxhook:nn { sffamily }   { \xeCJK@family { \CJKsfdefault } }
+\ctex_gadd_ltxhook:nn { ttfamily }   { \xeCJK@family { \CJKttdefault } }
+\ctex_gadd_ltxhook:nn { normalfont } { \xeCJK@family { \CJKfamilydefault } }
 %    \end{macrocode}
-% \end{macro}
 % \end{macro}
 %
 %    \begin{macrocode}


### PR DESCRIPTION
## Summary

- Remove legacy font hook fallback code targeting LaTeX < 2020/10/01 from both `ctex` and `xeCJK`
- `ctex`: Remove the false branch of `\cs_if_exist:NTF \ctex_gadd_ltxhook:nn` in `\ctex_provide_font_hook:NNN` (old path that directly manipulated `\@rmfamilyhook` or patched `\rmfamily`)
- `xeCJK`: Remove the false branch of `\ctex_if_format_at_least:nTF { 2020/10/01 }` (including both the `\@rmfamilyhook` sub-path and the `\fontfamily` redefinition sub-path, ~40 lines)
- Both packages now exclusively use the LaTeX 2020/10/01+ NFSS hook API (`\hook_gput_code:nnn` via `\ctex_gadd_ltxhook:nn`)

**Breaking change**: LaTeX < 2020/10/01 is no longer supported for font family hooks.

## Test plan

- [x] xeCJK `l3build check -q` — all 4 tests pass
- [x] ctex `l3build check -q` — 65/66 pass; only `fonts02.xetex.diff` fails (pre-existing, unrelated)

Closes #746
