### PR TITLE
fix(xeCJK): 重定义 \char 使其绕过 interchar 机制 (#407)

### DIFF
--- a/llmdoc/index.md
+++ b/llmdoc/index.md
@@ -30,5 +30,6 @@
 - `llmdoc/memory/reflections/704-ctxdoc-patch-health-test.md` — 反思: 为 `support/ctxdoc.cls` 建立 patch 健康检查时，确认 l3build `check` 目标需要用 `checksuppfiles` 显式复制 support 文件，且 nonstop 模式下必须使用 `\msg_critical` 才能把 patch 失败升级为真正终止编译的错误。
 - `llmdoc/memory/reflections/735-zhlineskip-split-leading-leak.md` — 反思: zhlineskip #735 split 行距泄漏的根因（TeX 分组层级）、vbox 尺寸回归测试策略与 l3build 框架补建。
 - `llmdoc/memory/reflections/581-xecjk-zero-width-format-chars.md` — 反思: xeCJK #581 中零宽格式字符应在输入层忽略，而不是进入 interchar 字符分类。
-- `llmdoc/memory/reflections/556-verb-xkanjiskip-lltjcore.md` — 反思: ctex #556 中从 autoxspacing 误判修正为“禁用 ltj-latex 后漏掉 lltjcore 的 `\verb` 补丁”，以及基于 `\showbox` 的节点级定位方法。
+- `llmdoc/memory/reflections/556-verb-xkanjiskip-lltjcore.md` — 反思: ctex #556 中从 autoxspacing 误判修正为”禁用 ltj-latex 后漏掉 lltjcore 的 `\verb` 补丁”，以及基于 `\showbox` 的节点级定位方法。
 - `llmdoc/memory/reflections/284-fullwidth-tilde-longpunct.md` — 反思: xeCJK #284 中全角波浪号等连接号的残留问题不在可见空格，而在 MiddlePunct 引入的不必要标点压缩节点；应借助 `\showbox` 对比确认 LongPunct 路径的更干净节点模型。
+- `llmdoc/memory/reflections/407-char-interchar-bypass.md` — 反思: xeCJK #407 中 `\char` 原语被 interchar 拦截的根因、`\char` vs mathcode 语义差异、测试场景设计偏差。

--- a/llmdoc/memory/reflections/407-char-interchar-bypass.md
+++ b/llmdoc/memory/reflections/407-char-interchar-bypass.md
@@ -1,0 +1,39 @@
+# Issue #407 char/interchar 绕过修复反思
+
+## Task
+- 记录 xeCJK Issue #407 的修复反思：`mtpro2` 的 `\overcbrace` 在 XeTeX 下被 xeCJK 的 interchar 机制误拦截，输出成中文间隔号。
+
+## Expected vs Actual
+- Expected outcome.
+  - `\char` 作为底层原语，应始终从当前字体直接取字形；`mtpro2` 在 `\hbox` 中通过 `\char"00B7` 访问 `mt2exe` 字体 183 号位时，不应被 xeCJK 改写字体。
+- Actual outcome.
+  - `U+00B7` 被 xeCJK 归入 `FullRight` interchar 类后，只要 `\XeTeXinterchartokenstate = 1`，`\char"00B7` 也会触发 interchartoks，导致进入 CJK 字体切换路径，最终把原本的数学花括号字形变成中文间隔号。
+
+## What Went Wrong
+- 最初没有先明确区分“直接字符输入”和“`\char` 原语输出”两条路径，容易把两者都当成同一种 interchar 触发问题来设计测试。
+- 第一版测试把数学模式中的 `\char` 与直接输入字符 `·` 并列比较，隐含假设两者在 math 模式下会走相同机制；这个假设不成立。
+- 调查早期如果没有充分利用 issue 讨论，很容易重复维护者已经完成的分析与补丁设计。
+
+## Root Cause
+- 对 XeTeX interchar 机制的认识不够细：`\XeTeXinterchartokenstate` 对文本与数学都生效，但数学模式里的“直接字符输入”通常走 mathcode / 数学族选择路径，而 `\char` 仍然是“从当前字体直接取字形”的底层原语。
+- xeCJK 的字符分类表把 U+00B7 当作中文边界控制对象处理，这对普通文本输入成立，但不应外推到 `\char` 这种明确要求绕过 NFSS、高层字符语义和自动边界处理的低层接口。
+- 测试设计时没有先回到真实触发场景：`mtpro2` 的问题出现在数学中的 `\hbox`，而不是裸数学原子输入。
+
+## Missing Docs or Signals
+- memory only:
+  - 需要在反思中明确记住：排查 xeCJK interchar 问题时，先区分“直接 Unicode 字符输入”“数学字符输入”“`\char` 原语输出”“盒子内文本字体输出”这几条路径，避免测试对象选错。
+  - 需要记住 issue 评论往往已经包含维护者对 TeX 原语语义的定性判断，尤其是兼容性补丁类问题，应优先吸收再验证。
+- promotion candidates:
+  - 可考虑在 `llmdoc/guides/` 或 `llmdoc/reference/` 增补一条 xeCJK interchar 调试准则：`\char` 属于底层取字形原语，兼容补丁原则上不应拦截；若某补丁会影响 `\char`，必须单独论证。
+  - 可考虑在 `llmdoc/reference/build-and-test.md` 或 xeCJK 相关指南中补充测试经验：数学模式中的直接字符与 `\hbox{\char...}` 不等价，涉及字体切换问题时应尽量复现真实盒子上下文。
+
+## Promotion Candidates
+- `guides/`:
+  - 增加“xeCJK interchar/字体切换问题排查”指南，明确先判断输入路径，再决定看字符分类、mathcode、或兼容 hook。
+- `reference/`:
+  - 增加一条事实性说明：`\XeTeXinterchartokenstate` 虽然在数学模式也开启，但直接数学字符与 `\char` 的字体来源和边界副作用不同。
+- `must/`:
+  - 若后续再次出现类似误测，可把“回归测试必须贴近真实触发场景，不得用语义不同的最小例子替代”提升为稳定要求。
+
+## Follow-up
+- 将本次经验沉淀为一条可复用检查清单：遇到 xeCJK 字体误切换问题时，先确认触发对象是否为 `\char` 原语；若是，优先检查是否应在输出该字符前临时关闭 `\XeTeXinterchartokenstate`，并用真实场景对应的盒子结构编写回归测试。

--- a/xeCJK/testfiles/char-interchar01.lvt
+++ b/xeCJK/testfiles/char-interchar01.lvt
@@ -1,0 +1,46 @@
+\input{regression-test}
+
+\documentclass{article}
+
+\usepackage{xeCJK}
+\setCJKmainfont{FandolSong-Regular.otf}
+
+\begin{document}
+
+\START
+
+\setbox0=\hbox{\char"00B7}
+\setbox1=\hbox{·}
+
+\edef\widthChar{\the\wd0}
+\edef\widthText{\the\wd1}
+
+\TEST{char~bypasses~interchar~for~middle~dot}{
+  \TYPE{char~=~\widthChar}
+  \TYPE{text~=~\widthText}
+  \ifdim\wd0=\wd1
+    \TYPE{FAIL:~char~used~CJK~font}
+  \else
+    \TYPE{PASS}
+  \fi
+}
+
+\setbox2=\hbox{$\vcenter{\hbox{\char"00B7}}$}
+\setbox3=\hbox{$\vcenter{\hbox{·}}$}
+
+\edef\widthMathChar{\the\wd2}
+\edef\widthMathText{\the\wd3}
+
+\TEST{char~in~math~hbox~bypasses~interchar}{
+  \TYPE{math-hbox-char~=~\widthMathChar}
+  \TYPE{math-hbox-text~=~\widthMathText}
+  \ifdim\wd2=\wd3
+    \TYPE{FAIL:~char~used~CJK~font~in~math~hbox}
+  \else
+    \TYPE{PASS}
+  \fi
+}
+
+\END
+
+\end{document}

--- a/xeCJK/testfiles/char-interchar01.tlg
+++ b/xeCJK/testfiles/char-interchar01.tlg
@@ -1,0 +1,20 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+============================================================
+TEST 1: char~bypasses~interchar~for~middle~dot
+============================================================
+char~=~7.78pt
+text~=~10.0pt
+PASS
+============================================================
+LaTeX Font Info:    External font `cmex10' loaded for size
+(Font)              <7> on input line ....
+LaTeX Font Info:    External font `cmex10' loaded for size
+(Font)              <5> on input line ....
+============================================================
+TEST 2: char~in~math~hbox~bypasses~interchar
+============================================================
+math-hbox-char~=~7.78pt
+math-hbox-text~=~10.0pt
+PASS
+============================================================

--- a/xeCJK/xeCJK.dtx
+++ b/xeCJK/xeCJK.dtx
@@ -9053,6 +9053,41 @@ Copyright and Licence
 % \end{variable}
 % \end{macro}
 %
+% \changes{v3.9.2}{2026/04/27}{重定义 \tn{char}，使其绕过 interchar 机制（\#407）。}
+%
+% \begin{macro}{\xeCJK_default_char:w}
+% \begin{macro}{\@@_default_char_aux:}
+% \begin{variable}{\l_@@_default_char_int}
+% \tn{char} 是 \TeX 原语，用户使用它直接通过字符编码从当前字体取字形，
+% 不经过 NFSS 层。一些宏包（如 \pkg{mtpro2}）在数学模式中用 \tn{char} 取
+% 非 CJK 字形时，会被 \pkg{xeCJK} 的 interchar 机制拦截并切换到中文字体，
+% 导致字形变成中文标点（如间隔号）。这里参照 \pkg{LuaTeX-ja} 的做法，
+% 重定义 \tn{char}，使之临时关闭 |XeTeXinterchartokenstate|，保证输出的字符
+% 来自当前字体。
+%    \begin{macrocode}
+\cs_new_protected:Npn \xeCJK_default_char:w
+  {
+    \int_compare:nNnTF \tex_XeTeXinterchartokenstate:D > \c_zero_int
+      {
+        \c_group_begin_token
+          \tex_afterassignment:D \@@_default_char_aux:
+          \l_@@_default_char_int =
+      }
+      { \tex_char:D }
+  }
+\cs_new_protected:Npn \@@_default_char_aux:
+  {
+      \tex_XeTeXinterchartokenstate:D = \c_zero_int
+      \tex_char:D \l_@@_default_char_int
+    \c_group_end_token
+  }
+\int_new:N \l_@@_default_char_int
+\cs_set_eq:NN \char \xeCJK_default_char:w
+%    \end{macrocode}
+% \end{variable}
+% \end{macro}
+% \end{macro}
+%
 % \changes{v3.8.3}{2020/04/09}{兼容 \pkg{unicode-math} 和 \opt{CJKmath} 选项。}
 %
 % \begin{macro}{\@@_save_um_char:, \@@_save_um_char:}


### PR DESCRIPTION
## Summary

- 重定义 `\char` 原语，在输出字符前临时关闭 `XeTeXinterchartokenstate`，使 `\char` 始终从当前字体取字形
- 参照 LuaTeX-ja 的做法，采用 @qinglee 在 #407 评论中提出的方案
- 修复 `mtpro2` 等宏包通过 `\char` 访问非 CJK 字形时，`U+00B7` 位置被强制替换成中文间隔号的问题

Closes #407

## Test plan

- [x] 新增 `char-interchar01` 回归测试：验证 `\char"00B7` 在文本模式和数学 `\hbox` 中不触发 CJK 字体切换
- [x] xeCJK 全部 7 个测试通过，无回归
- [ ] CI 三平台验证