### PR TITLE
fix(xeCJK): 修复 \CJKunderline- 两组拼接时下划线间隙 (#531)

### DIFF
--- a/llmdoc/index.md
+++ b/llmdoc/index.md
@@ -34,3 +34,4 @@
 - `llmdoc/memory/reflections/556-verb-xkanjiskip-lltjcore.md` — 反思: ctex #556 中从 autoxspacing 误判修正为”禁用 ltj-latex 后漏掉 lltjcore 的 `\verb` 补丁”，以及基于 `\showbox` 的节点级定位方法。
 - `llmdoc/memory/reflections/284-fullwidth-tilde-longpunct.md` — 反思: xeCJK #284 中全角波浪号等连接号的残留问题不在可见空格，而在 MiddlePunct 引入的不必要标点压缩节点；应借助 `\showbox` 对比确认 LongPunct 路径的更干净节点模型。
 - `llmdoc/memory/reflections/407-char-interchar-bypass.md` — 反思: xeCJK #407 中 `\char` 原语被 interchar 拦截的根因、`\char` vs mathcode 语义差异、测试场景设计偏差。
+- `llmdoc/memory/reflections/531-underline-dash-leaders-alignment.md` — 反思: xeCJK #531 中 `\CJKunderline-` 接缝间隙的根因（`\leaders` 对齐 + 首次变体缺少左侧 pixel）、误判 ulem 通用问题的经过、PDF 坐标提取诊断法。

--- a/llmdoc/memory/reflections/531-underline-dash-leaders-alignment.md
+++ b/llmdoc/memory/reflections/531-underline-dash-leaders-alignment.md
@@ -1,0 +1,50 @@
+# [Task Reflection]
+
+## Task
+- 为 xeCJK issue #531 记录一次修复反思，聚焦 `\CJKunderline-{...}\CJKunderline-{...}` 两组拼接时接缝处约 2pt 下划线间隙的问题。
+- 总结从初始误判到最终定位 `\leaders` 对齐语义的分析过程，并沉淀后续处理 xeCJKfntef / ulem 下划线边界问题时可复用的检查点。
+
+## Expected vs Actual
+- 预期结果：
+  - `\CJKunderline-` 的连续拼接应与单个更长分组得到一致的下划线覆盖，接缝处不应出现可见空隙。
+  - `\xeCJK_ulem_var_leaders:` 的首次 leaders 变体应与标准 `\UL@leaders` 一样，能够覆盖 leaders 区域边界盒。
+- 实际结果：
+  - 两个相邻的 `\CJKunderline-` 分组在接缝处会跳过一个 leader box 宽度，形成约 2pt 的间隙。
+  - xdvipdfmx 输出坐标本身没有漂移；真正的问题发生在 TeX 侧 leaders 区域构造与对齐条件不满足，而不是驱动层数值误差。
+
+## What Went Wrong
+- 初期过早把问题归因为 ulem 通用的“kern-back overlay 浮点累积误差”，围绕 `\rlap` 叠加、PDF stream 坐标抽取、showbox 对比做了很多验证，但这一假设本身方向就错了。
+- 一开始更关注“为什么下划线画出来后位置不连贯”，却没有先对照标准 `\UL@leaders` 与 `\xeCJK_ulem_var_leaders:` 的边界构造差异，导致忽略了首次变体少了左侧 `-\UL@pixel` 这一关键事实。
+- 早期实验里把 `\rlap` 叠加结果当成对 overlay 路径的直接证明，但 `\CJKunderline` 在 hbox 内的行为与当时假设并不等价，造成了错误的“这是 ulem 普遍问题”的结论。
+
+## Root Cause
+- 根因不是 xdvipdfmx 的浮点累计误差，而是 `\leaders` 的标准对齐语义与 xeCJK subtract 模式的边界裁剪共同造成的边界漏覆盖。
+- `\CJKunderline-` 走 subtract 模式时，`\xeCJK_ulem_var_leaders:` 首次变体原先没有像标准 `\UL@leaders` 那样先执行左侧 `\skip_horizontal:n { - \UL@pixel }`，因此 leaders 区域左边界被收窄。
+- 与此同时，上一组收尾的 `\@@_ulem_right_skip:` 会对末字右侧做一个 `\UL@pixel` 的修剪。到了两组拼接接缝处，新组首个 leader box 的理论起点恰好落在 leaders 区域起始位置左侧一个极小量之外，不满足“完整嵌入 leaders 区域”的条件。
+- 对标准 `\leaders` 而言，box 会对齐到外层 hbox 左边缘的整数倍位置，若首个 box 不能完整落入区域，就会直接跳到下一个对齐点，于是产生一个 box 宽度的空隙。当前回归中该 box 宽度约为 `1.99997pt`，正对应用户观察到的接缝 gap。
+- `\CJKunderline`（不带 `-`）没有同类问题，是因为标准 `\UL@leaders` 具备双侧 pixel 溢出，边界盒始终能被覆盖。
+
+## Missing Docs or Signals
+- memory only:
+  - 这次最值得记住的误判链路是：先怀疑 overlay / 驱动浮点误差，再经 PDF 坐标排除驱动，最后才回到 `\leaders` 对齐语义本身。此类“看起来像坐标误差，实则是 TeX 盒对齐条件”的案例适合保留在 memory 中。
+  - `\rlap` 叠加测试在下划线路径上并不总能代表真实 leaders 行为，尤其当命令内部还会插入 glue、leaders 与边界修剪时，不能把 overlay 视觉结果直接当根因证据。
+- promotion candidates:
+  - 可考虑在 `guides/` 或 `reference/` 增补一条 xeCJK/ulem 排障准则：凡是涉及 `\leaders`、pixel 溢出和边界修剪的下划线问题，先检查 leaders 区域是否覆盖边界盒，再讨论驱动层坐标误差。
+  - 可考虑在 `reference/` 中明确记录：标准 `\leaders` 会把 leader box 对齐到外层盒左边缘的整数倍位置，且只显示完整嵌入指定区域的 box；这对分析边界漏线和“少一个 box 宽度”的 gap 很关键。
+  - 可考虑在 `build-and-test` 或相关指南里补充一种诊断方法：通过解压 PDF content stream 提取线段坐标，可直接确认 gap 是来自 TeX 侧节点布局还是驱动输出误差。
+
+## Promotion Candidates
+- `memory`:
+  - 保留本次“从浮点误差假设转向 leaders 对齐语义”的纠偏过程，以及 `\rlap` 叠加测试误导调查方向的具体教训。
+- `guides/`:
+  - 增加 xeCJKfntef / ulem 下划线边界问题的排障清单，优先对比标准 `\UL@leaders` 与定制 leaders 变体的左右 pixel 扩展是否对称。
+  - 增加一条诊断建议：当 showbox 只能看到 glue/leaders 结构而难以解释肉眼 gap 时，直接抽取 PDF 线段坐标验证实际缺口位置。
+- `reference/`:
+  - 记录 `\leaders` 的对齐与“完整嵌入”语义，说明边界少一个 `\UL@pixel` 就可能导致整个首个 leader box 被跳过。
+
+## Follow-up
+- 后续若再修改 xeCJKfntef / ulem 的 leaders 逻辑，优先逐项核对：
+  - 首次 leaders 变体是否与标准 `\UL@leaders` 保持同样的双侧 pixel 扩展；
+  - 收尾修剪宏是否会与下一段的 leaders 起始区域发生叠加效应；
+  - 拼接多组与单组长串的盒宽和线段覆盖是否一致。
+- 若后续整理稳定文档，优先把“先验证 leaders 区域覆盖边界盒，再怀疑驱动误差”提升为 xeCJK 下划线类问题的通用诊断规则。

--- a/xeCJK/testfiles/fntef-underline01.lvt
+++ b/xeCJK/testfiles/fntef-underline01.lvt
@@ -1,0 +1,33 @@
+\input{regression-test}
+
+\documentclass{article}
+
+\usepackage{xeCJK,xeCJKfntef}
+\setCJKmainfont{FandolSong-Regular.otf}
+
+\showboxdepth=5
+\showboxbreadth=100
+
+\begin{document}
+
+\START
+
+\OMIT
+\setbox0=\hbox{\CJKunderline-{国国国}\CJKunderline-{国国国}}
+\setbox2=\hbox{\CJKunderline-{国国国国国国}}
+\TIMO
+
+\TEST{CJKunderline-dash~junction~width~matches~single~group}{
+  \typeout{2x3~ width:~ \the\wd0}
+  \typeout{1x6~ width:~ \the\wd2}
+  \ifdim\wd0=\wd2
+    \typeout{PASS:~ widths~ match}
+  \else
+    \typeout{FAIL:~ widths~ differ}
+  \fi
+  \showbox0
+}
+
+\END
+
+\end{document}

--- a/xeCJK/testfiles/fntef-underline01.tlg
+++ b/xeCJK/testfiles/fntef-underline01.tlg
@@ -1,0 +1,136 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+============================================================
+TEST 1: CJKunderline-dash~junction~width~matches~single~group
+============================================================
+2x3~ width:~ 60.0pt
+1x6~ width:~ 60.0pt
+PASS:~ widths~ match
+> \box...=
+\hbox(7.53+2.39996)x60.0
+.\rule(*+*)x0.0
+.\penalty 10000
+.\glue -0.99998
+.\leaders 11.99997
+..\hbox(0.0+2.39996)x1.99997
+...\hbox(0.4+0.0)x1.99997, shifted 2.39996
+....\special{pdf:bc [0]}
+....\rule(0.4+0.0)x1.99997
+....\special{pdf:ec}
+.\glue -0.99998
+.\kern -10.0
+.\hbox(7.53+1.58998)x10.0
+..\kern -0.00005
+..\kern 0.00005
+..\TU/FandolSong-Regular.otf(0)/m/n/10 国
+.\glue -0.99998
+.\leaders 1.99997 plus 0.96002
+..\hbox(0.0+2.39996)x1.99997
+...\hbox(0.4+0.0)x1.99997, shifted 2.39996
+....\special{pdf:bc [0]}
+....\rule(0.4+0.0)x1.99997
+....\special{pdf:ec}
+.\glue -0.99998
+.\rule(*+*)x0.0
+.\penalty 10000
+.\glue -0.99998
+.\leaders 11.99997
+..\hbox(0.0+2.39996)x1.99997
+...\hbox(0.4+0.0)x1.99997, shifted 2.39996
+....\special{pdf:bc [0]}
+....\rule(0.4+0.0)x1.99997
+....\special{pdf:ec}
+.\glue -0.99998
+.\kern -10.0
+.\hbox(7.53+1.58998)x10.0
+..\kern -0.00005
+..\kern 0.00005
+..\TU/FandolSong-Regular.otf(0)/m/n/10 国
+.\glue -0.99998
+.\leaders 1.99997 plus 0.96002
+..\hbox(0.0+2.39996)x1.99997
+...\hbox(0.4+0.0)x1.99997, shifted 2.39996
+....\special{pdf:bc [0]}
+....\rule(0.4+0.0)x1.99997
+....\special{pdf:ec}
+.\glue -0.99998
+.\rule(*+*)x0.0
+.\penalty 10000
+.\glue -0.99998
+.\leaders 10.99998
+..\hbox(0.0+2.39996)x1.99997
+...\hbox(0.4+0.0)x1.99997, shifted 2.39996
+....\special{pdf:bc [0]}
+....\rule(0.4+0.0)x1.99997
+....\special{pdf:ec}
+.\kern -10.0
+.\hbox(7.53+1.58998)x10.0
+..\kern -0.00005
+..\kern 0.00005
+..\TU/FandolSong-Regular.otf(0)/m/n/10 国
+.\glue 0.0 plus 0.96002
+.\rule(*+*)x0.0
+.\penalty 10000
+.\glue -0.99998
+.\leaders 11.99997
+..\hbox(0.0+2.39996)x1.99997
+...\hbox(0.4+0.0)x1.99997, shifted 2.39996
+....\special{pdf:bc [0]}
+....\rule(0.4+0.0)x1.99997
+....\special{pdf:ec}
+.\glue -0.99998
+.\kern -10.0
+.\hbox(7.53+1.58998)x10.0
+..\kern -0.00005
+..\kern 0.00005
+..\TU/FandolSong-Regular.otf(0)/m/n/10 国
+.\glue -0.99998
+.\leaders 1.99997 plus 0.96002
+..\hbox(0.0+2.39996)x1.99997
+...\hbox(0.4+0.0)x1.99997, shifted 2.39996
+....\special{pdf:bc [0]}
+....\rule(0.4+0.0)x1.99997
+....\special{pdf:ec}
+.\glue -0.99998
+.\rule(*+*)x0.0
+.\penalty 10000
+.\glue -0.99998
+.\leaders 11.99997
+..\hbox(0.0+2.39996)x1.99997
+...\hbox(0.4+0.0)x1.99997, shifted 2.39996
+....\special{pdf:bc [0]}
+....\rule(0.4+0.0)x1.99997
+....\special{pdf:ec}
+.\glue -0.99998
+.\kern -10.0
+.\hbox(7.53+1.58998)x10.0
+..\kern -0.00005
+..\kern 0.00005
+..\TU/FandolSong-Regular.otf(0)/m/n/10 国
+.\glue -0.99998
+.\leaders 1.99997 plus 0.96002
+..\hbox(0.0+2.39996)x1.99997
+...\hbox(0.4+0.0)x1.99997, shifted 2.39996
+....\special{pdf:bc [0]}
+....\rule(0.4+0.0)x1.99997
+....\special{pdf:ec}
+.\glue -0.99998
+.\rule(*+*)x0.0
+.\penalty 10000
+.\glue -0.99998
+.\leaders 10.99998
+..\hbox(0.0+2.39996)x1.99997
+...\hbox(0.4+0.0)x1.99997, shifted 2.39996
+....\special{pdf:bc [0]}
+....\rule(0.4+0.0)x1.99997
+....\special{pdf:ec}
+.\kern -10.0
+.\hbox(7.53+1.58998)x10.0
+..\kern -0.00005
+..\kern 0.00005
+..\TU/FandolSong-Regular.otf(0)/m/n/10 国
+.\kern -0.00017
+.\kern 0.00017
+! OK.
+<argument> ...IL:~ widths~ differ} \fi \showbox 0 
+l. ...}

--- a/xeCJK/xeCJK.dtx
+++ b/xeCJK/xeCJK.dtx
@@ -9495,7 +9495,10 @@ Copyright and Licence
 % \end{macro}
 %
 % \begin{macro}[int]{\xeCJK_ulem_var_leaders:}
-% 第一次画下划线时，不需要向左平移 \tn{UL@pixel}，让左侧有间距。
+% 第一次画下划线时，向左平移 \tn{UL@pixel}，使 \tn{leaders} 对齐能覆盖接缝处的
+% 边界盒。因为 $\tn{UL@pixel} = 0.5 \times \text{box\_width}$，所以左侧不会多画出
+% 额外的 leader 盒子。此处使用与标准 \tn{UL@leaders} 一致的双侧 pixel 偏移，
+% 以修复 \cs{CJKunderline-} 两组拼接时的下划线间隙。
 %    \begin{macrocode}
 \cs_new_protected:Npn \xeCJK_ulem_leaders:
   { \@@_ulem_var_leaders: }
@@ -9504,7 +9507,8 @@ Copyright and Licence
     \scan_stop:
     \skip_if_eq:nnF { \UL@skip } { \c_zero_skip }
       {
-        \UL@leadtype \skip_horizontal:n { \UL@skip + \UL@pixel }
+        \skip_horizontal:n { - \UL@pixel }
+        \UL@leadtype \skip_horizontal:n { \UL@skip + 2\UL@pixel }
         \skip_horizontal:n { - \UL@pixel }
         \cs_gset_eq:NN \@@_ulem_var_leaders: \xeCJK_ulem_leaders:
       }


### PR DESCRIPTION
## Summary

- 修复 `\CJKunderline-` 两组拼接时约 2pt 的下划线间隙
- 根因: `xeCJKfntef` 的 subtract 模式首次 leaders 变体 (`\xeCJK_ulem_var_leaders:`) 缺少左侧 `-\UL@pixel` 偏移，导致 `\leaders` 对齐时在接缝处跳过一个 leader box
- 修复方式: 使首次 leaders 变体与标准 `\UL@leaders` 保持一致的双侧 pixel 溢出语义

## 根因分析

`\CJKunderline-` 使用 subtract 模式，其中 `\xeCJK_ulem_var_leaders:` 在第一次绘制下划线时只做了右侧 pixel 溢出而省略了左侧。当两组 `\CJKunderline-` 拼接时：

1. 上一组的 `\@@_ulem_right_skip:` 修剪掉右端的 `\UL@pixel`
2. 下一组的首次 leaders 变体缺少左侧 `-\UL@pixel`
3. 合计缺失 `2 × \UL@pixel = box_width ≈ 2pt`
4. `\leaders` 对齐要求 box 完整嵌入区域才显示，于是跳过一个 leader box

修复后首次变体的结构与标准 `\UL@leaders` 一致：`\hskip(-pixel) \UL@leadtype \hskip(skip+2*pixel) \hskip(-pixel)`。由于 `\UL@pixel = 0.5 × box_width`，左侧扩展不会在首字左边界之外多画出额外 leader box。

## Test plan

- [x] 新增 `fntef-underline01` 回归测试：比较 `2×3` 与 `1×6` 的 `\CJKunderline-` 宽度一致性 + `\showbox` 节点结构基线
- [x] xeCJK 全量 `l3build check` 12/12 通过
- [x] PDF content stream 线段坐标提取确认接缝处无间隙

Closes #531