### PR TITLE
fix(xecjk): 修复错误的常量赋值

### DIFF
--- a/xeCJK/xeCJK.dtx
+++ b/xeCJK/xeCJK.dtx
@@ -2339,10 +2339,8 @@ Copyright and Licence
 % \begin{variable}{\c_@@_FullLeft_chars_clist}
 % 以上两类标点符号出现在文字的左边，不应出现在行尾位置。
 %    \begin{macrocode}
-\clist_new:N \c_@@_FullLeft_chars_clist
-\clist_gconcat:NNN \c_@@_FullLeft_chars_clist
-                   \c_@@_OP_chars_clist
-                   \c_@@_PR_chars_clist
+\clist_const:Ne \c_@@_FullLeft_chars_clist
+  { \c_@@_OP_chars_clist , \c_@@_PR_chars_clist }
 %    \end{macrocode}
 % \end{variable}
 %
@@ -2453,19 +2451,14 @@ Copyright and Licence
 % \begin{variable}{\c_@@_FullRight_chars_clist}
 % 以上六类标点符号出现在文字的右边，不应出现在行首位置。
 %    \begin{macrocode}
-\clist_new:N \c_@@_FullRight_chars_clist
-\tl_map_inline:nn
+\clist_const:Ne \c_@@_FullRight_chars_clist
   {
-    \c_@@_CL_chars_clist
-    \c_@@_NS_chars_clist
-    \c_@@_EX_chars_clist
-    \c_@@_IS_chars_clist
-    \c_@@_PO_chars_clist
+    \c_@@_CL_chars_clist ,
+    \c_@@_NS_chars_clist ,
+    \c_@@_EX_chars_clist ,
+    \c_@@_IS_chars_clist ,
+    \c_@@_PO_chars_clist ,
     \c_@@_hyphens_chars_clist
-  }
-  {
-    \clist_gconcat:NNN \c_@@_FullRight_chars_clist
-                       \c_@@_FullRight_chars_clist #1
   }
 %    \end{macrocode}
 % \end{variable}
@@ -8927,13 +8920,13 @@ Copyright and Licence
   {
     \token_if_chardef:NTF #1
       {
-        \prop_gput:Nne \c_@@_ambiguous_slot_prop {#2}
+        \prop_gput:Nne \g_@@_ambiguous_slot_prop {#2}
           { \int_eval:n {#1} }
         \cs_set_protected:Npx #1
           { \@@_ambiguous_char:n { \tex_Uchar:D #1 } }
       }
       {
-        \prop_gput:Nne \c_@@_ambiguous_slot_prop {#2}
+        \prop_gput:Nne \g_@@_ambiguous_slot_prop {#2}
           { \int_eval:n { \exp_after:wN ` #1 } }
         \cs_set_protected:Npx #1
           { \@@_ambiguous_char:n { \exp_not:o {#1} } }
@@ -8945,7 +8938,7 @@ Copyright and Licence
       { \@@_inactive_group_begin: #1 \@@_inactive_group_end: }
       {#1}
   }
-\prop_new:N \c_@@_ambiguous_slot_prop
+\prop_new:N \g_@@_ambiguous_slot_prop
 %    \end{macrocode}
 % \end{variable}
 % \end{macro}
@@ -9146,7 +9139,7 @@ Copyright and Licence
   }
 \cs_new_protected:Npn \@@_get_ambiguous_slot:
   {
-    \prop_get:NeNT \c_@@_ambiguous_slot_prop
+    \prop_get:NeNT \g_@@_ambiguous_slot_prop
       { \MT@encoding - \tex_the:D \MT@toks } \l_@@_tmp_tl
       { \cs_set_eq:NN \MT@char \l_@@_tmp_tl }
   }


### PR DESCRIPTION
`xeCJK` 也有常量赋值问题，`Global assignment to a constant variable`。

- 前两处可以直接用 `\clist_const:Ne` 展开合并。
- 第三处 `\c_@@_ambiguous_slot_prop` 的内容是逐步构建的，并非常量，使用 `g` 类型更符合逻辑。