### PR TITLE
test(ctxdoc): fix `\ctxdoc@patchfail`, update patch-health test

### DIFF
--- a/ctex/test/testfiles-ctxdoc/patch-health.lvt
+++ b/ctex/test/testfiles-ctxdoc/patch-health.lvt
@@ -5,8 +5,8 @@
 
 \START
 
-\TEST{ctxdoc~class~loads~without~patch~failures}{
-  \TYPE{All~patches~applied~successfully}
+\TEST{ctxdoc class loads without patch failures}{
+  \TYPE{All patches applied successfully}
 }
 
 \END

--- a/ctex/test/testfiles-ctxdoc/patch-health.tlg
+++ b/ctex/test/testfiles-ctxdoc/patch-health.tlg
@@ -1,7 +1,7 @@
 This is a generated file for the l3build validation system.
 Don't change this file in any respect.
 ============================================================
-TEST 1: ctxdoc~class~loads~without~patch~failures
+TEST 1: ctxdoc class loads without patch failures
 ============================================================
-All~patches~applied~successfully
+All patches applied successfully
 ============================================================

--- a/support/ctxdoc.cls
+++ b/support/ctxdoc.cls
@@ -34,12 +34,8 @@
   { Failed~to~patch~command~`#1'. }
 \cs_gset_protected:Npn \ctex_patch_failure:N #1
   { \msg_critical:nnx { ctxdoc } { patch-failure } { \token_to_str:N #1 } }
+\cs_new:Npn \ctxdoc@patchfail { \ctex_patch_failure:N }
 \ExplSyntaxOff
-\def\ctxdoc@patchfail#1{%
-  \ExplSyntaxOn
-  \msg_critical:nnx { ctxdoc } { patch-failure } { \token_to_str:N #1 }%
-  \ExplSyntaxOff
-}
 \ctexset{
   abstractname   = 简介,
   indexname      = 代码索引,
@@ -234,8 +230,7 @@
   { \noindent }
   { \skip_vertical:n { -\parskip } \noindent }
   { }
-  { \msg_critical:nnx { ctxdoc } { patch-failure }
-      { \token_to_str:N \__codedoc_function_descr_start:w } }
+  { \ctex_patch_failure:N \__codedoc_function_descr_start:w }
 %% l3doc 会在 function 环境的 syntax 和 descr 盒子中间加上 \medskipamount 的距离。
 %% 但是若 syntax 盒子为空（未使用 syntax 环境），就会显得不好看。
 %% 此时我们通过将 \medskipamount 设置为零来修正。若盒子非空，则将 \parskip 还回去。
@@ -243,8 +238,7 @@
   { }
   { \ctex_doc_fix_yoffset: }
   { }
-  { \msg_critical:nnx { ctxdoc } { patch-failure }
-      { \token_to_str:N \__codedoc_function_assemble: } }
+  { \ctex_patch_failure:N \__codedoc_function_assemble: }
 \cs_new_protected_nopar:Npn \ctex_doc_fix_yoffset:
   {
     \box_if_empty:NTF \g__codedoc_syntax_box
@@ -256,22 +250,19 @@
   { }
   { \MacroFont }
   { }
-  { \msg_critical:nnx { ctxdoc } { patch-failure }
-      { \token_to_str:N \__codedoc_typeset_functions: } }
+  { \ctex_patch_failure:N \__codedoc_typeset_functions: }
 \ctex_patch_cmd_once:NnnnTF \__codedoc_macro_init:
   { }
   { \hbox:n }
   { \MacroFont \hbox:n }
   { }
-  { \msg_critical:nnx { ctxdoc } { patch-failure }
-      { \token_to_str:N \__codedoc_macro_init: } }
+  { \ctex_patch_failure:N \__codedoc_macro_init: }
 \ctex_patch_cmd_once:NnnnTF \__codedoc_macro_dump:
   { }
   { \hbox_unpack_drop:N }
   { \MacroFont \hbox_unpack_drop:N }
   { }
-  { \msg_critical:nnx { ctxdoc } { patch-failure }
-      { \token_to_str:N \__codedoc_macro_dump: } }
+  { \ctex_patch_failure:N \__codedoc_macro_dump: }
 \cs_set_eq:NN \__codedoc_macro_end_style:n \use_none:n
 \cs_set_protected:Npn \__codedoc_macro_typeset_one:nN #1#2
   {


### PR DESCRIPTION
- 修复 `\ctxdoc@patchfail` 的定义
- 把三种 patch 失败的报错，归一到使用 `\ctex_patch_failure:N`
- 替换测试中的空格，`s/~/ /g`