### PR TITLE
fix(ctex): 修复 LuaTeX 下 \verb 前 xkanjiskip 丢失 (#556)

### DIFF
--- a/ctex/ctex.dtx
+++ b/ctex/ctex.dtx
@@ -6512,6 +6512,29 @@ Copyright and Licence
   { \ltjsetparameter { autospacing = false , autoxspacing = false } }
 %    \end{macrocode}
 %
+% \changes{v2.5.12}{2026/04/27}{修复内联 \tn{verb} 前 \opt{xkanjiskip} 丢失的问题
+%   （移植 \pkg{lltjcore} 对 \tn{verb} 和 \tn{do@noligs} 的修复）。}
+%
+% \pkg{LuaTeX-ja} 的 \file{lltjcore.sty} 会将 \LaTeX{} 的 \tn{verb} 中
+% \tn{null}（即 |\hbox{}|）替换为 |\vadjust{}|，因为空 |\hbox{}| 会阻断
+% \opt{xkanjiskip} 的自动插入。由于 \pkg{ctex} 禁用了 \pkg{ltj-latex}，
+% 这里需要自行复制该修复。
+%    \begin{macrocode}
+\@namedef { ver@lltjcore.sty } { }
+\if@compatibility \else
+  \def \verb
+    {
+      \relax \ifmmode \hbox \else \leavevmode \vadjust { } \fi
+      \bgroup
+        \verb@eol@error \let \do \@makeother \dospecials
+        \verbatim@font \@noligs
+        \language \l@nohyphenation
+        \@ifstar \@sverb \@verb
+    }
+\fi
+\patchcmd { \do@noligs } { \kern \z@ } { \vadjust { } } { } { }
+%    \end{macrocode}
+%
 % \begin{macro}{\@@@@italiccorr}
 % \LaTeX{} 的倾斜校正也要重新定义。
 %    \begin{macrocode}

--- a/ctex/test/testfiles/verb01.luatex.tlg
+++ b/ctex/test/testfiles/verb01.luatex.tlg
@@ -1,0 +1,16 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+(load cache: extra_fandolfang-regular.luc)(load cache: extra_lmmono10-regular.luc)
+Package fontspec Info: 
+(fontspec)             Font family 'FandolFang-Regular(0)' created for font 'FandolFang-Regular' with options [NFSSEncoding=LTJY3,JFM=zh_CN/quanjiao,Extension={.otf},LTJFONTUID=3].
+(fontspec)              
+(fontspec)              This font family consists of the following NFSS series/shapes:
+(fontspec)              
+(fontspec)             - 'normal' (m/n) with NFSS spec.: <->"[FandolFang-Regular.otf]:mode=node;script=latn;language=dflt;jfm=zh_CN/quanjiao;"
+============================================================
+TEST 1: xkanjiskip~survives~verb
+============================================================
+verb~=~42.94794pt
+texttt~=~42.94794pt
+PASS
+============================================================

--- a/ctex/test/testfiles/verb01.lvt
+++ b/ctex/test/testfiles/verb01.lvt
@@ -1,0 +1,41 @@
+\ExplSyntaxOn
+\sys_if_engine_luatex:F
+  {
+    \ExplSyntaxOff
+    \input { regression-test }
+    \START
+    \TYPE { Only~ tested~ with~ LuaTeX. }
+    \END
+    \file_input_stop:
+  }
+\ExplSyntaxOff
+
+\input{regression-test}
+
+\documentclass{article}
+
+\usepackage[fontset=fandol]{ctex}
+
+\begin{document}
+
+\START
+
+\setbox0=\hbox{字\verb|foo|字}
+\setbox1=\hbox{字\texttt{foo}字}
+
+\edef\widthVerb{\the\wd0}
+\edef\widthTexttt{\the\wd1}
+
+\TEST{xkanjiskip~survives~verb}{
+  \TYPE{verb~=~\widthVerb}
+  \TYPE{texttt~=~\widthTexttt}
+  \ifdim\wd0=\wd1
+    \TYPE{PASS}
+  \else
+    \TYPE{FAIL:~verb~and~texttt~widths~differ}
+  \fi
+}
+
+\END
+
+\end{document}

--- a/ctex/test/testfiles/verb01.pdftex.tlg
+++ b/ctex/test/testfiles/verb01.pdftex.tlg
@@ -1,0 +1,3 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+Only tested with LuaTeX.

--- a/ctex/test/testfiles/verb01.tlg
+++ b/ctex/test/testfiles/verb01.tlg
@@ -1,0 +1,3 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+Only tested with LuaTeX.

--- a/ctex/test/testfiles/verb01.uptex.tlg
+++ b/ctex/test/testfiles/verb01.uptex.tlg
@@ -1,0 +1,3 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+Only tested with LuaTeX.


### PR DESCRIPTION
## Summary

- 移植 `lltjcore.sty` 对 `\verb` 和 `\do@noligs` 的补丁到 ctex 的 LuaTeX 引擎适配层
- 将 `\verb` 中的 `\null`（空 `\hbox{}`）替换为 `\vadjust{}`，防止阻断 luatexja 的 xkanjiskip 自动插入
- 声明 `ver@lltjcore.sty` 防止 lltjcore 被重复加载

## Root cause

ctex 通过 `\@namedef{ver@ltj-latex.sty}{}` 禁用了 `ltj-latex`，连带跳过了 `lltjcore.sty` 的加载。而 `lltjcore` 中有关键补丁：将 LaTeX 原生 `\verb` 定义中的 `\null`（`\hbox{}`）替换为 `\vadjust{}`。

空 `\hbox{}` 会产生一个 hlist 节点，阻断 luatexja 在相邻 CJK 字符与 latin 字符之间自动插入 xkanjiskip glue。`\vadjust{}` 产生 adjust 节点，不影响水平列表中的 glue 插入。

纯 luatexja（不加载 ctex）不受影响，因为 `lltjcore` 正常加载并完成了补丁。

## Test plan

- [x] 新增 `verb01` 回归测试：比较 `字\verb|foo|字` 与 `字\texttt{foo}字` 的 hbox 宽度
- [x] LuaTeX 下宽度一致（PASS），非 LuaTeX 引擎跳过
- [x] 全量 `l3build check` 无新回归

Closes #556