### PR TITLE
fix(CJKpunct): 修复段末全角右标点后出现多余空行 (#671)

### DIFF
--- a/CJKpunct/CJKpunct.dtx
+++ b/CJKpunct/CJKpunct.dtx
@@ -417,6 +417,7 @@ Copyright and Licence
       @rrule@\CJKpunct@currentpunct\endcsname depth \z@ height \z@
 
     \ifnum\CJKpunct@currentcharclass=2\relax
+      \nobreak
       \hskip \csname CJKpunct\CJKpunct@punctstyle @\CJK@enc @\CJKpunct@family
         @rglue@\CJKpunct@currentpunct\endcsname  plus 0.1em minus 0.1 em
     \fi

--- a/CJKpunct/testfiles/punct-rglue.lvt
+++ b/CJKpunct/testfiles/punct-rglue.lvt
@@ -1,0 +1,46 @@
+\input{regression-test}
+
+\documentclass{article}
+
+\OMIT
+\usepackage{CJKutf8}
+\usepackage{CJKspace}
+\usepackage{CJKpunct}
+\TIMO
+
+\begin{document}
+
+\START
+
+\begin{CJK*}{UTF8}{gbsn}
+
+\ExplSyntaxOn
+
+% Test for issue #671: right punctuation's rglue must be preceded by
+% \nobreak to prevent TeX from breaking at paragraph end.
+%
+% Strategy: build hbox with "测。", unhbox to get all nodes on a fresh
+% hlist, then peel [kern][kern][rglue] from the tail and verify that a
+% penalty 10000 (\nobreak) sits immediately before the rglue.
+
+\TEST{Right~punct~rglue~preceded~by~nobreak~(github~\#671)}{
+  \hbox_set:Nn \l_tmpa_box { 测。 }
+  \hbox_set:Nn \l_tmpb_box {
+    \tex_unhbox:D \l_tmpa_box
+    \tex_unkern:D
+    \tex_unkern:D
+    \tex_unskip:D
+    \xdef \g_tmpa_tl { \the \tex_lastpenalty:D }
+  }
+  \int_compare:nNnTF { \g_tmpa_tl } = { 10000 }
+    { \TYPE { PASS:~nobreak~before~rglue } }
+    { \TYPE { FAIL:~penalty~is~\g_tmpa_tl } }
+}
+
+\ExplSyntaxOff
+
+\end{CJK*}
+
+\END
+
+\end{document}

--- a/CJKpunct/testfiles/punct-rglue.tlg
+++ b/CJKpunct/testfiles/punct-rglue.tlg
@@ -1,0 +1,18 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+(../UTF8.bdg
+File: UTF8.bdg ....-..-.. 4.8.5
+) (../UTF8.enc
+File: UTF8.enc ....-..-.. 4.8.5
+) (../UTF8.chr
+File: UTF8.chr ....-..-.. 4.8.5
+)
+============================================================
+TEST 1: Right punct rglue preceded by nobreak (github \#671)
+============================================================
+LaTeX Font Info:    Trying to load font information for C70+gbsn on input line ....
+File: c70gbsn.fdx ....-..-.. 4.8.5
+)
+Package CJKpunct Info: punctuation spaces for family 'gbsn' do not exist. Use family 'def' instead. on input line ....
+PASS: nobreak before rglue
+============================================================

--- a/llmdoc/index.md
+++ b/llmdoc/index.md
@@ -24,3 +24,4 @@
 - `llmdoc/memory/decisions/751-newCJKfontfamily-scope.md` — 记录 #751 / PR #773 中 `\newCJKfontfamily` 从全局命令定义改为局部定义的原因、决策与影响范围。
 - `llmdoc/memory/decisions/746-remove-legacy-font-hooks.md` — 决策: 移除对 LaTeX < 2020/10/01 的字体钩子兼容代码，响应上游移除 `\@rmfamilyhook`。
 - `llmdoc/memory/decisions/688-pifont-interchartokenstate-leak.md` — 决策: pifont hook 中先进入水平模式防止 interchartokenstate 泄漏到输出例程。
+- `llmdoc/memory/reflections/671-cjkpunct-rglue-nobreak.md` — 反思: CJKpunct #671 修复中的节点级调试技术与 `\unhbox` 测试模式。

--- a/llmdoc/memory/reflections/671-cjkpunct-rglue-nobreak.md
+++ b/llmdoc/memory/reflections/671-cjkpunct-rglue-nobreak.md
@@ -1,0 +1,42 @@
+---
+name: 671-cjkpunct-rglue-nobreak
+description: CJKpunct #671 修复反思：段末右标点 rglue 断行问题的调试经验与节点级测试技术
+type: reflection
+---
+
+## 任务
+
+修复 CJKpunct issue #671：段末全角右标点（如"。"）后出现多余空行。
+
+## 修复
+
+在 `CJKpunct/CJKpunct.dtx` 第 420 行，右标点 class 2 的 `rglue`（`\hskip`）前加 `\nobreak`，阻止 TeX 在此处断行。
+
+## 关键调试经验
+
+### `\showbox` 是 CJKpunct 节点调试的首选工具
+
+CJKpunct 的标点挤压通过 rule/glyph/rule/glue/kern 组合实现，只有 `\showbox` 能完整展示节点序列。文档或源码描述的"逻辑序列"可能过度简化。
+
+### `\lastkern`/`\lastpenalty`/`\lastnodetype` 在 hbox 构建中不可靠
+
+CJKpunct 的 `{{{...}}}` 三层分组 + CJK 追踪 kern 机制导致：在 `\hbox_set:Nn` 内部直接用 `\last...` 原语无法看到预期节点。原因是 CJK 追踪 kern 可能在分组关闭后通过 `\aftergroup` 添加。
+
+**正确做法**：先完整构建 hbox，再用 `\unhbox` 展开到新 hlist，然后剥离节点：
+```tex
+\setbox0=\hbox{ 测。 }
+\setbox2=\hbox{\unhbox0 \unkern\unkern\unskip \xdef\temp{\the\lastpenalty}}
+```
+
+### 捕获 `\last...` 值必须用 `\the` 扩展
+
+`\count255=\lastnodetype\relax` 赋值方式不可靠（返回 8230 等垃圾值）。正确方式是 `\xdef\temp{\the\lastpenalty}` 在 hbox 内捕获，hbox 外读取。
+
+### `\typeout` 在 hbox 内可能干扰节点列表
+
+即使 `\immediate\write` 理论上不添加节点，在 CJK 活跃字符环境下仍可能导致 `\lastnodetype` 返回 -1。避免在探测节点时使用任何输出命令。
+
+## 遗留项
+
+- CJKpunct 的内部架构（标点挤压节点模型、class 1/2 分类、样式策略）尚未纳入 llmdoc stable docs
+- CI 中未包含 CJKpunct 测试步骤（build-and-test.md 需更新）

--- a/llmdoc/reference/build-and-test.md
+++ b/llmdoc/reference/build-and-test.md
@@ -88,12 +88,13 @@
 
 `ctex/test/testfiles/` 仍是该仓库最完整的回归测试目录。测试文件使用 `\START`、`\END`、`\TEST{...}{...}` 之类标准测试宏组织案例；运行 `l3build check` 后会把实际日志与 `.tlg` 对比。若某引擎结果与标准引擎一致，`saveall()` 会清理重复的引擎专属 `.tlg`。
 
-现在除 `ctex` 外，`xeCJK/` 与 `zhnumber/` 也已经接入独立的 `testfiles/` 回归目录：
+现在除 `ctex` 外，`xeCJK/`、`zhnumber/` 与 `CJKpunct/` 也已经接入独立的 `testfiles/` 回归目录：
 
 - `xeCJK/testfiles/`：`basic01`、`punctstyle01`、`fonts01`
 - `zhnumber/testfiles/`：`basic01`、`style01`、`deprecation01`
+- `CJKpunct/testfiles/`：`punct-basic`、`punct-indent`、`punct-rglue`
 
-这意味着这两个子包已不再只依赖主包依赖链覆盖，修改它们时可以直接在各自目录运行 `l3build check`。
+这意味着这些子包已不再只依赖主包依赖链覆盖，修改它们时可以直接在各自目录运行 `l3build check`。
 
 ## 引擎矩阵
 
@@ -113,6 +114,7 @@
 
 - `xeCJK`：`testfiledir = "./testfiles"`、`stdengine = "xetex"`、`checkengines = {"xetex"}`，见 `xeCJK/build.lua`。
 - `zhnumber`：`testfiledir = "./testfiles"`、`stdengine = "xetex"`、`checkengines = {"pdftex", "xetex", "luatex"}`，见 `zhnumber/build.lua`。
+- `CJKpunct`：`stdengine = "pdftex"`、`checkengines = {"pdftex"}`，见 `CJKpunct/build.lua`。CJKpunct 仅工作在 pdfTeX (CJK 宏包) 路线下。
 
 `zhnumber` 的 `pdftex` 输出与标准 XeTeX 基线存在差异，因此测试目录中保留了 `.pdftex.tlg` 专属基线，例如 `zhnumber/testfiles/basic01.pdftex.tlg`。
 


### PR DESCRIPTION
## Summary

- 在右标点 (class 2) 的 `rglue` (`\hskip`) 前插入 `\nobreak`，阻止 TeX 在段末将 `rglue` 作为合法断行点
- 修复 #671：段末全角右标点（如"。"）后产生多余空行的问题
- 新增 l3build 回归测试 `punct-rglue`，验证 `rglue` 前存在 `\penalty 10000`

## 根因

`\CJKpunct@CJKpunctsymbol` 为右标点输出 `[rrule] [rglue] [kern] [kern]` 序列。`rglue` 是普通 `\hskip`，构成合法断行点。段末若 TeX 在此断行，后续 `[kern] [kern] [penalty 10000] [parfillskip]` 全部为 discardable 节点，被丢弃后留下空 `\hbox(0.0+0.0)x\hsize`，形成可见的多余空行。

## 改动

`CJKpunct/CJKpunct.dtx` 第 420 行，`rglue` 前加一行 `\nobreak`（共 1 行）。

## Test plan

- [x] `cd CJKpunct && l3build check` — 3/3 通过（punct-basic, punct-indent, punct-rglue）
- [x] `cd ctex && l3build check -q` — 无新增失败（fonts02.xetex 为已有问题）
- [x] 去掉修复后测试报 `FAIL: penalty is 0`，恢复修复后报 `PASS`
- [x] `\showbox` 确认节点序列中新增 `\penalty 10000` 位于 rglue 前

Closes #671