### PR TITLE
xeCJK, ctex: 改进 \newCJKfontfamily 的报错和测试

### DIFF
--- a/ctex/ctex.dtx
+++ b/ctex/ctex.dtx
@@ -5931,7 +5931,7 @@ Copyright and Licence
       { }
   }
 \msg_new:nnn { ctex } { command-already-defined }
-  { Control~sequence~\iow_char:N \\#1~is~already~defined. }
+  { Control~sequence~#1~is~already~defined. }
 \NewDocumentCommand \newCJKfontfamily { o m o m }
   {
     \tl_set:Nx \l_@@_tmp_tl

--- a/ctex/test/testfiles/fontfamily01.luatex.tlg
+++ b/ctex/test/testfiles/fontfamily01.luatex.tlg
@@ -1,17 +1,20 @@
 This is a generated file for the l3build validation system.
 Don't change this file in any respect.
 ============================================================
-TEST 1: newCJKfontfamily inside group
-============================================================
-inside: defined
-============================================================
-============================================================
-TEST 2: newCJKfontfamily should not leak outside group
-============================================================
-outside: undefined
-============================================================
-============================================================
-TEST 3: newCJKfontfamily at top level
+TEST 1: newCJKfontfamily at top level
 ============================================================
 top-level: defined
 ============================================================
+============================================================
+TEST 2: newCJKfontfamily inside group, should not leak outside group
+============================================================
+inside: defined
+outside: undefined
+============================================================
+============================================================
+TEST 3: newCJKfontfamily on existing control sequence
+============================================================
+! Class ctexart Error: Control sequence \testfontC is already defined.
+Type <return> to continue.
+ ...                                              
+l. ...}

--- a/ctex/test/testfiles/fontfamily01.lvt
+++ b/ctex/test/testfiles/fontfamily01.lvt
@@ -18,20 +18,22 @@
 
 \ExplSyntaxOn
 
-\TEST{newCJKfontfamily~inside~group}{
+\TEST{newCJKfontfamily~at~top~level}{
+  \newCJKfontfamily \testfontB { FandolHei-Regular.otf }
+  \TYPE { top-level:~ \cs_if_exist:NTF \testfontB { defined } { undefined } }
+}
+
+\TEST{newCJKfontfamily~inside~group,~should~not~leak~outside~group}{
   \group_begin:
     \newCJKfontfamily \testfontA { FandolKai-Regular.otf }
     \TYPE { inside:~ \cs_if_exist:NTF \testfontA { defined } { undefined } }
   \group_end:
-}
-
-\TEST{newCJKfontfamily~should~not~leak~outside~group}{
   \TYPE { outside:~ \cs_if_exist:NTF \testfontA { defined } { undefined } }
 }
 
-\TEST{newCJKfontfamily~at~top~level}{
-  \newCJKfontfamily \testfontB { FandolHei-Regular.otf }
-  \TYPE { top-level:~ \cs_if_exist:NTF \testfontB { defined } { undefined } }
+\TEST{newCJKfontfamily~on~existing~control~sequence}{
+  \def \testfontC { dummy }
+  \newCJKfontfamily \testfontC { FandolSong-Regular.otf }
 }
 
 \ExplSyntaxOff

--- a/ctex/test/testfiles/fontfamily01.pdftex.tlg
+++ b/ctex/test/testfiles/fontfamily01.pdftex.tlg
@@ -1,3 +1,0 @@
-This is a generated file for the l3build validation system.
-Don't change this file in any respect.
-LuaTeX Only.

--- a/ctex/test/testfiles/fontfamily01.uptex.tlg
+++ b/ctex/test/testfiles/fontfamily01.uptex.tlg
@@ -1,3 +1,0 @@
-This is a generated file for the l3build validation system.
-Don't change this file in any respect.
-LuaTeX Only.

--- a/xeCJK/testfiles/fontfamily01.lvt
+++ b/xeCJK/testfiles/fontfamily01.lvt
@@ -11,20 +11,22 @@
 
 \ExplSyntaxOn
 
-\TEST{newCJKfontfamily~inside~group}{
+\TEST{newCJKfontfamily~at~top~level}{
+  \newCJKfontfamily \testfontB { FandolHei-Regular.otf }
+  \TYPE { top-level:~ \cs_if_exist:NTF \testfontB { defined } { undefined } }
+}
+
+\TEST{newCJKfontfamily~inside~group,~should~not~leak~outside~group}{
   \group_begin:
     \newCJKfontfamily \testfontA { FandolKai-Regular.otf }
     \TYPE { inside:~ \cs_if_exist:NTF \testfontA { defined } { undefined } }
   \group_end:
-}
-
-\TEST{newCJKfontfamily~should~not~leak~outside~group}{
   \TYPE { outside:~ \cs_if_exist:NTF \testfontA { defined } { undefined } }
 }
 
-\TEST{newCJKfontfamily~at~top~level}{
-  \newCJKfontfamily \testfontB { FandolHei-Regular.otf }
-  \TYPE { top-level:~ \cs_if_exist:NTF \testfontB { defined } { undefined } }
+\TEST{newCJKfontfamily~on~existing~control~sequence}{
+  \def \testfontC { dummy }
+  \newCJKfontfamily \testfontC { FandolSong-Regular.otf }
 }
 
 \ExplSyntaxOff

--- a/xeCJK/testfiles/fontfamily01.tlg
+++ b/xeCJK/testfiles/fontfamily01.tlg
@@ -1,17 +1,23 @@
 This is a generated file for the l3build validation system.
 Don't change this file in any respect.
 ============================================================
-TEST 1: newCJKfontfamily inside group
-============================================================
-inside: defined
-============================================================
-============================================================
-TEST 2: newCJKfontfamily should not leak outside group
-============================================================
-outside: undefined
-============================================================
-============================================================
-TEST 3: newCJKfontfamily at top level
+TEST 1: newCJKfontfamily at top level
 ============================================================
 top-level: defined
 ============================================================
+============================================================
+TEST 2: newCJKfontfamily inside group, should not leak outside group
+============================================================
+inside: defined
+outside: undefined
+============================================================
+============================================================
+TEST 3: newCJKfontfamily on existing control sequence
+============================================================
+! Package xeCJK Error: Control sequence \testfontC is already defined.
+Type <return> to continue.
+ ...                                              
+l. ...}
+LaTeX does not know anything more about this error, sorry.
+Try typing <return> to proceed.
+If that doesn't work, type X <return> to quit.

--- a/xeCJK/xeCJK.dtx
+++ b/xeCJK/xeCJK.dtx
@@ -7332,7 +7332,7 @@ Copyright and Licence
       { }
   }
 \@@_msg_new:nn { command-already-defined }
-  { Control~sequence~\iow_char:N \\#1~is~already~defined. }
+  { Control~sequence~#1~is~already~defined. }
 \NewDocumentCommand \newCJKfontfamily { o m o m }
   {
     \tl_set:Nx \l_@@_tmp_tl


### PR DESCRIPTION
- 删除错误信息中的多余 backslash，并测试触发报错的情况
- 删除不必要的 `fontfamily01.<engine>.tlg`
- 改进测试，`\TEST{<title>}{<contents>}` 的 `<contents>` 已经在一个分组里，在第二个 `\TEST` 里测试前一个 `\TEST` 里的局部定义是否局部，是总是成功的。