### PR TITLE
fix(xeCJK): 新增 NoBreakLongPunct 属性，修复省略号允许行首断行 (#681)

### DIFF
--- a/ctex/test/testfiles-contrib/pkuthss.tlg
+++ b/ctex/test/testfiles-contrib/pkuthss.tlg
@@ -2084,9 +2084,10 @@ Completed box being shipped out [3]
 ...........\rule(14.06366+6.02736)x0.0
 ........\penalty 10000
 ........\hbox(0.0+0.0)x0.0
-.........\hbox(0.0+0.0)x0.0, shifted -23.09103
+.........\hbox(0.0+0.0)x0.0, shifted -20.09103
 ..........\special{pdf:dest (equation.2.1) [@thispage /XYZ @xpos @ypos null]}
 ..........\penalty 10000
+........\kern 0.0
 ........\hbox(8.14243+2.13194)x23.07822
 .........\TU/XITS(0)/m/n/12.045 (2.1
 .........\kern -0.0002
@@ -2152,9 +2153,10 @@ Completed box being shipped out [3]
 ...........\rule(14.06366+6.02736)x0.0
 ........\penalty 10000
 ........\hbox(0.0+0.0)x0.0
-.........\hbox(0.0+0.0)x0.0, shifted -23.09103
+.........\hbox(0.0+0.0)x0.0, shifted -20.09103
 ..........\special{pdf:dest (equation.2.2) [@thispage /XYZ @xpos @ypos null]}
 ..........\penalty 10000
+........\kern 0.0
 ........\hbox(8.14243+2.13194)x23.07822
 .........\TU/XITS(0)/m/n/12.045 (2.2
 .........\kern -0.0002
@@ -2216,9 +2218,10 @@ Completed box being shipped out [3]
 ...........\rule(14.06366+6.02736)x0.0
 ........\penalty 10000
 ........\hbox(0.0+0.0)x0.0
-.........\hbox(0.0+0.0)x0.0, shifted -23.09103
+.........\hbox(0.0+0.0)x0.0, shifted -20.09103
 ..........\special{pdf:dest (equation.2.3) [@thispage /XYZ @xpos @ypos null]}
 ..........\penalty 10000
+........\kern 0.0
 ........\hbox(8.14243+2.13194)x23.07822
 .........\TU/XITS(0)/m/n/12.045 (2.3
 .........\kern -0.0002

--- a/ctex/test/testfiles/punct.tlg
+++ b/ctex/test/testfiles/punct.tlg
@@ -2634,7 +2634,7 @@ Completed box being shipped out [4]
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 没
 ....\glue 0.0 plus 0.39433
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 赢
-....\penalty 0
+....\penalty 10000
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 …
 ....\penalty 10000
 ....\glue 0.0
@@ -2879,7 +2879,7 @@ Completed box being shipped out [4]
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 没
 ....\glue 0.0 plus 0.39433
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 赢
-....\penalty 0
+....\penalty 10000
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 …
 ....\penalty 10000
 ....\glue 0.0
@@ -3121,7 +3121,7 @@ Completed box being shipped out [4]
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 没
 ....\glue 0.0 plus 0.39433
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 赢
-....\penalty 0
+....\penalty 10000
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 …
 ....\penalty 10000
 ....\glue 0.0
@@ -3362,7 +3362,7 @@ Completed box being shipped out [4]
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 没
 ....\glue 0.0 plus 0.39433
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 赢
-....\penalty 0
+....\penalty 10000
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 …
 ....\penalty 10000
 ....\glue 0.0
@@ -3610,7 +3610,7 @@ Completed box being shipped out [4]
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 没
 ....\glue 0.0 plus 0.39433
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 赢
-....\penalty 0
+....\penalty 10000
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 …
 ....\penalty 10000
 ....\glue 0.0
@@ -3685,7 +3685,7 @@ Overfull \hbox (4.51656pt too wide) in paragraph at lines ...
 .\TU/FandolSong-Regular(0)/m/n/10.53937 「好
 .\glue 0.0 plus 0.39433
 .\TU/FandolSong-Regular(0)/m/n/10.53937 的
-.\penalty 0
+.\penalty 10000
 .\TU/FandolSong-Regular(0)/m/n/10.53937 …
 .\penalty 10000
 .\glue 0.0
@@ -3799,7 +3799,7 @@ Completed box being shipped out [5]
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 「好
 ....\glue 0.0 plus 0.39433
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 的
-....\penalty 0
+....\penalty 10000
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 …
 ....\penalty 10000
 ....\glue 0.0
@@ -3943,7 +3943,7 @@ Completed box being shipped out [5]
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 「好
 ....\glue 0.0 plus 0.39433
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 的
-....\penalty 0
+....\penalty 10000
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 …
 ....\penalty 10000
 ....\glue 0.0
@@ -4087,7 +4087,7 @@ Completed box being shipped out [5]
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 「好
 ....\glue 0.0 plus 0.39433
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 的
-....\penalty 0
+....\penalty 10000
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 …
 ....\penalty 10000
 ....\glue 0.0
@@ -4231,7 +4231,7 @@ Completed box being shipped out [5]
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 「好
 ....\glue 0.0 plus 0.39433
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 的
-....\penalty 0
+....\penalty 10000
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 …
 ....\penalty 10000
 ....\glue 0.0
@@ -4374,7 +4374,7 @@ Completed box being shipped out [5]
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 「好
 ....\glue 0.0 plus 0.39433
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 的
-....\penalty 0
+....\penalty 10000
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 …
 ....\penalty 10000
 ....\glue 0.0

--- a/llmdoc/memory/reflections/681-xecjk-ellipsis-longpunct.md
+++ b/llmdoc/memory/reflections/681-xecjk-ellipsis-longpunct.md
@@ -1,0 +1,67 @@
+---
+title: "681: xeCJK 省略号断行分类修复"
+type: reflection
+---
+
+# 681: xeCJK 省略号断行分类修复
+
+## 问题
+
+XeLaTeX 路线下，U+2025（․․）与 U+2026（…）默认属于 `LongPunct`。普通 `LongPunct` 在前方会走允许断行的路径，因此 TeX 可能在省略号前断行，表现为省略号可以出现在行首。
+
+这与中文排版中省略号通常不应出现在行首的预期不符，也暴露出 xeCJK 标点系统里“字符集合名称”和“具体断行/胶水行为”之间并不是一一等价的直觉关系。
+
+## 最终修复
+
+最终没有把 U+2025 与 U+2026 从 `LongPunct` 直接移到 `MiddlePunct`，而是新增了一个正交属性 `NoBreakLongPunct`：
+
+- 在 `\g_@@_special_punct_clist` 中加入 `nobreak_long`
+- 通过现有 special punct 扩展机制自动生成 `\@@_punct_if_nobreak_long:NTF` 谓词
+- 新增用户键 `NoBreakLongPunct` / `NoBreakLongPunct+` / `NoBreakLongPunct-`
+- 默认值设为 `U+2025 U+2026`
+
+这样 U+2025/U+2026 仍然保留在 `LongPunct` 中，因此“长标点”的对偶 kerning、相同长标点间 nobreak、boundary 处理等既有行为全部保留；与此同时，在需要决定“能否在其前断行”的路径上，再额外检查它是否属于 `NoBreakLongPunct`，从而禁止在省略号前断行。
+
+对应实现上，xeCJK 修改了 3 处断行路径：
+
+- `\@@_CJK_and_FullRight_glue:N`：`LongPunct + NoBreakLongPunct` 时改走 nobreak
+- `\@@_Default_and_FullRight_glue:N`：同样改为 nobreak
+- `\@@_punct_kern:NN`：当右侧相邻标点属于 `NoBreakLongPunct` 时禁止断行
+
+同时补充了 `xeCJK/testfiles/ellipsis01.lvt` 与对应 `.tlg`，把“省略号前应为 `\penalty 10000`”固化为 l3build 回归测试。
+
+## 为什么不是移到 `MiddlePunct`
+
+最初看起来，把 U+2025/U+2026 从 `LongPunct` 移到 `MiddlePunct` 似乎就能让它们走 `\xeCJK_no_break:` 路径，从而修复 issue #681。但这个方案会把省略号整体切换到“居中标点”体系，进一步引入 `MiddlePunct` 专属的 glue / rule / 宽度语义副作用。
+
+也就是说，`LongPunct` 与 `MiddlePunct` 并不是可随意互换的“标点标签”，而是两组绑定了不同排版行为的属性集合。省略号需要的只是“保留 LongPunct 行为，但在前面禁止断行”，这和 `MiddlePunct` 的设计目标并不相同。
+
+因此，最终方案采用新增 `NoBreakLongPunct` 这一正交属性，而不是简单改换分类。
+
+## 容易混淆的点
+
+### `LongPunct` 与 `MiddlePunct` 是正交行为集合，不是可互换别名
+
+这次修复再次说明，这两个集合的差异不只是名字：
+
+- `LongPunct` 负责长标点相关的 kern、成对处理、边界行为等语义
+- `MiddlePunct` 负责居中标点的宽度、glue/rule 与相关排版语义
+
+因此，调整默认标点集合时，不能只看“这个字符看起来像哪类标点”，而要先确认它依赖的是哪条节点处理路径、哪组宽度语义和哪套断行规则。
+
+### xeCJK 的 special punct 是可扩展属性系统
+
+这次实现也暴露了 xeCJK 标点系统的一个重要扩展模式：
+
+- 先在 `\g_@@_special_punct_clist` 中声明属性名
+- 再由初始化逻辑生成对应的 seq 与判定谓词
+- 用户键 `Foo` / `Foo+` / `Foo-` 通过统一的 `\@@_set_special_punct:nn`、`\@@_add_special_punct:nn`、`\@@_sub_special_punct:nn` 接口接入
+
+因此，当某个字符需要“在保留原有主分类行为的前提下，再附加一条独立规则”时，优先考虑新增正交 special punct 属性，而不是硬把它塞进另一个已有分类里。
+
+## 教训
+
+- xeCJK 标点默认集合背后绑定的是具体的断行、kern、glue、rule 与 boundary 处理，不能只按名称直觉理解。
+- `LongPunct` 与 `MiddlePunct` 是不同维度的行为集合；想改变某个局部行为时，应优先寻找是否能增加正交属性，而不是简单搬移字符。
+- xeCJK 的 special punct 采用“clist + seq + 自动生成 predicate”的扩展模式，这为类似修复提供了低侵入、可维护的实现路径。
+- 对这种“默认字符集合 + 断行路径”类修复，最稳妥的方式仍然是补充节点/penalty 级回归测试，而不是只看肉眼排版结果。

--- a/llmdoc/reference/build-and-test.md
+++ b/llmdoc/reference/build-and-test.md
@@ -162,10 +162,7 @@ CI 中当前执行的测试步骤是：
 - `Test xeCJK`：在 `./xeCJK` 运行 `l3build check -q`
 - `Test zhnumber`：在 `./zhnumber` 运行 `l3build check -q`
 - `Test CJKpunct`：在 `./CJKpunct` 运行 `l3build check -q`
-<<<<<<< HEAD
-=======
 - `Test zhlineskip`：在 `./zhlineskip` 运行 `l3build check -q`
->>>>>>> 5448b292 (fix(zhlineskip): 修复 split 环境行距恢复泄漏导致的 display 间距异常 (#735))
 
 `Test xeCJK`、`Test zhnumber`、`Test CJKpunct` 都带有 `if: ${{ !cancelled() }}`，因此只要工作流未被取消，就会继续执行，不会因为前一个测试步骤失败而自动跳过。卫星包步骤还会在运行前检测 `testfiles` 目录或 `build.lua` 中的 `testfiledir` 配置；若未发现测试配置，则安全输出跳过信息，而不是直接失败。
 
@@ -175,10 +172,7 @@ CI 中当前执行的测试步骤是：
 - `xeCJK/build/**/*.diff`
 - `zhnumber/build/**/*.diff`
 - `CJKpunct/build/**/*.diff`
-<<<<<<< HEAD
-=======
 - `zhlineskip/build/**/*.diff`
->>>>>>> 5448b292 (fix(zhlineskip): 修复 split 环境行距恢复泄漏导致的 display 间距异常 (#735))
 
 另外，`ctex` 测试步骤的 step id 已由 `test` 调整为 `test-ctex`，以便与新增的 `test-xecjk`、`test-zhnumber`、`test-cjkpunct` 一起在后续 artifact 条件表达式中区分引用。
 

--- a/xeCJK/testfiles/ellipsis01.lvt
+++ b/xeCJK/testfiles/ellipsis01.lvt
@@ -1,0 +1,21 @@
+\input{regression-test}
+
+\documentclass{article}
+
+\usepackage{xeCJK}
+\setCJKmainfont{FandolSong-Regular.otf}
+
+\begin{document}
+
+\START
+
+\loggingoutput
+
+\TEST{Ellipsis~nobreak~(issue~681)}{
+  天地玄黄……宇宙洪荒。
+  \clearpage
+}
+
+\END
+
+\end{document}

--- a/xeCJK/testfiles/ellipsis01.tlg
+++ b/xeCJK/testfiles/ellipsis01.tlg
@@ -1,0 +1,65 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+============================================================
+TEST 1: Ellipsis~nobreak~(issue~681)
+============================================================
+Completed box being shipped out [1]
+\vbox(633.0+0.0)x407.0
+.\glue 16.0
+.\vbox(617.0+0.0)x345.0, shifted 62.0
+..\vbox(12.0+0.0)x345.0, glue set 12.0fil
+...\glue 0.0 plus 1.0fil
+...\hbox(0.0+0.0)x345.0
+....\hbox(0.0+0.0)x345.0
+..\glue 25.0
+..\glue(\lineskip) 0.0
+..\vbox(550.0+0.0)x345.0, glue set 539.94232fil
+...\write-{}
+...\glue(\topskip) 2.19
+...\hbox(7.81+1.87999)x345.0, glue set 226.44fil
+....\hbox(0.0+0.0)x15.0
+....\TU/FandolSong-Regular.otf(0)/m/n/10 天
+....\glue 0.0 plus 0.96002
+....\TU/FandolSong-Regular.otf(0)/m/n/10 地
+....\glue 0.0 plus 0.96002
+....\TU/FandolSong-Regular.otf(0)/m/n/10 玄
+....\glue 0.0 plus 0.96002
+....\TU/FandolSong-Regular.otf(0)/m/n/10 黄
+....\penalty 10000
+....\TU/FandolSong-Regular.otf(0)/m/n/10 …
+....\penalty 10000
+....\glue 0.0
+....\TU/FandolSong-Regular.otf(0)/m/n/10 …
+....\rule(0.0+0.0)x-1.7
+....\glue 1.7
+....\glue 0.0 plus 0.96002
+....\TU/FandolSong-Regular.otf(0)/m/n/10 宇
+....\glue 0.0 plus 0.96002
+....\TU/FandolSong-Regular.otf(0)/m/n/10 宙
+....\glue 0.0 plus 0.96002
+....\TU/FandolSong-Regular.otf(0)/m/n/10 洪
+....\glue 0.0 plus 0.96002
+....\TU/FandolSong-Regular.otf(0)/m/n/10 荒
+....\penalty 10000
+....\TU/FandolSong-Regular.otf(0)/m/n/10 。
+....\rule(0.0+0.0)x-6.44
+....\kern 0.0004
+....\kern -0.0004
+....\kern -0.18753
+....\kern 0.18753
+....\penalty 10000
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
+...\glue -1.87999
+...\glue 0.0 plus 1.0fil
+...\glue 0.0
+...\glue 0.0 plus 0.0001fil
+..\glue(\baselineskip) 23.34
+..\hbox(6.66+0.0)x345.0
+...\hbox(6.66+0.0)x345.0, glue set 170.0fil
+....\glue 0.0 plus 1.0fil
+....\TU/lmr/m/n/10 1
+....\kern -0.0002
+....\kern 0.0002
+....\glue 0.0 plus 1.0fil
+============================================================

--- a/xeCJK/xeCJK.dtx
+++ b/xeCJK/xeCJK.dtx
@@ -587,8 +587,19 @@ Copyright and Licence
 %   \begin{syntax}
 %     LongPunct = \Arg{( — ⸺ ‥ … )}
 %   \end{syntax}
-%   设置长标点，例如破折号“——”与省略号“……”，允许在长标点前后
-%   断行，但是禁止在它们之间断行。
+%   设置长标点，例如破折号”——“与省略号”……”，允许在长标点前后
+%   断行，但是禁止在它们之间断行。同时属于 |NoBreakLongPunct|
+%   的长标点则禁止在其前面断行。
+% \end{function}
+%
+% \begin{function}[EXP]{NoBreakLongPunct,NoBreakLongPunct+,NoBreakLongPunct-}
+%   \begin{syntax}
+%     NoBreakLongPunct = \Arg{( ‥ … )}
+%   \end{syntax}
+%   设置禁止在其前面断行的长标点。属于 |NoBreakLongPunct| 的字符必须同时属于
+%   |LongPunct|。与普通长标点不同，\pkg{xeCJK} 禁止在这类标点前面断行，但仍
+%   允许在其后面断行，并禁止在相同长标点之间断行。缺省值包含省略号
+%   “\textbf{‥}”和”\textbf{…}”。
 % \end{function}
 %
 % \begin{function}[EXP]{MiddlePunct,MiddlePunct+,MiddlePunct-}
@@ -4017,8 +4028,11 @@ Copyright and Licence
 % \end{macro}
 %
 % \changes{v3.6.0}{2018/01/23}{总允许长标点与其他标点之间折行。}
+% \changes{v3.9.3}{2026/04/27}
+% {\texttt{NoBreakLongPunct} 在右侧时禁止折行。}
 % \begin{macro}{\xeCJK_punct_kern:NN,\@@_punct_kern:NN}
-% 相邻两个标点之间的间距，总允许长标点与其他标点之间折行。
+% 相邻两个标点之间的间距，总允许长标点与其他标点之间折行，
+% 但 |NoBreakLongPunct| 在右侧时禁止折行。
 %    \begin{macrocode}
 \cs_new_protected:Npn \@@_punct_kern:NN #1#2
   {
@@ -4029,7 +4043,11 @@ Copyright and Licence
           { \@@_punct_breakable_kern:NN }
           {
             \@@_punct_if_long:NTF #2
-              { \@@_punct_breakable_kern:NN }
+              {
+                \@@_punct_if_nobreak_long:NTF #2
+                  { \@@_punct_nobreak_kern:NN }
+                  { \@@_punct_breakable_kern:NN }
+              }
               { \@@_punct_nobreak_kern:NN }
           }
       }
@@ -4553,6 +4571,8 @@ Copyright and Licence
 % {修正标点同为 \texttt{LongPunct} 与 \texttt{MiddlePunct} 时的实现错误。}
 % \changes{v3.6.0}{2018/01/14}
 % {\texttt{Default} 类与 \texttt{MiddlePunct} 之间不应该有 \tn{CJKglue}。}
+% \changes{v3.9.3}{2026/04/27}
+% {新增 \texttt{NoBreakLongPunct} 属性，禁止在省略号等长标点前断行。}
 %
 % \begin{macro}
 % {\@@_CJK_and_FullRight_glue:N,\@@_Default_and_FullRight_glue:N}
@@ -4560,7 +4580,11 @@ Copyright and Licence
 \cs_new_protected:Npn \@@_CJK_and_FullRight_glue:N #1
   {
     \@@_punct_if_long:NTF #1
-      { \xeCJK_allow_break: }
+      {
+        \@@_punct_if_nobreak_long:NTF #1
+          { \xeCJK_no_break: }
+          { \xeCJK_allow_break: }
+      }
       { \xeCJK_no_break: }
     \@@_punct_if_middle:NT #1
       {
@@ -4572,7 +4596,11 @@ Copyright and Licence
 \cs_new_protected:Npn \@@_Default_and_FullRight_glue:N #1
   {
     \@@_punct_if_long:NTF #1
-      { \xeCJK_allow_break: }
+      {
+        \@@_punct_if_nobreak_long:NTF #1
+          { \xeCJK_no_break: }
+          { \xeCJK_allow_break: }
+      }
       { \xeCJK_no_break: }
     \@@_punct_if_middle:NT #1
       {
@@ -5307,7 +5335,7 @@ Copyright and Licence
 % \changes{v3.4.0}{2016/05/13}{\texttt{RubberPunctSkip} 选项有新的值 \texttt{plus} 和 \texttt{minus}。}
 %
 % \begin{macro}
-%  {AllowBreakBetweenPuncts,KaiMingPunct,LongPunct,
+%  {AllowBreakBetweenPuncts,KaiMingPunct,LongPunct,NoBreakLongPunct,
 %   MiddlePunct,PunctWidth,PunctBoundWidth,RubberPunctSkip}
 % 相关选项声明。
 %    \begin{macrocode}
@@ -5335,6 +5363,9 @@ Copyright and Licence
     LongPunct     .code:n = { \@@_set_special_punct:nn { long } {#1} } ,
     LongPunct+    .code:n = { \@@_add_special_punct:nn { long } {#1} } ,
     LongPunct-    .code:n = { \@@_sub_special_punct:nn { long } {#1} } ,
+    NoBreakLongPunct  .code:n = { \@@_set_special_punct:nn { nobreak_long } {#1} } ,
+    NoBreakLongPunct+ .code:n = { \@@_add_special_punct:nn { nobreak_long } {#1} } ,
+    NoBreakLongPunct- .code:n = { \@@_sub_special_punct:nn { nobreak_long } {#1} } ,
     MiddlePunct   .code:n = { \@@_set_special_punct:nn { middle } {#1} } ,
     MiddlePunct+  .code:n = { \@@_add_special_punct:nn { middle } {#1} } ,
     MiddlePunct-  .code:n = { \@@_sub_special_punct:nn { middle } {#1} } ,
@@ -5360,7 +5391,7 @@ Copyright and Licence
 % 相关选项定义的辅助函数。
 %    \begin{macrocode}
 \clist_new:N \g_@@_special_punct_clist
-\clist_gset:Nn \g_@@_special_punct_clist { mixed_width , long , middle }
+\clist_gset:Nn \g_@@_special_punct_clist { mixed_width , long , nobreak_long , middle }
 \cs_new:Npn \@@_special_punct_seq:n #1 { g_@@_special_punct_#1_seq }
 \cs_new:Npn \@@_special_punct_tl:nN #1#2 { g_@@_special_punct_#1_#2_tl }
 \clist_map_inline:Nn \g_@@_special_punct_clist
@@ -8324,6 +8355,7 @@ Copyright and Licence
     NoBreakCS       = { \footnote \footnotemark \nobreak } ,
     KaiMingPunct    = { ^^^^3002 ^^^^ff0e ^^^^ff1f ^^^^ff01 } ,
     LongPunct       = { ^^^^2014 ^^^^2e3a ^^^^2025 ^^^^2026 } ,
+    NoBreakLongPunct = { ^^^^2025 ^^^^2026 } ,
     MiddlePunct     = { ^^^^2013 ^^^^2014 ^^^^2e3a ^^^^2027 ^^^^00b7 ^^^^30fb ^^^^ff65 } ,
     AllowBreakBetweenPuncts = false
   }


### PR DESCRIPTION
## Summary

- 新增 `NoBreakLongPunct` 用户键和 `nobreak_long` 内部属性，作为 `LongPunct` 的正交修饰
- 默认将省略号（U+2025 ‥、U+2026 …）加入 `NoBreakLongPunct`
- 修改 `\@@_CJK_and_FullRight_glue:N`、`\@@_Default_and_FullRight_glue:N`、`\@@_punct_kern:NN` 三处断行路径，对 `NoBreakLongPunct` 字符在其前方插入 `penalty 10000` 而非 `penalty 0`
- 省略号保留在 `LongPunct` 中，对偶 kerning、相同长标点间 nobreak、boundary 处理完全不变
- 破折号（U+2014、U+2E3A）行为不受任何影响

## Motivation

XeLaTeX 下省略号"……"可出现在行首（issue #681）。根因是 `LongPunct` 在标点前插入 `penalty 0` 允许断行。LuaLaTeX 路线通过 luatexja kinsoku 机制不允许此行为，两条路线不一致。

直接将省略号从 `LongPunct` 移至 `MiddlePunct` 会引入居中 glue/rule 副作用（省略号不是居中标点）。因此引入正交的 `NoBreakLongPunct` 属性，仅覆盖断行行为。

## Test plan

- [x] 新增 `xeCJK/testfiles/ellipsis01.lvt` 回归测试，验证省略号前为 `penalty 10000`
- [x] xeCJK 全部 6 个测试通过（`l3build check`）
- [x] 手动验证破折号 "——" 的 penalty/kern 结构不变
- [x] CI 三平台验证

Closes #681