### PR TITLE
docs: 在 beforeskip/afterskip 文档中增加 titlesec 不兼容提示

### DIFF
--- a/ctex/ctex.dtx
+++ b/ctex/ctex.dtx
@@ -2262,6 +2262,10 @@ Copyright and Licence
 %   \end{syntax}
 %   \opt{beforeskip} 选项用于设置章节标题前的垂直间距。
 %   该选项的默认设置见表~\ref{tab:beforeskip-default}。
+%
+%   \textbf{注意：}若加载了 \pkg{titlesec} 宏包（且未使用其 \opt{loadonly} 选项），
+%   \pkg{titlesec} 将完全接管章节标题命令。此时 \opt{beforeskip} 选项不再生效，
+%   应改用 \pkg{titlesec} 的 \tn{titlespacing} 命令来设置标题前间距。
 % \end{function}
 %
 % \begin{function}[EXP,updated=2015-06-27]{.../afterskip}
@@ -2277,6 +2281,10 @@ Copyright and Licence
 %   该选项的默认设置见表~\ref{tab:afterskip-default}。
 %   注意 \opt{sub3section} 或 \opt{sub4section} 宏包选项（见
 %   \ref{subs:options-heading}~节）会影响 \opt{aftertitle} 选项的默认值。
+%
+%   \textbf{注意：}若加载了 \pkg{titlesec} 宏包（且未使用其 \opt{loadonly} 选项），
+%   \pkg{titlesec} 将完全接管章节标题命令。此时 \opt{afterskip} 选项不再生效，
+%   应改用 \pkg{titlesec} 的 \tn{titlespacing} 命令来设置标题后间距。
 % \end{function}
 %
 % \begin{table}[htbp]


### PR DESCRIPTION
## Summary

- 在 `beforeskip` 和 `afterskip` 选项的用户文档中增加醒目提示：加载 `titlesec` 宏包后这两个选项不再生效，应改用 `\titlespacing`
- 此信息此前仅出现在文档后部的实现注解段落中，用户不易注意到

Closes #734

## Test plan

- [ ] 确认 `l3build doc` 能正常生成 ctex 文档
- [ ] 确认新增提示在 PDF 文档中显示正确