### PR TITLE
fix(ctex): 修复 macOS 15+ 下 fontset=mac 的字体检测问题

### DIFF
--- a/ctex/ctex.dtx
+++ b/ctex/ctex.dtx
@@ -1036,6 +1036,9 @@ Copyright and Licence
 %   \item[mac] 使用 macOS 系统下的字体，\emph{不支持 \pdfLaTeX}，根据版本分为
 %     |macnew| 和 |macold| 两种。
 %   \item[macnew] 使用 El Capitan 或之后的多字重华文字体和苹方字体。
+%     从 macOS~15 (Sequoia) 开始，部分字体（苹方、楷体、仿宋、隶书、圆体）转为
+%     \emph{downloadable}，\CTeX{} 会自动检测可用性：可用时使用，不可用时静默跳过
+%     或回退。若需要完整的字体集，请在系统字体册中手动下载相关字体。
 %   \item[macold] 使用 Yosemite 或之前的华文字体。
 %   \item[ubuntu] 使用 Ubuntu 系统下的思源宋体、思源黑体和 \TeX{} 发行版自带的
 %     文鼎楷体，\emph{不支持 \pdfLaTeX}。
@@ -1090,6 +1093,7 @@ Copyright and Licence
 % 在 \opt{macnew} 字库中，还定义了 \tn{pingfang}：
 % \begin{optdesc}
 %   \item[\tn{pingfang}] 苹方黑体，CJK 等价命令 |\CJKfamily{zhpf}|。
+%     在 macOS~15 及之后，苹方字体可能尚未下载，此时该命令不会被定义。
 % \end{optdesc}
 %
 % \section{排版格式设定}
@@ -10975,17 +10979,77 @@ Copyright and Licence
 % \paragraph{\opt{mac} 相关}
 %
 % \changes{v2.4.14}{2018/05/01}{区分 \opt{macold} 及 \opt{macnew}。}
+% \changes{v2.5.11}{2026/04/29}{\opt{macnew} 增加 macOS~15+ 兼容，字体运行时检测。}
 %
 % 按 \href{https://github.com/CTeX-org/ctex-kit/issues/351}{Issue 351}
 % 的讨论，以 El Capitan 为分界，分别设置 |macold|（El Capitan 之前）
 % 和 |macnew|（El Capitan 及之后）。检测方式则以 El Capitan 及之后
-% 的苹方字体为准。
+% 的苹方字体为准。从 macOS~15 (Sequoia) 开始，苹方字体转为
+% \emph{downloadable}，不再位于传统路径，故增加版本号检测作为后备。
 %
 %    \begin{macrocode}
 %<*mac>
+\tl_new:N \g_@@_macos_ver_tl
+\msg_new:nnn { ctex } { macos-version-detect-failed }
+  { Cannot~detect~macOS~version.~Falling~back~to~macold~fontset. }
+\sys_if_engine_luatex:TF
+  {
+    \lua_now:n
+      {
+        local~f~=~io.open("/System/Library/CoreServices/SystemVersion.plist",~"r");~
+        if~f~then~
+          local~content~=~f:read("*a");~
+          f:close();~
+          local~ver~=~content:match("ProductVersion.-<string>(.-)</string>");~
+          if~ver~then~
+            local~dot~=~ver:find(".",~1,~true);~
+            local~major~=~dot~and~ver:sub(1,~dot~-~1)~or~ver;~
+            if~major~then~
+              token.set_macro("g__ctex_macos_ver_tl",~major,~"global");~
+            end;~
+          end;~
+        end
+      }
+  }
+  {
+    \ior_new:N \g_@@_macos_ver_ior
+    \bool_new:N \g_@@_macos_ver_found_bool
+    \file_if_exist:nT { /System/Library/CoreServices/SystemVersion.plist }
+      {
+        \ior_open:Nn \g_@@_macos_ver_ior
+          { /System/Library/CoreServices/SystemVersion.plist }
+        \ior_map_inline:Nn \g_@@_macos_ver_ior
+          {
+            \bool_if:NTF \g_@@_macos_ver_found_bool
+              {
+                \tl_set:Nn \l_tmpa_tl {#1}
+                \regex_replace_once:nnN
+                  { .*? <string> (\d+) .* } { \1 } \l_tmpa_tl
+                \tl_gset:NV \g_@@_macos_ver_tl \l_tmpa_tl
+                \ior_map_break:
+              }
+              {
+                \tl_if_in:nnT {#1} { ProductVersion }
+                  { \bool_gset_true:N \g_@@_macos_ver_found_bool }
+              }
+          }
+        \ior_close:N \g_@@_macos_ver_ior
+      }
+  }
 \file_if_exist:nTF { /System/Library/Fonts/PingFang.ttc }
   { \ctex_file_input:n { ctex-fontset-macnew.def } }
-  { \ctex_file_input:n { ctex-fontset-macold.def } }
+  {
+    \tl_if_empty:NTF \g_@@_macos_ver_tl
+      {
+        \msg_warning:nn { ctex } { macos-version-detect-failed }
+        \ctex_file_input:n { ctex-fontset-macold.def }
+      }
+      {
+        \int_compare:nNnTF { \g_@@_macos_ver_tl } < { 15 }
+          { \ctex_file_input:n { ctex-fontset-macold.def } }
+          { \ctex_file_input:n { ctex-fontset-macnew.def } }
+      }
+  }
 %</mac>
 %    \end{macrocode}
 %
@@ -11075,21 +11139,154 @@ Copyright and Licence
     \setCJKfamilyfont { zhkai  } { STKaiti    }
 %</macold>
 %<*macnew>
-    \setCJKmainfont { Songti~SC~Light }
-      [
-        BoldFont       = Songti~SC~Bold,
-        ItalicFont     = Kaiti~SC,
-        BoldItalicFont = Kaiti~SC~Bold
-      ]
-    \setCJKsansfont { PingFang~SC }
-    \setCJKmonofont { STFangsong  }
-    \setCJKfamilyfont { zhsong } { Songti~SC~Light } [ BoldFont = Songti~SC~Bold ]
-    \setCJKfamilyfont { zhhei  } { Heiti~SC~Light  } [ BoldFont = Heiti~SC~Medium ]
-    \setCJKfamilyfont { zhpf   } { PingFang~SC     }
-    \setCJKfamilyfont { zhfs   } { STFangsong      }
-    \setCJKfamilyfont { zhkai  } { Kaiti~SC        } [ BoldFont = Kaiti~SC~Bold ]
-    \setCJKfamilyfont { zhli   } { Baoli~SC        }
-    \setCJKfamilyfont { zhyou  } { Yuanti~SC~Light } [ BoldFont = Yuanti~SC~Regular ]
+    \sys_if_engine_luatex:TF
+      {
+        \lua_now:n
+          {
+            local~lfs~=~require("lfs");~
+            local~search_bases~=~{
+              "/System/Library/AssetsV2/com_apple_MobileAsset_Font8",
+              "/System/Library/AssetsV2/PreinstalledAssetsV2/"
+                ..~"InstallWithOs/com_apple_MobileAsset_Font7",
+            };~
+            local~function~find_font_dir(filename)~
+              for~_,~base~in~ipairs(search_bases)~do~
+                local~ok,~iter,~obj~=~pcall(lfs.dir,~base);~
+                if~ok~then~
+                  for~entry~in~iter,~obj~do~
+                    if~not~(entry~==~"."~or~entry~==~"..")~then~
+                      local~p~=~base~..~"/"~..~entry
+                        ..~"/AssetData/"~..~filename;~
+                      if~lfs.attributes(p,~"mode")~then~
+                        return~base~..~"/"~..~entry~..~"/AssetData/";~
+                      end;~
+                    end;~
+                  end;~
+                end;~
+              end;~
+              return~nil;~
+            end;~
+            local~fonts~=~{
+              {"PingFang.ttc",~"g__ctex_mac_pingfang_dir_tl"},
+              {"Kaiti.ttc",~~~~"g__ctex_mac_kaiti_dir_tl"},
+              {"STFANGSO.ttf",~"g__ctex_mac_stfangso_dir_tl"},
+              {"Baoli.ttc",~~~~"g__ctex_mac_baoli_dir_tl"},
+              {"Yuanti.ttc",~~~"g__ctex_mac_yuanti_dir_tl"},
+            };~
+            for~_,~f~in~ipairs(fonts)~do~
+              local~dir~=~find_font_dir(f[1]);~
+              token.set_macro(f[2],~dir~or~"",~"global");~
+            end
+          }
+        \tl_if_empty:NTF \g__ctex_mac_kaiti_dir_tl
+          {
+            \setCJKmainfont { Songti~SC~Light }
+              [ BoldFont = Songti~SC~Bold ]
+          }
+          {
+            \setCJKmainfont { Songti~SC~Light }
+              [
+                BoldFont       = Songti~SC~Bold ,
+                ItalicFont     = Kaiti.ttc ,
+                ItalicFeatures = { Path = \g__ctex_mac_kaiti_dir_tl , FontIndex = 0 } ,
+                BoldItalicFont = Kaiti.ttc ,
+                BoldItalicFeatures = { Path = \g__ctex_mac_kaiti_dir_tl , FontIndex = 3 } ,
+              ]
+          }
+        \setCJKfamilyfont { zhsong } { Songti~SC~Light }
+          [ BoldFont = Songti~SC~Bold ]
+        \setCJKfamilyfont { zhhei  } { Heiti~SC~Light  }
+          [ BoldFont = Heiti~SC~Medium ]
+        \tl_if_empty:NTF \g__ctex_mac_pingfang_dir_tl
+          { \setCJKsansfont { Heiti~SC~Light } [ BoldFont = Heiti~SC~Medium ] }
+          {
+            \setCJKsansfont { PingFang.ttc }
+              [
+                Path          = \g__ctex_mac_pingfang_dir_tl ,
+                FontIndex     = 2 ,
+                BoldFont      = PingFang.ttc ,
+                BoldFontIndex = 8 ,
+              ]
+            \setCJKfamilyfont { zhpf } { PingFang.ttc }
+              [ Path = \g__ctex_mac_pingfang_dir_tl , FontIndex = 2 ]
+          }
+        \tl_if_empty:NTF \g__ctex_mac_stfangso_dir_tl
+          { \setCJKmonofont { Heiti~SC~Light } }
+          {
+            \setCJKmonofont { STFANGSO.ttf }
+              [ Path = \g__ctex_mac_stfangso_dir_tl ]
+            \setCJKfamilyfont { zhfs } { STFANGSO.ttf }
+              [ Path = \g__ctex_mac_stfangso_dir_tl ]
+          }
+        \tl_if_empty:NF \g__ctex_mac_kaiti_dir_tl
+          {
+            \setCJKfamilyfont { zhkai } { Kaiti.ttc }
+              [
+                Path          = \g__ctex_mac_kaiti_dir_tl ,
+                FontIndex     = 0 ,
+                BoldFont      = Kaiti.ttc ,
+                BoldFontIndex = 3 ,
+              ]
+          }
+        \tl_if_empty:NF \g__ctex_mac_baoli_dir_tl
+          {
+            \setCJKfamilyfont { zhli } { Baoli.ttc }
+              [ Path = \g__ctex_mac_baoli_dir_tl , FontIndex = 0 ]
+          }
+        \tl_if_empty:NF \g__ctex_mac_yuanti_dir_tl
+          {
+            \setCJKfamilyfont { zhyou } { Yuanti.ttc }
+              [
+                Path          = \g__ctex_mac_yuanti_dir_tl ,
+                FontIndex     = 4 ,
+                BoldFont      = Yuanti.ttc ,
+                BoldFontIndex = 0 ,
+              ]
+          }
+      }
+      {
+        \fontspec_font_if_exist:nTF { Kaiti~SC }
+          {
+            \setCJKmainfont { Songti~SC~Light }
+              [
+                BoldFont       = Songti~SC~Bold ,
+                ItalicFont     = Kaiti~SC ,
+                BoldItalicFont = Kaiti~SC~Bold ,
+              ]
+          }
+          {
+            \setCJKmainfont { Songti~SC~Light }
+              [ BoldFont = Songti~SC~Bold ]
+          }
+        \setCJKfamilyfont { zhsong } { Songti~SC~Light }
+          [ BoldFont = Songti~SC~Bold ]
+        \setCJKfamilyfont { zhhei  } { Heiti~SC~Light  }
+          [ BoldFont = Heiti~SC~Medium ]
+        \fontspec_font_if_exist:nTF { PingFang~SC }
+          {
+            \setCJKsansfont { PingFang~SC }
+            \setCJKfamilyfont { zhpf } { PingFang~SC }
+          }
+          { \setCJKsansfont { Heiti~SC~Light } [ BoldFont = Heiti~SC~Medium ] }
+        \fontspec_font_if_exist:nTF { STFangsong }
+          {
+            \setCJKmonofont { STFangsong }
+            \setCJKfamilyfont { zhfs } { STFangsong }
+          }
+          { \setCJKmonofont { Heiti~SC~Light } }
+        \fontspec_font_if_exist:nT { Kaiti~SC }
+          {
+            \setCJKfamilyfont { zhkai } { Kaiti~SC }
+              [ BoldFont = Kaiti~SC~Bold ]
+          }
+        \fontspec_font_if_exist:nT { Baoli~SC }
+          { \setCJKfamilyfont { zhli } { Baoli~SC } }
+        \fontspec_font_if_exist:nT { Yuanti~SC~Light }
+          {
+            \setCJKfamilyfont { zhyou } { Yuanti~SC~Light }
+              [ BoldFont = Yuanti~SC~Regular ]
+          }
+      }
 %</macnew>
   }
 %</macold|macnew>

--- a/ctex/ctex.dtx
+++ b/ctex/ctex.dtx
@@ -11146,11 +11146,21 @@ Copyright and Licence
         \lua_now:n
           {
             local~lfs~=~require("lfs");~
-            local~search_bases~=~{
-              "/System/Library/AssetsV2/com_apple_MobileAsset_Font8",
-              "/System/Library/AssetsV2/PreinstalledAssetsV2/"
-                ..~"InstallWithOs/com_apple_MobileAsset_Font7",
+            local~search_bases~=~{};~
+            local~asset_roots~=~{
+              "/System/Library/AssetsV2",
+              "/System/Library/AssetsV2/PreinstalledAssetsV2/InstallWithOs",
             };~
+            for~_,~root~in~ipairs(asset_roots)~do~
+              local~ok,~iter,~obj~=~pcall(lfs.dir,~root);~
+              if~ok~then~
+                for~d~in~iter,~obj~do~
+                  if~d:find("^com_apple_MobileAsset_Font")~then~
+                    table.insert(search_bases,~root~..~"/"~..~d);~
+                  end;~
+                end;~
+              end;~
+            end;~
             local~function~find_font_dir(filename)~
               for~_,~base~in~ipairs(search_bases)~do~
                 local~ok,~iter,~obj~=~pcall(lfs.dir,~base);~

--- a/ctex/ctex.dtx
+++ b/ctex/ctex.dtx
@@ -11139,6 +11139,7 @@ Copyright and Licence
     \setCJKfamilyfont { zhkai  } { STKaiti    }
 %</macold>
 %<*macnew>
+    \bool_new:N \g_@@_mac_pingfang_bool
     \sys_if_engine_luatex:TF
       {
         \lua_now:n
@@ -11209,6 +11210,7 @@ Copyright and Licence
               ]
             \setCJKfamilyfont { zhpf } { PingFang.ttc }
               [ Path = \g__ctex_mac_pingfang_dir_tl , FontIndex = 2 ]
+            \bool_gset_true:N \g_@@_mac_pingfang_bool
           }
         \tl_if_empty:NTF \g__ctex_mac_stfangso_dir_tl
           { \setCJKmonofont { Heiti~SC~Light } }
@@ -11266,6 +11268,7 @@ Copyright and Licence
           {
             \setCJKsansfont { PingFang~SC }
             \setCJKfamilyfont { zhpf } { PingFang~SC }
+            \bool_gset_true:N \g_@@_mac_pingfang_bool
           }
           { \setCJKsansfont { Heiti~SC~Light } [ BoldFont = Heiti~SC~Medium ] }
         \fontspec_font_if_exist:nTF { STFangsong }
@@ -11478,8 +11481,15 @@ Copyright and Licence
     \cs_new_eq:NN \pingfang \heiti
   }
   {
-    \NewDocumentCommand \yahei    { } { \CJKfamily { zhpf } }
-    \NewDocumentCommand \pingfang { } { \CJKfamily { zhpf } }
+    \bool_if:NTF \g_@@_mac_pingfang_bool
+      {
+        \NewDocumentCommand \yahei    { } { \CJKfamily { zhpf } }
+        \NewDocumentCommand \pingfang { } { \CJKfamily { zhpf } }
+      }
+      {
+        \cs_new_eq:NN \yahei    \heiti
+        \cs_new_eq:NN \pingfang \heiti
+      }
   }
 %</macnew>
 %</!mac>

--- a/ctex/ctex.dtx
+++ b/ctex/ctex.dtx
@@ -1093,7 +1093,8 @@ Copyright and Licence
 % 在 \opt{macnew} 字库中，还定义了 \tn{pingfang}：
 % \begin{optdesc}
 %   \item[\tn{pingfang}] 苹方黑体，CJK 等价命令 |\CJKfamily{zhpf}|。
-%     在 macOS~15 及之后，苹方字体可能尚未下载，此时该命令不会被定义。
+%     在 macOS~15 及之后，苹方字体可能尚未下载，此时该命令将回退为
+%     \tn{heiti} 的别名。
 % \end{optdesc}
 %
 % \section{排版格式设定}

--- a/llmdoc/architecture/package-architecture.md
+++ b/llmdoc/architecture/package-architecture.md
@@ -58,7 +58,11 @@
 
 #### 3. 字体集层
 
-`ctex-fontset-{windows,mac,macnew,ubuntu,fandol,adobe,founder,hanyi}.def` 提供默认字体族映射，负责把“中文主字体/无衬线/等宽”等高层概念落到具体发行版或操作系统字体名。
+`ctex-fontset-{windows,mac,macnew,macold,ubuntu,fandol,adobe,founder,hanyi}.def` 提供默认字体族映射，负责把“中文主字体/无衬线/等宽”等高层概念落到具体发行版或操作系统字体名。
+
+`fontset=mac` 仍是自动入口，而不是独立字体集；它会在运行时于 `macnew` 和 `macold` 之间分流。自 PR #782 起，这个分流不再只依赖 `/System/Library/Fonts/PingFang.ttc` 是否存在，而是保留该路径检测作为快速路径，并在其失效时读取 `/System/Library/CoreServices/SystemVersion.plist` 的主版本号作为后备：版本号 `>= 15` 仍进入 `macnew`，`< 15` 进入 `macold`，检测失败则 warning 后回退 `macold`。
+
+更重要的是，`macnew` 内部还要按引擎二次分支：XeTeX 用 `\fontspec_font_if_exist:nTF` 判断字体名是否可见；LuaTeX 则用 Lua 扫描 `/System/Library/AssetsV2` 下的 `com_apple_MobileAsset_Font*` 目录，定位 downloadable 字体的 `AssetData/` 路径，再配合 `Path=` 与 `FontIndex` 显式加载。也就是说，macOS 15+ 的适配发生在“fontset 层的自动分流 + macnew 内的引擎专属字体探测”两级，而不是通过新增 `mac15plus` 一类公开字体集完成。详见 `llmdoc/reference/ctex-fontset-mac.md`。
 
 #### 4. 方案层
 

--- a/llmdoc/index.md
+++ b/llmdoc/index.md
@@ -13,6 +13,7 @@
 
 - `llmdoc/reference/build-and-test.md` — `l3build`、共享构建配置、测试框架、CI/CD、CTAN 发布与版本管理参考。
 - `llmdoc/reference/coding-conventions.md` — expl3 命名、`@@` 私有空间、作用域语义、docstrip 标签、`\CTEX@` 遗留接口与文档排版基础设施。
+- `llmdoc/reference/ctex-fontset-mac.md` — `ctex` 中 `fontset=mac` / `macnew` / `macold` 的选择逻辑、macOS 15+ 检测后备、XeTeX/LuaTeX 字体探测差异与回退语义。
 
 ## guides
 
@@ -22,6 +23,7 @@
 
 - `llmdoc/memory/decisions/725-cleveref-patch-toggle.md` — 决策: 不在 ctex 侧修复 cleveref appendix 语义问题，改为提供 `patch/cleveref` 开关。
 - `llmdoc/memory/decisions/751-newCJKfontfamily-scope.md` — 记录 #751 / PR #773 中 `\newCJKfontfamily` 从全局命令定义改为局部定义的原因、决策与影响范围。
+- `llmdoc/memory/decisions/782-fontset-mac-macos15plus-detection.md` — 决策: 不新增 `mac15plus`，改为在 `fontset=mac` 内增加 macOS 版本检测后备，并按 XeTeX/LuaTeX 分别探测 macOS 15+ downloadable 字体。
 - `llmdoc/memory/decisions/746-remove-legacy-font-hooks.md` — 决策: 移除对 LaTeX < 2020/10/01 的字体钩子兼容代码，响应上游移除 `\@rmfamilyhook`。
 - `llmdoc/memory/decisions/688-pifont-interchartokenstate-leak.md` — 决策: pifont hook 中先进入水平模式防止 interchartokenstate 泄漏到输出例程。
 - `llmdoc/memory/decisions/715-hyperref-driverfallback.md` — 决策: hyperref driverfallback 按加载状态分支处理，避免重复设置警告。

--- a/llmdoc/memory/decisions/782-fontset-mac-macos15plus-detection.md
+++ b/llmdoc/memory/decisions/782-fontset-mac-macos15plus-detection.md
@@ -1,0 +1,89 @@
+# 决策：保留 `fontset=mac`，在 macOS 15+ 上改为版本检测加运行时字体探测
+
+## 背景
+
+Issue #722 / PR #782 处理的是 `fontset=mac` 在 macOS 15+ 上的失效问题。旧实现以 `/System/Library/Fonts/PingFang.ttc` 是否存在作为 `macnew` / `macold` 的唯一判定条件；这在早期系统上可行，但从 macOS 15 (Sequoia) 起，苹方、楷体、仿宋、隶书、圆体等部分 CJK 字体转为 downloadable，不再位于传统系统字体路径。
+
+结果是：
+
+- `fontset=mac` 会把 macOS 15+ 误判成 `macold`；
+- 即使强制走 `macnew`，XeTeX 与 LuaTeX 对 downloadable 字体的可见性也并不相同；
+- 原先计划中的 `fontset=mac15plus` 会把“系统版本差异”暴露为新的公开字体集名称，增加长期接口负担。
+
+## 关键观察
+
+在 macOS 26 的实测中，稳定结论是：
+
+- XeTeX 与 LuaTeX 都能读取 `SystemVersion.plist`，因此 macOS 主版本号可作为可靠后备判定信号；
+- XeTeX 下 `\fontspec_font_if_exist:nTF { PingFang SC }` 在字体已下载时可用；
+- LuaTeX 下同样的名字探针对 `PingFang SC` 不可靠，不能作为 downloadable 字体可用性的判断依据；
+- LuaTeX 可以通过扫描 `/System/Library/AssetsV2` 及其 `com_apple_MobileAsset_Font*` 子树，找到 downloadable 字体实际存放的 `AssetData/` 路径，并用 `Path=` + `FontIndex` 显式加载。
+
+## 决策
+
+### 1. 不新增 `fontset=mac15plus`
+
+继续把 `fontset=mac` 作为用户入口，仅在内部保留 `macnew` 与 `macold` 两个字体集概念。`mac15plus` 不作为兼容 alias 保留。
+
+这样可以维持公开接口稳定：用户仍然只需要选择“mac 平台默认字体集”，不需要学习新的系统版本专用字体集名。
+
+### 2. `fontset=mac` 改为双阶段判定
+
+新的自动判定顺序是：
+
+1. 先检查 `/System/Library/Fonts/PingFang.ttc` 是否存在；
+2. 若存在，直接视为 `macnew`；
+3. 若不存在，再读取 `SystemVersion.plist` 的主版本号；
+4. 版本号 `>= 15` 时仍使用 `macnew`，`< 15` 时使用 `macold`；
+5. 若版本检测失败，则 warning 后回退到 `macold`。
+
+也就是说，传统路径检测被保留为快速路径，但不再是唯一真相来源。
+
+### 3. `macnew` 内部按引擎使用不同的运行时探测策略
+
+- XeTeX：使用 `\fontspec_font_if_exist:nTF` 按字体名检查可用性；
+- LuaTeX：使用 Lua + `lfs.dir` 动态扫描 AssetsV2 路径，并以 `Path=` + `FontIndex` 显式加载 downloadable 字体；
+- 核心字体 `Songti SC`、`Heiti SC` 仍作为可用性的稳定底座；
+- `PingFang`、`Kaiti`、`STFANGSO`、`Baoli`、`Yuanti` 等视为可选增强，缺失时静默跳过或回退。
+
+### 4. `\pingfang` / `\yahei` 保持命令可用，但允许回退到黑体
+
+当 `PingFang` 不可用时，不再把相关命令暴露为“缺失接口”，而是退回 `\heiti` 语义，以保持旧文档的接口兼容性。
+
+## 取舍理由
+
+### 为什么不保留 `mac15plus`
+
+- 用户心智模型更差：`fontset` 本来表示字体集预设，不应把具体系统版本暴露成新的长期公开名称。
+- 维护成本更高：一旦保留 alias，后续还要长期说明 `mac`、`macnew`、`mac15plus` 三者关系。
+- 实际问题并不是“需要第三种字体集”，而是 `mac` 的平台检测和 `macnew` 的字体发现机制都需要升级。
+
+### 为什么 LuaTeX 不沿用名字探针
+
+因为在实测里，LuaTeX 对 downloadable 字体的名字可见性并不可靠。若继续依赖 `\fontspec_font_if_exist:nTF { PingFang SC }`，会把“字体已安装但 luaotfload 看不见”的情况误判成字体不存在。
+
+### 为什么检测失败时回退到 `macold`
+
+这是保守失败策略：
+
+- `macold` 不依赖 downloadable 字体；
+- 相比误进 `macnew` 后大量 optional 字体缺席，退回 `macold` 更接近旧系统上的稳定最小可用配置；
+- 同时保留 warning，便于用户和维护者发现平台探测链路异常。
+
+## 影响范围
+
+- `ctex/ctex.dtx` 中 `%<*mac>`：自动选择 `macnew` / `macold` 的逻辑。
+- `ctex/ctex.dtx` 中 `%<*macnew>`：XeTeX 与 LuaTeX 的字体加载策略。
+- `ctex/ctex.dtx` 的用户文档：`fontset=mac`、`macnew`、`\pingfang` 的说明。
+
+## 对后续维护的约束
+
+1. 未来若 macOS 再次调整 downloadable 字体的目录编号，LuaTeX 路径应继续依赖 `com_apple_MobileAsset_Font*` 的动态发现，而不是写死具体 `FontN` 目录名。
+2. 不要把 XeTeX 与 LuaTeX 的字体探测代码强行合并；两条后端路径的可靠信号不同。
+3. 若以后补测试，应把“系统版本判定”和“字体可选回退”视为两个独立行为来覆盖。
+
+## 关联记录
+
+- Issue #722
+- PR #782
+- `llmdoc/reference/ctex-fontset-mac.md`

--- a/llmdoc/reference/ctex-fontset-mac.md
+++ b/llmdoc/reference/ctex-fontset-mac.md
@@ -1,0 +1,145 @@
+# ctex fontset 与 macOS 系统字体检测
+
+## 适用范围
+
+本文只记录 `ctex/ctex.dtx` 中 `fontset` 尤其是 `fontset=mac` / `macnew` / `macold` 的稳定行为、分层边界与跨引擎差异。若问题表现为 XeTeX 专属的标点、字符分类或第三方包 hook，应转到 `llmdoc/architecture/package-architecture.md` 中的 `xeCJK` 架构部分。
+
+## fontset 层的职责边界
+
+`ctex` 的字体集层负责把“默认中文正文字体/黑体/仿宋/楷书”等高层角色映射到具体系统字体或发行版字体，并在运行时决定应加载哪份 `ctex-fontset-*.def`。在 `ctex` 的典型加载链中，字体集层位于引擎层之后、方案层之前：
+
+1. `ctex.sty` 建立统一选项与运行期变量；
+2. `ctex-engine-*.def` 选择引擎后端；
+3. `ctex-fontset-*.def` 把字体角色落到平台字体；
+4. `ctex-scheme-*.def` / `ctex-heading-*.def` 再叠加中文样式与标题行为。
+
+因此，`fontset` 相关问题首先要判断是：
+
+- 字体集选择错了；还是
+- 已选中的字体集内部又需要按引擎分支做运行时可用性检测。
+
+PR #782 对 `fontset=mac` 的改造属于后一类：保留 `macnew` / `macold` 两个字体集概念，但重写 `mac` 的自动判定与 `macnew` 的运行时字体探测逻辑，而不是再引入新的公开字体集名称。
+
+## `fontset=mac` 的选择不变量
+
+`fontset=mac` 仍然是“自动在 `macnew` 和 `macold` 之间二选一”的入口，不再引入也不保留 `mac15plus` 之类的公开 alias。稳定不变量如下：
+
+- 如果 `/System/Library/Fonts/PingFang.ttc` 存在，直接视为旧式本地安装路径可用，加载 `ctex-fontset-macnew.def`。
+- 如果该路径不存在，则再读取 `/System/Library/CoreServices/SystemVersion.plist` 的主版本号。
+- 主版本号 `>= 15` 时，仍加载 `ctex-fontset-macnew.def`。
+- 主版本号 `< 15` 时，加载 `ctex-fontset-macold.def`。
+- 若版本号检测失败，则发出 `macos-version-detect-failed` warning，并回退到 `macold`。
+
+这意味着当前设计把“苹方字体是否仍在传统路径”从唯一判定条件降级为快速路径；当 macOS 15+ 把 CJK 字体改为 downloadable、导致传统路径失效时，系统版本检测成为必要后备。对应实现位于 `ctex/ctex.dtx` 的 `%<*mac>` 区段。
+
+## 版本号检测的跨引擎实现
+
+`fontset=mac` 的版本号读取不是统一复用一套后端，而是按引擎分别实现：
+
+### LuaTeX
+
+LuaTeX 通过 `\lua_now:n` 直接执行 Lua：
+
+- 用 `io.open` 读取 `SystemVersion.plist`；
+- 用 Lua `string.match` 提取 `ProductVersion` 对应 `<string>`；
+- 只取主版本号；
+- 通过 `token.set_macro(..., "global")` 写回 `\g_@@_macos_ver_tl`。
+
+### XeTeX
+
+XeTeX 路径用 expl3 文件读取完成同一工作：
+
+- `\ior_open:Nn` 打开 `SystemVersion.plist`；
+- `\ior_map_inline:Nn` 逐行扫描；
+- 先定位包含 `ProductVersion` 的行，再在下一行用 `\regex_replace_once:nnN` 提取主版本号；
+- 成功后全局写入 `\g_@@_macos_ver_tl` 并 `\ior_map_break:` 结束扫描。
+
+这个实现分工本身是一个稳定信号：遇到 macOS 平台探测问题时，不应假设 XeTeX 与 LuaTeX 共享同一段底层代码，必须按引擎分别核查 plist 读取链路。
+
+## `macnew` 的运行时字体策略
+
+`macnew` 现在不再假设整组华文字体与苹方字体都稳定常驻本地。它的策略分成两层：
+
+### 1. 核心字体优先保证
+
+以下角色被视为核心能力，优先保证可加载：
+
+- 正文字体：`Songti SC Light` / `Songti SC Bold`
+- 黑体基础：`Heiti SC Light` / `Heiti SC Medium`
+
+其中宋体与黑体仍作为 `zhsong`、`zhhei` 等主字体族的稳定底座；这保证即使 downloadable 字体缺席，`macnew` 仍能形成可用的主字体配置，而不是整体失效。
+
+### 2. 可选字体按可用性启用
+
+以下字体被视为可选增强：
+
+- `PingFang` / `PingFang SC`
+- `Kaiti` / `Kaiti SC`
+- `STFANGSO` / `STFangsong`
+- `Baoli` / `Baoli SC`
+- `Yuanti` / `Yuanti SC`
+
+这些字体在 macOS 15+ 上可能尚未下载，因此运行时检测采用“可用则配置，不可用则静默跳过或回退”的模型，而不是把缺失视为致命错误。
+
+## `macnew` 的 XeTeX 分支
+
+XeTeX 分支依赖 `fontspec` 的运行时名字解析能力，使用 `\fontspec_font_if_exist:nTF` 检查字体名是否可见。稳定行为如下：
+
+- `Songti SC` / `Heiti SC` 直接按名字加载；
+- `PingFang SC` 可见时，将无衬线主字体设为 `PingFang SC`，并定义 `zhpf`；
+- `PingFang SC` 不可见时，将 `\setCJKsansfont` 回退为 `Heiti SC Light` / `Heiti SC Medium`；
+- `Kaiti SC`、`STFangsong`、`Baoli SC`、`Yuanti SC Light` 都按“检测到才定义相应 family”的方式处理。
+
+这里有一个重要边界：XeTeX 只依赖名字可见性，不处理 AssetsV2 路径扫描。因此在 XeTeX 路线下，问题通常表现为“字体名是否被 fontspec 看见”，而不是“路径拼接是否正确”。
+
+## `macnew` 的 LuaTeX 分支
+
+LuaTeX 分支不能依赖 `\fontspec_font_if_exist:nTF { PingFang SC }` 判断 downloadable 字体，因为该探针在 LuaTeX 下对这类字体并不可靠。当前稳定策略是直接用 Lua 扫描 macOS 的 AssetsV2 目录树：
+
+- 枚举 `/System/Library/AssetsV2` 与 `/System/Library/AssetsV2/PreinstalledAssetsV2/InstallWithOs`；
+- 动态发现所有 `com_apple_MobileAsset_Font*` 目录，而不是写死 `Font6` / `Font7` / `Font8` 之类具体编号；
+- 在其 hash 子目录下查找 `AssetData/` 中的目标字体文件；
+- 找到后，把该 `AssetData/` 路径记录到对应的全局 token list；
+- 对 downloadable 字体使用 `Path = ...` + `FontIndex = ...` 显式加载。
+
+当前扫描的目标字体文件包括：
+
+- `PingFang.ttc`
+- `Kaiti.ttc`
+- `STFANGSO.ttf`
+- `Baoli.ttc`
+- `Yuanti.ttc`
+
+其中：
+
+- 核心字体 `Songti SC`、`Heiti SC` 仍按名字加载，因为 `luaotfload` 能直接看到它们；
+- downloadable 字体则必须通过路径加索引显式指定；
+- 若某个可选字体未找到，对应 family 不定义或回退，不报错。
+
+这是 PR #782 改造后最关键的 LuaTeX 设计点：LuaTeX 路径对 macOS 15+ downloadable 字体的支持依赖文件系统发现，不依赖名字存在性探针。
+
+## `\pingfang` / `\yahei` 的稳定回退语义
+
+`macnew` 下仍保留与旧用户接口兼容的字体命令，但其语义已变为“尽量使用苹方，否则退回黑体”：
+
+- 若 `PingFang` / `PingFang SC` 可用，则定义 `zhpf`，`\pingfang` 指向该 family；
+- 若不可用，则不再把 `\pingfang` / `\yahei` 视为不可用命令，而是回退为 `\heiti` 的别名。
+
+因此，对外接口的稳定承诺是“命令继续存在”，而不是“命令总能指向苹方本身”。用户若需要完整的苹方、楷体、仿宋、隶书、圆体集合，应先在字体册中下载相应字体资源。
+
+## 排障检索顺序
+
+遇到 `fontset=mac` 相关问题时，按以下顺序判断：
+
+1. `fontset=mac` 是否选错了 `macnew` / `macold`；
+2. 若是 macOS 15+，检查 `SystemVersion.plist` 读取链是否成功；
+3. 区分 XeTeX 还是 LuaTeX：
+   - XeTeX：优先检查 `\fontspec_font_if_exist:nTF` 对字体名的可见性；
+   - LuaTeX：优先检查 AssetsV2 扫描与 `Path`/`FontIndex` 显式加载；
+4. 若缺的是 `PingFang`、`Kaiti`、`STFangsong`、`Baoli`、`Yuanti` 一类字体，再判断它是否本来就属于可选 downloadable 字体，而不是核心必备字体。
+
+## 相关源码入口
+
+- `ctex/ctex.dtx` 中 `%<*mac>`：`fontset=mac` 的 `macnew` / `macold` 自动判定。
+- `ctex/ctex.dtx` 中 `%<*macnew>`：`macnew` 在 XeTeX / LuaTeX / upLaTeX 路径下的字体设定。
+- `ctex/ctex.dtx` 中 `fontset` 用户文档区：`macnew`、`\pingfang`、`\yahei` 的用户可见说明。


### PR DESCRIPTION
## Summary

Closes #722
Closes: #788

macOS 15 (Sequoia) 起，PingFang 等 CJK 字体转为 downloadable，不再位于
`/System/Library/Fonts/` 传统路径。原有 `fontset=mac` 通过检测 `PingFang.ttc`
文件存在性判断 macnew/macold 的方式失效，导致 macOS 15+ 误判为 macold。

### 设计变更（相对于此 PR 旧版本）

**不再新增 `fontset=mac15plus`**，改为在现有 `mac` / `macnew` 架构内解决：

1. **`fontset=mac` 判定逻辑**：保留传统 PingFang.ttc 文件检测；文件不存在时，
   通过读取 `SystemVersion.plist` 获取 macOS 主版本号作为后备判据。
   - 版本 ≥ 15 → macnew
   - 版本 < 15 → macold
   - 检测失败 → warning + 回退 macold

2. **macnew XeTeX 分支**：用 `\fontspec_font_if_exist:nTF` 运行时检测字体可用性
   - 核心字体（Songti SC、Heiti SC）直接加载
   - PingFang SC 可用时作为 sans，不可用回退 Heiti SC
   - Kaiti、STFangsong、Baoli、Yuanti 为可选字体，不可用时静默跳过

3. **macnew LuaTeX 分支**：用 Lua `lfs` 扫描 AssetsV2 目录定位字体文件
   - luaotfload 无法通过字体名找到 downloadable 字体
   - 通过 `Path=` + `FontIndex` 显式加载
   - 核心字体（Songti SC、Heiti SC）仍通过名字加载（luaotfload 可见）

4. **版本号检测**：
   - LuaTeX：`io.open` 读取 plist + string.match 提取版本
   - XeTeX：expl3 `\ior_map_inline:Nn` + `\regex_replace_once:nnN`

### 技术验证（macOS 26, Tahoe）

| 能力 | XeTeX | LuaTeX |
|------|-------|--------|
| 读取 macOS 版本号 | ✓ (`\ior_map_inline`) | ✓ (`io.open` + match) |
| `\fontspec_font_if_exist:nTF {PingFang SC}` | ✓ (已下载时) | ✗ (始终 false) |
| `\fontspec_font_if_exist:nTF {Heiti SC}` | ✓ | ✓ |
| 通过 AssetsV2 路径加载字体 | N/A | ✓ |

## Test plan

- [x] XeLaTeX + `fontset=mac` 自动检测 → macnew，编译通过
- [x] LuaLaTeX + `fontset=mac` 自动检测 → macnew，编译通过
- [x] XeLaTeX + `fontset=macnew` 直接指定，编译通过
- [x] LuaLaTeX + `fontset=macnew` 直接指定，编译通过
- [x] 所有可选字体（Kaiti/STFangsong/Baoli/Yuanti）正确检测和加载
- [x] PingFang 不可用时正确回退 Heiti SC
- [x] 无 font warning（包括 LuaTeX italic/slanted）
- [ ] CI 验证 Windows/Ubuntu 平台不受影响