### PR TITLE
doc(ctex): 补充3处 `\ref` 命令遗漏的 `~`, 修改一处右括号使用半角的笔误

### DIFF
--- a/ctex/ctex.dtx
+++ b/ctex/ctex.dtx
@@ -1192,7 +1192,7 @@ Copyright and Licence
 %     zihao = <-4|5|false>
 %   \end{syntax}
 %   将文章默认字号（\tn{normalsize}）设置为小四号字或五号字，
-%   具体情况见表 \ref{tab:fontsize}。\opt{false} 禁用本功能。
+%   具体情况见表~\ref{tab:fontsize}。\opt{false} 禁用本功能。
 %   本选项可以用于四个 \CTeX\ 文档类和 \pkg{ctex} 宏包，
 %   也可以用于 \pkg{ctexsize} 宏包。
 %

--- a/ctex/ctex.dtx
+++ b/ctex/ctex.dtx
@@ -1594,7 +1594,7 @@ Copyright and Licence
 % \subsection{页面格式设置与汉化}
 % \label{subs:pagestyle}
 %
-% 页面格式设置与汉化的功能（及章节标题样式设置功能，见第 \ref{sec:secstyle} 节）^^A
+% 页面格式设置与汉化的功能（及章节标题样式设置功能，见第 \ref{sec:secstyle}~节）^^A
 % 由 \pkg{ctexheading} 宏包完成。加载该宏包时，或者使用 \CTeX\ 文档类时，^^A
 % 或者是使用 \pkg{ctex} 宏包并设定选项 \opt{heading = true} 时，相关功能被激活。
 % 此时，整个文档的页面格式（page style）被设定为 |headings|，即相当于设置了
@@ -1694,7 +1694,7 @@ Copyright and Licence
 %
 % \CTeX\ 宏集对 \LaTeX\ 的标准文档类（\cls{article}、\cls{report}、
 % \cls{book}）和 \cls{beamer} 进行了章节标题样式设置功能的扩充。
-% 章节标题样式设置功能（及页面格式设置与汉化功能，见第 \ref{subs:pagestyle} 节）^^A
+% 章节标题样式设置功能（及页面格式设置与汉化功能，见第 \ref{subs:pagestyle}~节）^^A
 % 由 \pkg{ctexheading} 宏包完成。加载该宏包时，或者使用 \CTeX\ 文档类时，^^A
 % 或者是使用 \pkg{ctex} 宏包并设定选项 \opt{heading = true} 时，相关功能被激活。
 % 其中，独立使用 \pkg{ctexheading} 宏包时，本节介绍各选项的默认值与指定
@@ -1704,7 +1704,7 @@ Copyright and Licence
 %
 % \changes{v2.0}{2015/03/21}{\tn{CTEXsetup}, \tn{CTEXoptions} 是过时命令。}
 %
-% 章节标题的样式选项是分层设置的。顶层的选项是章节标题名称（例如 |section|)，
+% 章节标题的样式选项是分层设置的。顶层的选项是章节标题名称（例如 |section|），
 % 次一层的选项是章节标题的样式（例如 \opt{nameformat}）。章节标题名称包括
 % |part|, |chapter|, |section|, |subsection|, |subsubsection|, |paragraph|,
 % |subparagraph|。可用的样式选项包括：

--- a/ctex/ctex.dtx
+++ b/ctex/ctex.dtx
@@ -578,15 +578,15 @@ Copyright and Licence
 %
 % \fi
 %
-% \changes{v2.0}{2014/03/06}{应用 \LaTeXiii{} 重新整理代码。}
+% \changes{v2.0}{2014/03/06}{应用 \LaTeXiii\ 重新整理代码。}
 % \changes{v2.6.0}{2026/05/04}{文档字体统一为 Noto CJK 系列（\#686）。}
 % \changes{v2.0}{2014/03/12}{删除 \file{c19gbsn.fd} 和 \file{c19gkai.fd}。}
 % \changes{v2.1}{2015/05/18}{将章节标题设置功能提取到可以独立使用的宏包
 %   \pkg{ctexheading} 中。}
 % \changes{v2.2}{2015/06/24}{不再依赖 \pkg{etoolbox} 宏包。}
 % \changes{v2.4}{2015/02/19}{加强 \pkg{beamer} 宏包支持。}
-% \changes{v2.4.12}{2018/01/13}{同步 \LaTeXiii{} 2017/12/16。}
-% \changes{v2.4.15}{2019/03/23}{同步 \LaTeXiii{} 2019/03/05。}
+% \changes{v2.4.12}{2018/01/13}{同步 \LaTeXiii\ 2017/12/16。}
+% \changes{v2.4.15}{2019/03/23}{同步 \LaTeXiii\ 2019/03/05。}
 % \changes{v2.5.1}{2020/05/02}{\pkg{zhconv} 更名为 \pkg{ctex-zhconv}。}
 %
 % \CheckSum{6916}
@@ -609,17 +609,17 @@ Copyright and Licence
 %
 % \GetFileId{ctex.sty}
 %
-% \title{\bfseries \CTeX{} 宏集手册}
+% \title{\bfseries \CTeX\ 宏集手册}
 % \author{\href{http://www.ctex.org}{CTEX.ORG}}
 % \date{\filedate\qquad\fileversion\thanks{\ctexkitrev{\ExplFileVersion}.}}
 % \maketitle
 %
 % \begin{abstract}
-% \CTeX{} 宏集是面向中文排版的通用 \LaTeX{} 排版框架，为中文 \LaTeX{} 文档
+% \CTeX\ 宏集是面向中文排版的通用 \LaTeX\ 排版框架，为中文 \LaTeX\ 文档
 % 提供了汉字输出支持、标点压缩、字体字号命令、标题文字汉化、中文版式调整、数字
 % 日期转换等支持功能，可适应论文、报告、书籍、幻灯片等不同类型的中文文档。
 %
-% \CTeX{} 宏集支持 \LaTeX、\pdfLaTeX、\XeLaTeX、\LuaLaTeX、\upLaTeX{} 等多种不同
+% \CTeX\ 宏集支持 \LaTeX、\pdfLaTeX、\XeLaTeX、\LuaLaTeX、\upLaTeX\ 等多种不同
 % 的编译方式，并为它们提供了统一的界面。主要功能由宏包 \pkg{ctex} 以及中文文档类
 % \cls{ctexart}、\cls{ctexrep}、\cls{ctexbook} 和 \cls{ctexbeamer} 实现。
 % \end{abstract}
@@ -635,7 +635,7 @@ Copyright and Licence
 %
 % \subsection*{历史}
 %
-% \CTeX{} 宏集的源头有两个：一是王磊编写的 \cls{cjkbook} 文档类，二是吴凌云编写的
+% \CTeX\ 宏集的源头有两个：一是王磊编写的 \cls{cjkbook} 文档类，二是吴凌云编写的
 % \file{GB.cap}。
 % 这些工作没有经过认真系统的设计，也没有用户文档，不利于维护和改进。
 %
@@ -645,64 +645,64 @@ Copyright and Licence
 %
 % 2009 年 5 月，我们在 Google Code 建立了 ctex-kit 项目^^A
 % \footnote{\nolinkurl{http://code.google.com/p/ctex-kit/}，该链接现已失效。}，
-% 对 \pkg{ctex} 宏包及相关脚本进行了整合，并加入了对 \XeTeX{} 引擎的支持。
+% 对 \pkg{ctex} 宏包及相关脚本进行了整合，并加入了对 \XeTeX\ 引擎的支持。
 % 在开发新版本时，考虑到合作开发和调试的方便，我们放弃了 \pkg{doc} 和 \pkg{DocStrip}，
 % 采取了直接编写宏包代码的方式。
 %
-% 2014 年 3 月，为了适应 \LaTeX{} 的最新发展，特别是 \LaTeXiii{} 的逐渐成熟，李清用
-% \LaTeXiii{} 重构了整个宏包的代码，并重新使用 \pkg{doc} 和 \pkg{DocStrip} 工具进行代码
-% 的管理，升级版本号为 2.0，并改称 \CTeX{} 宏集。
+% 2014 年 3 月，为了适应 \LaTeX\ 的最新发展，特别是 \LaTeXiii\ 的逐渐成熟，李清用
+% \LaTeXiii\ 重构了整个宏包的代码，并重新使用 \pkg{doc} 和 \pkg{DocStrip} 工具进行代码
+% 的管理，升级版本号为 2.0，并改称 \CTeX\ 宏集。
 %
 % 2015 年 3 月，由于 Google Code 即将停止服务，ctex-kit 项目迁移至
 % \href{https://github.com/CTeX-org/ctex-kit}{GitHub}^^A
 % \footnote{\url{https://github.com/CTeX-org/ctex-kit}}。
 %
-% 最初，Knuth 在设计开发 \TeX{} 的时候没有考虑到多国文字支持，特别是对多字节的中日韩
-% 表意文字的支持。这使得 \TeX{} 以至后来的 \LaTeX{} 对中文的支持一直不是很好。即使在
-% \pkg{CJK} 宏包解决了中文字符处理的问题以后，中文用户使用 \LaTeX{} 仍然要面对许
+% 最初，Knuth 在设计开发 \TeX\ 的时候没有考虑到多国文字支持，特别是对多字节的中日韩
+% 表意文字的支持。这使得 \TeX\ 以至后来的 \LaTeX\ 对中文的支持一直不是很好。即使在
+% \pkg{CJK} 宏包解决了中文字符处理的问题以后，中文用户使用 \LaTeX\ 仍然要面对许
 % 多困难。
 % 这些困难里，以章节标题的中文化为最。由于中文和西文书写习惯的差异，用户很难使用标准
 % 文档类中的代码结构来表达中文标题。于是，用户不得不对标准文档类做较大的修改。
 % 除此之外，日期格式、首行缩进、中文字号和字距等细节问题，也需要精细的调校。
-% 我们设计 \CTeX{} 宏集的目的之一就是解决这些 \LaTeX{} 文档的汉化难题。
+% 我们设计 \CTeX\ 宏集的目的之一就是解决这些 \LaTeX\ 文档的汉化难题。
 %
-% 另一方面，随着 \TeX{} 引擎和 \LaTeX{} 宏包的不断发展，\LaTeX{} 的中文支持方式从早期的
+% 另一方面，随着 \TeX\ 引擎和 \LaTeX\ 宏包的不断发展，\LaTeX\ 的中文支持方式从早期的
 % 专用系统（如 \pkg{CCT}）发展为适用于不同引擎的多种方式^^A
-% \footnote{比如：\pdfTeX{} 引擎下的 \pkg{CJK}、\pkg{zhmCJK}宏包，
-% \XeTeX{} 引擎下的 \pkg{xeCJK} 宏包和 \LuaTeX{} 引擎下的 \pkg{LuaTeX-ja} 宏包。}。
+% \footnote{比如：\pdfTeX\ 引擎下的 \pkg{CJK}、\pkg{zhmCJK}宏包，
+% \XeTeX\ 引擎下的 \pkg{xeCJK} 宏包和 \LuaTeX\ 引擎下的 \pkg{LuaTeX-ja} 宏包。}。
 % 这些方式的适用情况和使用方式有不少细节上的差异，同时操作系统的不同、语言环境的不同等
-% 客观情况又进一步带来了更多的细节差异。我们设计 \CTeX{} 宏集的另一个主要目的就是
+% 客观情况又进一步带来了更多的细节差异。我们设计 \CTeX\ 宏集的另一个主要目的就是
 % 尽可能消除这些差异带来的影响，使用户能够以一个统一的接口来使用不同的中文支持方式，
 % 使得同一份文档能够在不同环境下交换使用。
 %
-% \CTeX{} 宏集的许多实现细节离不开热心朋友们在 \nolinkurl{bbs.ctex.org} 论坛^^A
-% \footnote{2018 年，\CTeX{} 论坛因故无限期关闭，此链接现已失效。}^^A
+% \CTeX\ 宏集的许多实现细节离不开热心朋友们在 \nolinkurl{bbs.ctex.org} 论坛^^A
+% \footnote{2018 年，\CTeX\ 论坛因故无限期关闭，此链接现已失效。}^^A
 % 上的讨论，在此对参与讨论的朋友们表示感谢。
 %
 % \subsection*{关于宏集名字的说明}
 %
-% \CTeX{} 之名是英文单词 China（中国）或 Chinese（中文）的首字母“C”与 “\TeX{}”
+% \CTeX\ 之名是英文单词 China（中国）或 Chinese（中文）的首字母“C”与 “\TeX”
 % 结合而成的。在纯文本环境下，该名字应写作“CTeX”。
 %
-% \CTeX{} 宏集是由 \href{https://github.com/CTeX-org}{\CTeX{} 社区}发起并维护的
-% \LaTeX{} \emph{宏包和文档类的集合}。
-% 社区另有发布名为 \href{http://www.ctex.org/CTeX}{\CTeX{} 套装}^^A
-% 的 \TeX{} 发行版，与本文档所述的 \CTeX{} 宏集并非是同一事物。
+% \CTeX\ 宏集是由 \href{https://github.com/CTeX-org}{\CTeX\ 社区}发起并维护的
+% \LaTeX\ \emph{宏包和文档类的集合}。
+% 社区另有发布名为 \href{http://www.ctex.org/CTeX}{\CTeX\ 套装}^^A
+% 的 \TeX\ 发行版，与本文档所述的 \CTeX\ 宏集并非是同一事物。
 %
 % \pkg{ctex} 则是本宏集中的 \pkg{ctex.sty} 的名字。这一完全小写的名称，在过去
-% 也被用来指代整个 \CTeX{} 宏集，不过现在则特指 \pkg{ctex.sty} 这一宏包。
+% 也被用来指代整个 \CTeX\ 宏集，不过现在则特指 \pkg{ctex.sty} 这一宏包。
 % 在不引起歧义的情况下，它也可以沿用过去的习惯，代指整个宏集。
 %
 % \section{简明教程}
 %
-% \subsection{\CTeX{} 宏集的组成}
+% \subsection{\CTeX\ 宏集的组成}
 %
-% 为了适应用户不同的需求，我们将 \CTeX{} 宏集的主要功能设计安排在四个中文文档类和
+% 为了适应用户不同的需求，我们将 \CTeX\ 宏集的主要功能设计安排在四个中文文档类和
 % 三个宏包当中，具体的组成见表~\ref{tab:ctex}。
 %
 % \begin{table}[htbp]
 % \centering
-% \caption{\CTeX{} 宏集的组成}\label{tab:ctex}
+% \caption{\CTeX\ 宏集的组成}\label{tab:ctex}
 % \begin{tabularx}{\linewidth}{llX}
 % \toprule
 %   类别   & 文件 & 说明 \\
@@ -719,23 +719,23 @@ Copyright and Licence
 %   宏包   & \file{ctex.sty}        & 提供全部功能，但\emph{默认不开启章节标题设置功能}，
 %                                     需要使用 \opt{heading} 选项来开启 \\
 %          & \file{ctexsize.sty}    & 定义和调整中文字号，可以在 \pkg{ctex} 宏包
-%                                     或 \CTeX{} 中文文档类之外单独调用 \\
+%                                     或 \CTeX\ 中文文档类之外单独调用 \\
 %          & \file{ctexheading.sty} & 提供章节标题设置功能（见 \ref{sec:secstyle}
-%                                     节），可以在 \pkg{ctex} 宏包或 \CTeX{} 中文
+%                                     节），可以在 \pkg{ctex} 宏包或 \CTeX\ 中文
 %                                     文档类之外单独调用 \\
 % \bottomrule
 % \end{tabularx}
 % \end{table}
 %
-% \subsection{\CTeX{} 宏集的安装和更新}
+% \subsection{\CTeX\ 宏集的安装和更新}
 % \label{subsec:easy-ins}
-% 最常见的 \TeX{} 发行版（\TeXLive{} 和 \MiKTeX{}）已收录 \CTeX{} 宏集及其依赖的宏包和宏集。
+% 最常见的 \TeX\ 发行版（\TeXLive\ 和 \MiKTeX）已收录 \CTeX\ 宏集及其依赖的宏包和宏集。
 % \footnote{\pkg{zhmCJK} 宏包是个例外。当用户显式指定选项 \opt{zhmap = zhmCJK} 时，^^A
-% \CTeX{} 宏集依赖它。由于，它没有被 \TeXLive{} 和 \MiKTeX{} 收录，用户可能需要遵照其说明文档
-% 自行安装。}如果本地安装 \TeXLive{} 或 \MiKTeX{} 不是完整版本，则可能需要通过这
+% \CTeX\ 宏集依赖它。由于，它没有被 \TeXLive\ 和 \MiKTeX\ 收录，用户可能需要遵照其说明文档
+% 自行安装。}如果本地安装 \TeXLive\ 或 \MiKTeX\ 不是完整版本，则可能需要通过这
 % 两个发行版提供的\emph{包管理器}来安装宏包。
 %
-% \TeXLive{} 的包管理器是 tlmgr（\TeXLive{} Manager）。用户可以在系统命令行中^^A
+% \TeXLive\ 的包管理器是 tlmgr（\TeXLive\ Manager）。用户可以在系统命令行中^^A
 % \footnote{Windows 系统的命令行是 CMD 命令提示符，你可以使用 Win + R 组合键
 % 打开“运行”对话框，然后输入 cmd 确认打开命令提示符窗口。}执行
 % \begin{frameverb}
@@ -748,47 +748,47 @@ Copyright and Licence
 % \begin{frameverb}
 %   tlmgr install ctex
 % \end{frameverb}
-% 来安装 \CTeX{} 宏集^^A
+% 来安装 \CTeX\ 宏集^^A
 % \footnote{*nix 用户可能需要超级用户权限（sudo）才能正确安装宏集。}。
 %
-% \MiKTeX{} 通常会在缺失宏包时自动完成安装。如需手动安装，可以使用其管理维护
-% 工具 \MiKTeX{} Console。用户可以打开管理器，连接上远程仓库之后，在“Package”
+% \MiKTeX\ 通常会在缺失宏包时自动完成安装。如需手动安装，可以使用其管理维护
+% 工具 \MiKTeX\ Console。用户可以打开管理器，连接上远程仓库之后，在“Package”
 % 选项卡中搜索“ctex”并安装即可。
-% 也可以使用 mpm（\MiKTeX{} Package Manager），在命令行执行
+% 也可以使用 mpm（\MiKTeX\ Package Manager），在命令行执行
 % \begin{frameverb}
 %   mpm --admin --install=ctex
 % \end{frameverb}
-% 来安装 \CTeX{} 宏集。
+% 来安装 \CTeX\ 宏集。
 %
-% 若希望了解 \CTeX{} 宏集具体的依赖情况或手工安装宏集的方法，
+% 若希望了解 \CTeX\ 宏集具体的依赖情况或手工安装宏集的方法，
 % 请参阅第 \ref{sec:dep-ins}~节。
 %
 % 当我们将宏集的新版本发布于 CTAN，且为发行版的远程仓库更新后，用户就可以在本地
 % 通过包管理器获取新版本。
 %
-% 对于 \TeXLive{}，可以在 tlmgr 的图形界面点击“更新全部已安装的”按钮或者在
+% 对于 \TeXLive，可以在 tlmgr 的图形界面点击“更新全部已安装的”按钮或者在
 % 命令行执行
 % \begin{frameverb}
 %   tlmgr update --all
 % \end{frameverb}
 % 来完整更新已安装的宏包。
 %
-% 对于 \MiKTeX{}，在 \MiKTeX{} Console 中找到“Updates”选项卡，检查更新后即可
+% 对于 \MiKTeX，在 \MiKTeX\ Console 中找到“Updates”选项卡，检查更新后即可
 % 选择升级宏包。也可以使用 mpm，在命令行执行
 % \begin{frameverb}
 %   mpm --admin --update
 % \end{frameverb}
 % 来进行更新。
 %
-% \subsection{使用 \CTeX{} 文档类}
+% \subsection{使用 \CTeX\ 文档类}
 %
 % \emph{如果用户需要在三个标准文档类或 \cls{beamer} 的基础上添加中文及版式的支持，
-% 我们建议用户使用 \CTeX{} 宏集提供的四个中文文档类。}
+% 我们建议用户使用 \CTeX\ 宏集提供的四个中文文档类。}
 %
-% \CTeX{} 宏集提供了四个中文文档类：\cls{ctexart}、\cls{ctexrep}、\cls{ctexbook} 和
-% \cls{ctexbeamer}，分别对应 \LaTeX{} 的标准文档类 \cls{article}、\cls{report}、
+% \CTeX\ 宏集提供了四个中文文档类：\cls{ctexart}、\cls{ctexrep}、\cls{ctexbook} 和
+% \cls{ctexbeamer}，分别对应 \LaTeX\ 的标准文档类 \cls{article}、\cls{report}、
 % \cls{book} 和 \cls{beamer}。使用它们的时候，需要将涉及到的所有源文件使用 UTF-8
-% 编码保存\footnote{使用 (pdf)\LaTeX{} 时也能够使用 GBK 编码，但不推荐。（见
+% 编码保存\footnote{使用 (pdf)\LaTeX\ 时也能够使用 GBK 编码，但不推荐。（见
 % \ref{subs:encoding}~节）}。
 %
 % \begin{ctexexam}
@@ -822,33 +822,33 @@ Copyright and Licence
 % \emph{用户在使用非标准文档类及 \cls{beamer} 时，如果需要添加中文及版式的支持，
 % 则可以使用 \pkg{ctex} 宏包。}
 %
-% 对于建立在 \LaTeX{} 标准文档类之上开发的文档类，在使用 \pkg{ctex} 宏包时
+% 对于建立在 \LaTeX\ 标准文档类之上开发的文档类，在使用 \pkg{ctex} 宏包时
 % 加上 \opt{heading} 选项，可以将章节标题设置为中文风格。
 % \begin{ctexexam}
 %   \documentclass{ltxdoc}
 %   \usepackage[heading = true]{ctex}
 %   \begin{document}
 %   \section{简介}
-%   章节标题中文化的 \LaTeX{} 手册。
+%   章节标题中文化的 \LaTeX\ 手册。
 %   \end{document}
 % \end{ctexexam}
 %
 % \section{宏包选项与 \tn{ctexset} 命令}
 % \label{sec:options}
 %
-% \CTeX{} 宏集已经尽可能就中文的行文和版式习惯做了调整和配置，通常而言，这些配置
-% 已经够用。因此，除非必要，我们不建议普通用户修改这些默认配置。如果你认为 \CTeX{} 宏集
+% \CTeX\ 宏集已经尽可能就中文的行文和版式习惯做了调整和配置，通常而言，这些配置
+% 已经够用。因此，除非必要，我们不建议普通用户修改这些默认配置。如果你认为 \CTeX\ 宏集
 % 的默认配置还可以完善，可以在项目主页上^^A
 % \href{https://github.com/CTeX-org/ctex-kit/issues}{提交 issue}，
 % 向我们反映，我们会酌情在后续版本中予以改进。
 %
-% 不过，\CTeX{} 宏集也提供了一系列选项。用户可以使用这些选项来控制 \CTeX{} 宏集的行为。
+% 不过，\CTeX\ 宏集也提供了一系列选项。用户可以使用这些选项来控制 \CTeX\ 宏集的行为。
 % 按形式分类，这些选项有的以传统的方式提供，有的以 \meta{key}|=|\meta{value} 的形式提供。
 % 按指定位置分类，这些选项又可以分为以下三类：
 % \begin{itemize}
-% \item 名字后带有 \rexptarget\rexpstar{} 号的选项，只能作为宏包/文档类选项，需要
+% \item 名字后带有 \rexptarget\rexpstar\ 号的选项，只能作为宏包/文档类选项，需要
 %   在引入宏包/文档类的时候指定；
-% \item 名字后带有 \exptarget\expstar{} 号的选项，只能通过 \CTeX{} 宏集提供的
+% \item 名字后带有 \exptarget\expstar\ 号的选项，只能通过 \CTeX\ 宏集提供的
 %   用户接口 \tn{ctexset} 来设定；
 % \item 名字后不带有特殊符号的选项，既可以作为宏包/文档类选项，也可以通过
 %   \tn{ctexset} 来设定。
@@ -859,7 +859,7 @@ Copyright and Licence
 %   \begin{syntax}
 %     \tn{ctexset} \Arg{键值列表}
 %   \end{syntax}
-% 是 \CTeX{} 宏集的通用控制命令，用来在宏包载入后控制宏包的各项功能。
+% 是 \CTeX\ 宏集的通用控制命令，用来在宏包载入后控制宏包的各项功能。
 % \tn{ctexset} 的参数是一个键值列表，以通用的接口完成各项设置。
 % \end{function}
 %
@@ -873,7 +873,7 @@ Copyright and Licence
 %   }
 % \end{ctexexam}
 %
-% \tn{ctexset} 采用 \LaTeXiii{} 风格的键值设置，支持不同类型的选项与层次化的选
+% \tn{ctexset} 采用 \LaTeXiii\ 风格的键值设置，支持不同类型的选项与层次化的选
 % 项设置，相关示例见 \ref{sec:secstyle}~节。
 %
 % \section{编译方式、编码与中文字库}
@@ -882,14 +882,14 @@ Copyright and Licence
 % \subsection{编译方式}
 % \label{subs:compile}
 %
-% \CTeX{} 宏集会根据用户使用的编译方式\footnote{\LaTeX、\pdfLaTeX、\XeLaTeX、
-% \LuaLaTeX{} 及 \upLaTeX。}，在底层选择不同的中文支持方式（见
+% \CTeX\ 宏集会根据用户使用的编译方式\footnote{\LaTeX、\pdfLaTeX、\XeLaTeX、
+% \LuaLaTeX\ 及 \upLaTeX。}，在底层选择不同的中文支持方式（见
 % 表~\ref{tab:chinese-support}）。
 %
 % \begin{table}[htbp]
 % \centering
 % \begin{threeparttable}
-% \caption{\CTeX{} 宏集的中文支持方式}
+% \caption{\CTeX\ 宏集的中文支持方式}
 % \label{tab:chinese-support}
 % \begin{tabular}{*6c}
 %   \toprule
@@ -899,26 +899,26 @@ Copyright and Licence
 %   \bottomrule
 % \end{tabular}
 % \begin{tablenotes}
-% \item[*] p\LaTeX-ng（或称 \ApLaTeX）与 \upLaTeX{} 兼容。使用 p\LaTeX-ng 编译
-% 时，\pkg{ctex} 采用与 \upLaTeX{} 相同的设置。
+% \item[*] p\LaTeX-ng（或称 \ApLaTeX）与 \upLaTeX\ 兼容。使用 p\LaTeX-ng 编译
+% 时，\pkg{ctex} 采用与 \upLaTeX\ 相同的设置。
 % \end{tablenotes}
 % \end{threeparttable}
 % \end{table}
 %
-% 不同的编译方式和中文支持方式会在一定程度上影响 \CTeX{} 宏集的行为，比如宏包对
+% 不同的编译方式和中文支持方式会在一定程度上影响 \CTeX\ 宏集的行为，比如宏包对
 % 文档编码、字体选择、空格、标点等的处理。具体细节将在本文档后续内容中进行阐述。
 %
 % \subsection{中文编码}
 % \label{subs:encoding}
 %
 % \begin{function}[rEXP,updated=2019-11-10]{GBK, UTF8}
-%   指明编写文档时使用的编码。\CTeX{} 宏集无法检测文档源文件的实际编码格式，因此需要
+%   指明编写文档时使用的编码。\CTeX\ 宏集无法检测文档源文件的实际编码格式，因此需要
 %   用户通过选项声明。如果没有显式指定，则默认采用 UTF-8 编码。
 %
-%   使用 \XeLaTeX{}、\LuaLaTeX{} 或 \upLaTeX{} 编译时，\CTeX{} 宏集强制使用
-%   UTF-8 编码，此时 \opt{GBK} 选项无效；使用 (pdf)\LaTeX{} 编译时，
-%   \CTeX{} 宏集默认使用 UTF-8 编码，但用户也可以显式声明 \opt{GBK} 选项，
-%   使 \CTeX{} 宏集按 GBK 编码处理文档。
+%   使用 \XeLaTeX、\LuaLaTeX\ 或 \upLaTeX\ 编译时，\CTeX\ 宏集强制使用
+%   UTF-8 编码，此时 \opt{GBK} 选项无效；使用 (pdf)\LaTeX\ 编译时，
+%   \CTeX\ 宏集默认使用 UTF-8 编码，但用户也可以显式声明 \opt{GBK} 选项，
+%   使 \CTeX\ 宏集按 GBK 编码处理文档。
 %
 %   用户需要\emph{保证编译方式、源文件编码、宏包编码选项三者一致}。
 %
@@ -929,16 +929,16 @@ Copyright and Licence
 % \subsection{中文字库}
 % \label{subs:options-CJK-font}
 %
-% 以往，为 \LaTeX{} 文档配置中文支持是一件相当繁琐的事情。默认情况下，
-% \CTeX{} 宏集能自动检测用户使用的编译方式（参见 \ref{subs:compile}~节）和
-% 操作系统\footnote{\CTeX{} 宏集现在能够识别 macOS 及 Windows 系统，
+% 以往，为 \LaTeX\ 文档配置中文支持是一件相当繁琐的事情。默认情况下，
+% \CTeX\ 宏集能自动检测用户使用的编译方式（参见 \ref{subs:compile}~节）和
+% 操作系统\footnote{\CTeX\ 宏集现在能够识别 macOS 及 Windows 系统，
 % 并将其他系统统一归为 Linux。}，选择合适的底层支持和字库，从而简化配置过程。
 % 自动配置的情况参见表~\ref{tab:default-font-select}。
 %
 % \begin{table}[htbp]
 % \centering
 % \begin{threeparttable}
-% \caption{\CTeX{} 宏集自动配置字体策略}
+% \caption{\CTeX\ 宏集自动配置字体策略}
 % \label{tab:default-font-select}
 % \begin{tabular}{*{5}{c}}
 %   \toprule
@@ -964,13 +964,13 @@ Copyright and Licence
 %              & \makecell{\pkg{CJK} + \pkg{zhmetrics}\\中易字库 + 微软雅黑\tnote{6}}
 %              & 不可用 \\
 %   \cmidrule(lr){1-5}
-%   \makecell{\LaTeX{} + \\\dvipdfmx}
+%   \makecell{\LaTeX\ + \\\dvipdfmx}
 %              & 不可用
 %              & \makecell{\pkg{CJK} + \pkg{zhmetrics}\\华文字库 + 苹方}
 %              & \makecell{\pkg{CJK} + \pkg{zhmetrics}\\中易字库 + 微软雅黑\tnote{6}}
 %              & \makecell{\pkg{CJK} + \pkg{zhmetrics}\\Fandol 字库} \\
 %   \cmidrule(lr){1-5}
-%   \makecell{\upLaTeX{} + \\\dvipdfmx}
+%   \makecell{\upLaTeX\ + \\\dvipdfmx}
 %              & 不可用
 %              & \makecell{\pkg{zhmetrics-uptex}\\华文字库 + 苹方}
 %              & \makecell{\pkg{zhmetrics-uptex}\\中易字库 + 微软雅黑}
@@ -983,15 +983,15 @@ Copyright and Licence
 %   \item [3] 仅支持 Windows Vista 及以后的 Windows 操作系统。
 %   \item [4] 由马起园、苏杰、黄晨成等人开发的开源中文字体，
 %     参见：\url{https://www.ctan.org/pkg/fandol}。
-%   \item [5] \LuaLaTeX{} 编译时使用 \pkg{LuaTeX-ja} 宏包。对此，
+%   \item [5] \LuaLaTeX\ 编译时使用 \pkg{LuaTeX-ja} 宏包。对此，
 %     第 \ref{sec:lualatex-chinese}~节有特别说明。
 %   \item [6] 微软雅黑字体并不总是有效，这和选项 \opt{zhmap} 的取值有关。
 % \end{tablenotes}
 % \end{threeparttable}
 % \end{table}
 %
-% 通常，由 \CTeX{} 宏集进行的自动配置已经足够使用，无需用户手工干预；但
-% 是 \CTeX{} 仍然提供了一系列选项，供在 \CTeX{} 的自动选择机制因为
+% 通常，由 \CTeX\ 宏集进行的自动配置已经足够使用，无需用户手工干预；但
+% 是 \CTeX\ 仍然提供了一系列选项，供在 \CTeX\ 的自动选择机制因为
 % 意外情况失效，或者在用户有特殊需求的情况下使用。\emph{除非必要，用户不
 % 应使用这些选项。}
 %
@@ -999,7 +999,7 @@ Copyright and Licence
 %   \begin{syntax}
 %     zhmap = <\TTF|zhmCJK>
 %   \end{syntax}
-%   指定字体映射机制。本选项只在使用 (pdf)\LaTeX{} 编译时有意义。
+%   指定字体映射机制。本选项只在使用 (pdf)\LaTeX\ 编译时有意义。
 % \end{function}
 % \begin{optdesc}
 %   \item[true] 这是该选项的默认值。^^A
@@ -1008,8 +1008,8 @@ Copyright and Licence
 %   命令映射到 \file{.ttf} 文件。
 %
 %   \item[false] 使用传统的 CJK 字库（Type 1）^^A
-%   \footnote{使用 (pdf)\LaTeX{} 编译时，如果需要使用自定义的字体映射文件（比如需要
-%     使用 \LaTeX{} + Dvips 编译），或者希望使用 Type1 字库，请禁用本选项。为此，你
+%   \footnote{使用 (pdf)\LaTeX\ 编译时，如果需要使用自定义的字体映射文件（比如需要
+%     使用 \LaTeX\ + Dvips 编译），或者希望使用 Type1 字库，请禁用本选项。为此，你
 %     可能需要安装 CJK 字体。参考 \pkg{zhmetrics} 宏包提供的脚本
 %     \href{https://github.com/CTeX-org/ctex-kit/blob/master/zhmetrics/CTeXFonts.lua}
 %     {\file{CTeXFonts.lua}}。}。
@@ -1024,13 +1024,13 @@ Copyright and Licence
 %   \begin{syntax}
 %     fontset = <adobe|fandol|founder|hanyi|mac|macnew|macold|ubuntu|windows|none|...>
 %   \end{syntax}
-%   指定 \CTeX{} 宏集加载的字库。
+%   指定 \CTeX\ 宏集加载的字库。
 %
-%   如果没有指定 \opt{fontset} 的值，\CTeX{} 宏集将自动检测用户使用的操作系统，配置
+%   如果没有指定 \opt{fontset} 的值，\CTeX\ 宏集将自动检测用户使用的操作系统，配置
 %   相应的字体（参见表~\ref{tab:default-font-select}）。
 % \end{function}
 %
-% \CTeX{} 预定义了以下七种中文字库。
+% \CTeX\ 预定义了以下七种中文字库。
 %
 % \begin{optdesc}
 %   \item[adobe] 使用 Adobe 公司的四款中文字体，\emph{不支持 \pdfLaTeX}。
@@ -1041,41 +1041,41 @@ Copyright and Licence
 %     |macnew| 和 |macold| 两种。
 %   \item[macnew] 使用 El Capitan 或之后的多字重华文字体和苹方字体。
 %     从 macOS~15 (Sequoia) 开始，部分字体（苹方、楷体、仿宋、隶书、圆体）转为
-%     \emph{downloadable}，\CTeX{} 会自动检测可用性：可用时使用，不可用时静默跳过
+%     \emph{downloadable}，\CTeX\ 会自动检测可用性：可用时使用，不可用时静默跳过
 %     或回退。若需要完整的字体集，请在系统字体册中手动下载相关字体。
 %
 %     注意：上述自动检测仅对 |macnew| 字体集中的默认字体生效。
-%     如果需要在 \LuaLaTeX{} 下通过 \tn{setCJKmainfont} 等命令自定义使用
+%     如果需要在 \LuaLaTeX\ 下通过 \tn{setCJKmainfont} 等命令自定义使用
 %     macOS 的 \emph{downloadable} 字体，需要配置 |OSFONTDIR| 环境变量，
 %     将字体目录加入搜索路径。例如，在 shell 配置文件中添加：
 %     \begin{ctexexam}
 %       export OSFONTDIR="/System/Library/Fonts;/Library/Fonts;~/Library/Fonts"
 %     \end{ctexexam}
 %     配置后需运行 |luaotfload-tool --update| 重建字体数据库。
-%     \XeLaTeX{} 不受此限制，因为 \XeTeX{} 自身可通过系统接口发现字体。
+%     \XeLaTeX\ 不受此限制，因为 \XeTeX\ 自身可通过系统接口发现字体。
 %   \item[macold] 使用 Yosemite 或之前的华文字体。
-%   \item[ubuntu] 使用 Ubuntu 系统下的思源宋体、思源黑体和 \TeX{} 发行版自带的
+%   \item[ubuntu] 使用 Ubuntu 系统下的思源宋体、思源黑体和 \TeX\ 发行版自带的
 %     文鼎楷体，\emph{不支持 \pdfLaTeX}。
 %   \item[windows] 使用 Windows 系统下的中易字体和微软雅黑字体。
-%     当使用 (pdf)\LaTeX{} 编译时，微软雅黑仅在以下两种情形有效：
+%     当使用 (pdf)\LaTeX\ 编译时，微软雅黑仅在以下两种情形有效：
 %     安装有 \pkg{zhmCJK} 宏包且选项 \opt{zhmap=zhmCJK} 时，或者
 %     安装有微软雅黑的 Type1 字体且选项 \opt{zhmap=false} 时。
 % \end{optdesc}
 %
-% 如果不想使用 \CTeX{} 预定义的中文字库，可以设置 \opt{fontset} 为下述值之一。
+% 如果不想使用 \CTeX\ 预定义的中文字库，可以设置 \opt{fontset} 为下述值之一。
 %
 % \begin{optdesc}
 %   \item[none] 不配置中文字体，需要用户自己配置。
 %   \item[\meta{name}] 这里 \meta{name} 为自定义的名字。
-%   \CTeX{} 宏集将载入名为 |ctex-fontset-|\meta{name}|.def| 的文件作为字体配置
+%   \CTeX\ 宏集将载入名为 |ctex-fontset-|\meta{name}|.def| 的文件作为字体配置
 %   文件。因此，请先保证文件的存在。可以在当前工作目录或者本地 \texttt{TDS} 目录
 %   树下合适位置建立一个名为 |ctex-fontset-|\meta{name}|.def| 的文件，在这个文件
 %   里面自定义中文字体。然后通过使用 |fontset=|\meta{name} 选项来调用它。字体配置
-%   文件的具体写法可以参考 \CTeX{} 宏集 \texttt{fontset} 目录下的字体配置文件。
+%   文件的具体写法可以参考 \CTeX\ 宏集 \texttt{fontset} 目录下的字体配置文件。
 % \end{optdesc}
 %
 % 注意：\emph{如果希望使用 \tn{ctexset} 在导言区指定字库，则需要先在宏包/文档类选项中指定
-% \opt{fontset = none}}（这会禁用 \CTeX{} 宏集的操作系统检测功能和自动设定字库功能）。例如：
+% \opt{fontset = none}}（这会禁用 \CTeX\ 宏集的操作系统检测功能和自动设定字库功能）。例如：
 % \begin{ctexexam}
 %   \documentclass[fontset = none]{ctexart}
 %   \ctexset{fontset = founder}
@@ -1085,7 +1085,7 @@ Copyright and Licence
 %   \end{document}
 % \end{ctexexam}
 %
-% \CTeX{} 宏集预定义的中文字库还定义了一些字体命令。除了在 \opt{ubuntu} 字库中没有
+% \CTeX\ 宏集预定义的中文字库还定义了一些字体命令。除了在 \opt{ubuntu} 字库中没有
 % \tn{fangsong} 的定义外，所有字库都有以下四个字体命令：
 % \begin{optdesc}
 %   \item[\tn{songti}] 宋体，CJK 等价命令 |\CJKfamily{zhsong}|。
@@ -1128,10 +1128,10 @@ Copyright and Licence
 %   \end{verbatim}
 % \end{function}
 %
-% \CTeX{} 提供两种预设字号系统：
+% \CTeX\ 提供两种预设字号系统：
 %   \begin{optdesc}[itemsep=\medskipamount]
 %     \item[word] 默认值。源自 Microsoft Word / Adobe 等桌面排版软件的字号定义，
-%       亦与 GB/T~40070---2021 国家标准一致。这是 \CTeX{} 历史以来使用的字号体系。
+%       亦与 GB/T~40070---2021 国家标准一致。这是 \CTeX\ 历史以来使用的字号体系。
 %     \item[letterpress] 金属活字排印字号体系，基于严格的倍数关系。
 %       初号/二号/五号/七号形成 $\times 2$ 等比序列（$42:21:10.5:5.25$），
 %       一号/四号形成 $\times 2$ 序列（$28:14$），
@@ -1159,7 +1159,7 @@ Copyright and Licence
 %
 % 用户也可以定义自己的字号系统。将字号数据保存在
 % |ctex-fontsize-|\meta{name}|.def| 文件中，
-% 放到工作目录或 \TeX{} 目录树（TDS）中，然后指定
+% 放到工作目录或 \TeX\ 目录树（TDS）中，然后指定
 % |experiment/font-size-system=|\meta{name} 即可。
 % 自定义文件应使用 \cs{ctex_save_font_size:nn} 为每个字号注册数据。
 % 例如：
@@ -1193,7 +1193,7 @@ Copyright and Licence
 %   \end{syntax}
 %   将文章默认字号（\tn{normalsize}）设置为小四号字或五号字，
 %   具体情况见表 \ref{tab:fontsize}。\opt{false} 禁用本功能。
-%   本选项可以用于四个 \CTeX{} 文档类和 \pkg{ctex} 宏包，
+%   本选项可以用于四个 \CTeX\ 文档类和 \pkg{ctex} 宏包，
 %   也可以用于 \pkg{ctexsize} 宏包。
 %
 %   该选项的默认值与 \opt{scheme} 的取值有关。
@@ -1230,17 +1230,17 @@ Copyright and Licence
 %\end{table}
 %
 % \begin{function}[rEXP]{10pt, 11pt, 12pt}
-%   \CTeX{} 文档类是在 \LaTeX{} 标准文档类之上开发的。因此，除了可以使用 \CTeX{}
+%   \CTeX\ 文档类是在 \LaTeX\ 标准文档类之上开发的。因此，除了可以使用 \CTeX\
 %   宏包定义的字号选项之外，还可以使用标准文档类的同类选项（\opt{10pt}、\opt{11pt}
-%   和 \opt{12pt}）。在使用这些来自标准文档类的选项的时候，\CTeX{} 文档类的字号
+%   和 \opt{12pt}）。在使用这些来自标准文档类的选项的时候，\CTeX\ 文档类的字号
 %   选项会被抑制。亦即，在 \opt{zihao} 选项之后设置 \opt{10pt} 选项，
 %   \opt{zihao} 选项将不再起作用。
 % \end{function}
 %
-% 标准文档类的其他选项在 \CTeX{} 文档类中依旧有效。例如，设置纸张大小和方向的
+% 标准文档类的其他选项在 \CTeX\ 文档类中依旧有效。例如，设置纸张大小和方向的
 % \opt{a4paper} 和 \opt{landscape}，设置单双面的 \opt{oneside} 和
-% \opt{twoside} 等。\CTeX{} 会将这些选项传给标准文档类^^A
-% \footnote{事实上，\LaTeX{} 在文档类中的选项是全局设定的，除了对使用的文档类有
+% \opt{twoside} 等。\CTeX\ 会将这些选项传给标准文档类^^A
+% \footnote{事实上，\LaTeX\ 在文档类中的选项是全局设定的，除了对使用的文档类有
 % 影响外，也可能会影响到随后使用的宏包。如果这些宏包中有某些选项出现在文档类的
 % 选项列表中，那么该选项将会被自动激活。}。
 %
@@ -1253,13 +1253,13 @@ Copyright and Licence
 %   \end{syntax}
 %   本选项只能在调用 \pkg{ctex.sty} 时作为宏包选项使用。
 %
-%   \CTeX{} 宏集提供了一套用于修改文档章节标题格式的接口。该选项用于选择是否
+%   \CTeX\ 宏集提供了一套用于修改文档章节标题格式的接口。该选项用于选择是否
 %   启用该功能。详细的设置方法请参见第 \ref{subs:pagestyle}~节和第 \ref{sec:secstyle}~节。
 % \end{function}
 %
-% \CTeX{} 宏集提供的四个文档类总是启用该功能。如果在 \pkg{ctex.sty} 下启用该选项，
-% 将会检查当前是否使用 \LaTeX{} 标准文档类。
-% 若然，则该选项将会使得 \pkg{ctex.sty} 宏包的行为和 \CTeX{} 宏集提供的
+% \CTeX\ 宏集提供的四个文档类总是启用该功能。如果在 \pkg{ctex.sty} 下启用该选项，
+% 将会检查当前是否使用 \LaTeX\ 标准文档类。
+% 若然，则该选项将会使得 \pkg{ctex.sty} 宏包的行为和 \CTeX\ 宏集提供的
 % 四个中文文档类\emph{完全}一致；若不然，则会根据 \tn{chapter}
 % 是否有定义来使用 \cls{ctexbook} 或者 \cls{ctexart} 的标题设置。
 %
@@ -1277,7 +1277,7 @@ Copyright and Licence
 %   具体格式可参考 \ref{subsec:sec-spacing}~小节中的 \opt{runin} 和 \opt{afterskip} 选项。
 %
 %   注意，上述两个选项只有在非 \cls{beamer} 文档类下 \opt{heading} 选项启用的时候
-%   才有意义。亦即，只有在使用除了 \cls{ctexbeamer} 的三个 \CTeX{} 文档类或启用了
+%   才有意义。亦即，只有在使用除了 \cls{ctexbeamer} 的三个 \CTeX\ 文档类或启用了
 %   \opt{heading} 的 \pkg{ctex.sty} 的时候才有意义。
 % \end{function}
 %
@@ -1295,7 +1295,7 @@ Copyright and Licence
 %       整行距为 |1.3|；汉化文档中的标题名字（如“图”、“表”、“目录”和“参
 %       考文献”等，见 \ref{subs:capname}~节）；
 %       在 \opt{heading = true} 的情况下^^A
-%       \footnote{使用 \CTeX{} 文档类，或者使用 \pkg{ctex} 宏包且开启该选项时。}^^A
+%       \footnote{使用 \CTeX\ 文档类，或者使用 \pkg{ctex} 宏包且开启该选项时。}^^A
 %       （\ref{subs:options-heading}~节），还会将章节标题的风格修改为
 %       中文样式（见 \ref{sec:secstyle}~节）。
 %
@@ -1303,7 +1303,7 @@ Copyright and Licence
 %       联用时，会载入 \pkg{indentfirst} 宏包，以实现章节标题后的段首缩进。
 %     \item[plain] 不调整默认字号和行距，不会汉化文档中的标题名字，也不会将章节
 %       标题风格修改为中文样式，同时不会调整 \tn{pagestyle}，并禁用 \opt{autoindent}
-%       选项。事实上，此时的 \CTeX{} 宏集只提供了中文支持功能，而不对文章版式进行任何修改。
+%       选项。事实上，此时的 \CTeX\ 宏集只提供了中文支持功能，而不对文章版式进行任何修改。
 %   \end{optdesc}
 %
 % \begin{function}[updated=2014-04-11]{punct}
@@ -1327,14 +1327,14 @@ Copyright and Licence
 %   \begin{syntax}
 %     space = <\TF|(auto)>
 %   \end{syntax}
-%   是否在生成的 PDF 中保留汉字后面的空格。该选项仅在使用 \XeLaTeX{}/(pdf)\LaTeX{} 编译时有效。
+%   是否在生成的 PDF 中保留汉字后面的空格。该选项仅在使用 \XeLaTeX/(pdf)\LaTeX\ 编译时有效。
 % \end{function}
 %
 % \begin{optdesc}
 %   \item[true] 总是保留汉字后的空格。此时，用户需要自行在行尾加上~|%|~处理换行产生
-%     的空格\footnote{\LaTeX{} 将单个换行视作一个空格。}。
-%   \item[false] 使用 (pdf)\LaTeX{} 编译时：总是忽略掉汉字后面的空格，不论汉字后是什么；
-%     使用 \XeLaTeX{} 编译时，等同于 \opt{auto} 的效果。不建议使用该选项。
+%     的空格\footnote{\LaTeX\ 将单个换行视作一个空格。}。
+%   \item[false] 使用 (pdf)\LaTeX\ 编译时：总是忽略掉汉字后面的空格，不论汉字后是什么；
+%     使用 \XeLaTeX\ 编译时，等同于 \opt{auto} 的效果。不建议使用该选项。
 %   \item[auto] 根据空格后面的情况决定是否保留：如果空格后面是汉字，则忽略该
 %   空格，否则保留。
 % \end{optdesc}
@@ -1353,7 +1353,7 @@ Copyright and Licence
 %   \end{ctexexam}
 %   则会得到“{\ctexset{space=auto}汉字 分词 技术 English}”。
 %
-% \emph{使用 \textup{\LuaLaTeX{} 及 \upLaTeX} 编译的时候，该选项无效：汉字间的
+% \emph{使用 \textup{\LuaLaTeX\ 及 \upLaTeX} 编译的时候，该选项无效：汉字间的
 % 空格以及汉字与西文字符之间的空格总是有效，不会被忽略，但可以自动忽略掉由换行
 % 产生的空格。}
 %
@@ -1368,7 +1368,7 @@ Copyright and Licence
 %   时，相邻两行的基线（\tn{baselineskip}）距离为 $1.3\times 1.2=1.56$ 倍字体
 %   高度。对 \cls{beamer} 不改变行距，即使用默认的单倍行距。
 %
-%   \item[scheme = plain] \CTeX{} 宏集默认不调整行距倍数，文档中的行距由所选文档类和
+%   \item[scheme = plain] \CTeX\ 宏集默认不调整行距倍数，文档中的行距由所选文档类和
 %   其他宏包或用户设置决定。
 % \end{optdesc}
 %
@@ -1420,21 +1420,21 @@ Copyright and Licence
 %     experiment/CJKecglue = \Arg{弹性长度}
 %   \end{syntax}
 %   设置 CJK 文字与西文之间的间距（汉英文间胶）。这是一个实验性选项，
-%   目前仅在 \XeLaTeX{}、\LuaLaTeX{} 和 \upLaTeX{} 下有效，
-%   使用 \pdfLaTeX{} 编译时会产生警告。
+%   目前仅在 \XeLaTeX、\LuaLaTeX\ 和 \upLaTeX\ 下有效，
+%   使用 \pdfLaTeX\ 编译时会产生警告。
 % \end{function}
 %
-%   在 \XeLaTeX{} 下，此选项等价于设置
+%   在 \XeLaTeX\ 下，此选项等价于设置
 %   |\xeCJKsetup{CJKecglue={\hskip ...}}|；
-%   在 \LuaLaTeX{} 和 \upLaTeX{} 下，此选项设置 |xkanjiskip|。
+%   在 \LuaLaTeX\ 和 \upLaTeX\ 下，此选项设置 |xkanjiskip|。
 %   例如：
 %   \begin{ctexexam}
 %   \ctexset{experiment/CJKecglue = 0.25em plus 0.15em minus 0.05em}
 %   \end{ctexexam}
 %
-%   请注意，由于 \pdfLaTeX{} 下的 \pkg{CJK} 宏包没有独立的汉英文间胶概念，
+%   请注意，由于 \pdfLaTeX\ 下的 \pkg{CJK} 宏包没有独立的汉英文间胶概念，
 %   此选项无法在所有引擎下提供一致的行为。因此，\emph{除非确定文档仅会在
-%   \XeLaTeX{} 或 \LuaLaTeX{} 下编译}，否则不建议使用此选项。
+%   \XeLaTeX\ 或 \LuaLaTeX\ 下编译}，否则不建议使用此选项。
 %
 % \section{文档汉化}
 % \label{sec:chinese-localization}
@@ -1544,7 +1544,7 @@ Copyright and Licence
 %
 % 在标准文档类中 \cls{article} 的参考文献名使用宏 \tn{refname}，而
 % \cls{book} 和 \cls{report} 使用宏 \tn{bibname}。本选项会根据标准文档类的不同，自动
-% 设定 \tn{refname} 或是 \tn{bibname}。因此，对于标准文档类及对应的 \CTeX{} 文档类
+% 设定 \tn{refname} 或是 \tn{bibname}。因此，对于标准文档类及对应的 \CTeX\ 文档类
 % 可以统一地使用 \opt{bibname} 选项来控制参考文献标题名。
 %
 % 对于 \cls{beamer} 及对应的 \cls{ctexbeamer} 来说，它们同时具有宏 \tn{bibname} 和
@@ -1569,9 +1569,9 @@ Copyright and Licence
 %   \end{syntax}
 % 设置参考文献标题名 \tn{refname}。中文默认为“\refname”。
 %
-% 注意，三个标准文档类（及相应的 \CTeX{} 文档类）的参考文献标题名由 \opt{bibname} 选项
+% 注意，三个标准文档类（及相应的 \CTeX\ 文档类）的参考文献标题名由 \opt{bibname} 选项
 % 统一设置，本选项仅适用于 \cls{beamer} 及其对应的 \cls{ctexbeamer}。
-% 在三个标准文档类（及相应的 \CTeX{} 文档类）中使用 \opt{refname} 选项会报错。
+% 在三个标准文档类（及相应的 \CTeX\ 文档类）中使用 \opt{refname} 选项会报错。
 % \end{function}
 %
 % \begin{function}[EXP]{algorithmname}
@@ -1595,7 +1595,7 @@ Copyright and Licence
 % \label{subs:pagestyle}
 %
 % 页面格式设置与汉化的功能（及章节标题样式设置功能，见第 \ref{sec:secstyle} 节）^^A
-% 由 \pkg{ctexheading} 宏包完成。加载该宏包时，或者使用 \CTeX{} 文档类时，^^A
+% 由 \pkg{ctexheading} 宏包完成。加载该宏包时，或者使用 \CTeX\ 文档类时，^^A
 % 或者是使用 \pkg{ctex} 宏包并设定选项 \opt{heading = true} 时，相关功能被激活。
 % 此时，整个文档的页面格式（page style）被设定为 |headings|，即相当于设置了
 % \begin{frameverb}
@@ -1692,10 +1692,10 @@ Copyright and Licence
 % \section{章节标题样式设置}
 % \label{sec:secstyle}
 %
-% \CTeX{} 宏集对 \LaTeX{} 的标准文档类（\cls{article}、\cls{report}、
+% \CTeX\ 宏集对 \LaTeX\ 的标准文档类（\cls{article}、\cls{report}、
 % \cls{book}）和 \cls{beamer} 进行了章节标题样式设置功能的扩充。
 % 章节标题样式设置功能（及页面格式设置与汉化功能，见第 \ref{subs:pagestyle} 节）^^A
-% 由 \pkg{ctexheading} 宏包完成。加载该宏包时，或者使用 \CTeX{} 文档类时，^^A
+% 由 \pkg{ctexheading} 宏包完成。加载该宏包时，或者使用 \CTeX\ 文档类时，^^A
 % 或者是使用 \pkg{ctex} 宏包并设定选项 \opt{heading = true} 时，相关功能被激活。
 % 其中，独立使用 \pkg{ctexheading} 宏包时，本节介绍各选项的默认值与指定
 % \opt{scheme = plain} 时相同。
@@ -1761,7 +1761,7 @@ Copyright and Licence
 %   控制是否对\emph{不带星号}的章节标题进行编号。
 %   各级标题的默认值均为 \opt{true}。
 %
-%   \LaTeX{} 标准的章节标题命令（如 \tn{section}）大体上完成四项工作：
+%   \LaTeX\ 标准的章节标题命令（如 \tn{section}）大体上完成四项工作：
 %   输出标题内容、对标题编号（计数器增加 1）、将标题列入目录（若调用了
 %   \pkg{hyperref} 宏包还会添加 PDF 书签）、更新页眉页脚标记。带星号的
 %   章节标题命令（如 \tn{section*}）只简单地输出章节标题内容，但不对标题编号，
@@ -1782,7 +1782,7 @@ Copyright and Licence
 %   三章的标题分别为“第一章\quad A”、“B”和“C”，但在目录中则只出现
 %   “第一章\quad A”和“C”。
 %
-%   注意，章节标题是否编号还要受到 \LaTeX{} 计数器 |secnumdepth| 的控制^^A
+%   注意，章节标题是否编号还要受到 \LaTeX\ 计数器 |secnumdepth| 的控制^^A
 %   （可通过以下介绍的 \opt{secnumdepth} 选项设置）。
 %   例如，对于 |section| 而言，其深度为 1。因此，|section| 会被编号，当且仅当
 %   |secnumdepth| 不小于 1，并且 \opt{section/numbering} 为 \opt{true}，
@@ -1896,7 +1896,7 @@ Copyright and Licence
 %   将会使 \tn{section} 的编号变为大写罗马数字（如 I、II 等）。
 %
 %   \opt{number} 选项定义的同时将控制对章节计数器的交叉引用。在引用计数器时，
-%   记录在 \LaTeX{} 辅助文件中的是 \opt{number} 选项的定义。
+%   记录在 \LaTeX\ 辅助文件中的是 \opt{number} 选项的定义。
 %
 %   但是，\opt{number} 选项不会影响计数器本身的输出。即设置 |section/number|
 %   不会影响 \tn{thesection} 的定义（但该选项会影响 \tn{CTEXthesection} 的定
@@ -1935,7 +1935,7 @@ Copyright and Licence
 % \subsection{格式相关}
 % \label{subsec:sec-format}
 %
-% \CTeX{} 宏集提供了 \opt{numberformat}, \opt{nameformat}, \opt{titleformat},
+% \CTeX\ 宏集提供了 \opt{numberformat}, \opt{nameformat}, \opt{titleformat},
 % \opt{format} 这几个选项用来控制章节标题的格式。
 % 它们的作用范围如图~\ref{fig:heading-format} 所示。具体用法见下文。
 %
@@ -2008,7 +2008,7 @@ Copyright and Licence
 %     \bottomrule
 %     \end{tabular}
 %     \begin{tablenotes}
-%       \item[*] 为了与 \LaTeXe{} 的默认效果保持一致，在 \opt{scheme = plain}
+%       \item[*] 为了与 \LaTeXe\ 的默认效果保持一致，在 \opt{scheme = plain}
 %           时，part 和 chapter 的 \opt{nameformat} 和 \opt{titleformat}
 %           并不一样，因此没有使用 \opt{format} 选项统一设置名字和标题的格式。
 %     \end{tablenotes}
@@ -2295,7 +2295,7 @@ Copyright and Licence
 %   和 \opt{indent} 选项设置的宽度之和）。
 %
 %   注意，当 \opt{hang = true} 时，不恰当地设置选项 \opt{aftername} 的值，可能会引发
-%   错误。这是因为当 \opt{hang = true} 时，\LaTeX{} 内部会构造一个 \tn{hbox} 而
+%   错误。这是因为当 \opt{hang = true} 时，\LaTeX\ 内部会构造一个 \tn{hbox} 而
 %   进入受限水平模式（restricted horizontal mode）。若在 \opt{aftername} 中加入
 %   包含 \tn{vskip} 等会导致从受限水平模式切出的垂直命令（vertical command）时，就会报错。
 %   特别地，\opt{aftername} 的默认值也可能导致这种情形（见表~\ref{tab:aftername-default}）。
@@ -2682,7 +2682,7 @@ Copyright and Licence
 % \subsection{辅助命令}
 % \label{subsec:sec-commands}
 %
-% \CTeX{} 宏集还提供了一些辅助命令（宏），用于存储章节标题格式，或进行一些条件判断。
+% \CTeX\ 宏集还提供了一些辅助命令（宏），用于存储章节标题格式，或进行一些条件判断。
 %
 % \begin{function}{\CTEXthepart, \CTEXthechapter, \CTEXthesection,
 %   \CTEXthesubsection, \CTEXthesubsubsection, \CTEXtheparagraph,
@@ -2701,8 +2701,8 @@ Copyright and Licence
 %   \end{syntax}
 %   \tn{CTEXifname} 会根据当前章节有无名字展开得到不同内容（通常是格式命令）。
 %   由于章节名字总是与编号一起出现，章节有无名字通常也表达为“章节是否编号”。
-%   在 \LaTeX{} 中，后者取决于以下几个方面：章节深度是否不大于计数器
-%   |secnumdepth| 的值，章节标题是否使用不带星号的命令。在 \CTeX{} 宏集中，
+%   在 \LaTeX\ 中，后者取决于以下几个方面：章节深度是否不大于计数器
+%   |secnumdepth| 的值，章节标题是否使用不带星号的命令。在 \CTeX\ 宏集中，
 %   后者还取决于 \opt{.../numbering} 是否为 \opt{true}。
 %
 %   \tn{CTEXifname} 可用于 \opt{format}, \opt{titleformat}, \opt{aftertitle},
@@ -2812,7 +2812,7 @@ Copyright and Licence
 %
 % \subsection{中文数字转换}
 %
-% \CTeX{} 宏集的中文数字转换功能实际上是调用 \pkg{zhnumber} 宏包来完成。下面只
+% \CTeX\ 宏集的中文数字转换功能实际上是调用 \pkg{zhnumber} 宏包来完成。下面只
 % 介绍一些基本的用法，更高级的用法可以查阅 \pkg{zhnumber} 宏包的文档。
 %
 % \begin{function}[updated=2016-05-01]{\chinese}
@@ -2820,7 +2820,7 @@ Copyright and Licence
 %     \tn{chinese} \Arg{counter}
 %     \tn{pagenumbering} \{chinese\}
 %   \end{syntax}
-%   \tn{chinese} 命令与 \tn{roman} 等命令的用法类似，作用在一个 \LaTeX{}
+%   \tn{chinese} 命令与 \tn{roman} 等命令的用法类似，作用在一个 \LaTeX\
 %   计数器上，将计数器的值以中文数字的形式输出。
 % \end{function}
 %
@@ -2842,7 +2842,7 @@ Copyright and Licence
 %   \begin{syntax}
 %     \tn{CTEXnumber} "\"<macro> \Arg{number}
 %   \end{syntax}
-%   |\|<macro> 必须是一个 \TeX{} 宏，不需预先定义。\tn{CTEXnumber} 通过
+%   |\|<macro> 必须是一个 \TeX\ 宏，不需预先定义。\tn{CTEXnumber} 通过
 %   \tn{zhnumber} 将 \meta{number} 转为中文数字，最后将结果存储在 |\|<macro>
 %   里。对 |\|<macro> 的定义是局部的，将它展开一次就可以得到转换结果。
 % \end{function}
@@ -2866,19 +2866,19 @@ Copyright and Licence
 % 用于显示 \CTeX 标志。
 % \end{function}
 %
-% \section{\LuaLaTeX{} 下的中文支持方式}
+% \section{\LuaLaTeX\ 下的中文支持方式}
 % \label{sec:lualatex-chinese}
 %
-% 在 \LuaLaTeX{} 下，\CTeX{} 宏集依赖 \pkg{LuaTeX-ja} 宏包来完成中文支持。
-% 该宏包是日本 \TeX{} 社区的北川弘典、前田一贵、八登崇之等人开发的，设计目的主要
-% 是在 \LuaTeX{} 引擎下实现日本 p\TeX{} 引擎的（大部分）功能。它为了兼容 p\LaTeX
+% 在 \LuaLaTeX\ 下，\CTeX\ 宏集依赖 \pkg{LuaTeX-ja} 宏包来完成中文支持。
+% 该宏包是日本 \TeX\ 社区的北川弘典、前田一贵、八登崇之等人开发的，设计目的主要
+% 是在 \LuaTeX\ 引擎下实现日本 p\TeX\ 引擎的（大部分）功能。它为了兼容 p\LaTeX
 % 的使用习惯，对 \LaTeXe 的 \pkg{NFSS} 作了不少修改和扩充。这对于简体中文用户来说
-% 不是必要的，因而 \CTeX{} 禁用了它在 \LaTeX{} 格式下的大部分设置，只保留了必要的
+% 不是必要的，因而 \CTeX\ 禁用了它在 \LaTeX\ 格式下的大部分设置，只保留了必要的
 % 部分。同时修改了它的字体设置方式，使得相关命令与 \pkg{xeCJK} 宏包大致相同。
 %
-% 20150420 版以后的 \pkg{LuaTeX-ja} 宏包开始支持竖排，但 \CTeX{} 暂不支持竖排。
+% 20150420 版以后的 \pkg{LuaTeX-ja} 宏包开始支持竖排，但 \CTeX\ 暂不支持竖排。
 %
-% \subsection{\LuaLaTeX{} 下替代字体的设置}
+% \subsection{\LuaLaTeX\ 下替代字体的设置}
 %
 % \begin{function}[updated=2020-04-30]{AlternateFont}
 %   \begin{syntax}
@@ -2959,39 +2959,39 @@ Copyright and Licence
 %   当前 CJK 字体族。清除与重置操作总是全局的。
 % \end{function}
 %
-% \section{\CTeX{} 宏集的配置文件}
+% \section{\CTeX\ 宏集的配置文件}
 %
-% \CTeX{} 宏集提供了不同的配置文件，可以通过修改配置文件来改变 \CTeX{} 宏集的
+% \CTeX\ 宏集提供了不同的配置文件，可以通过修改配置文件来改变 \CTeX\ 宏集的
 % 默认行为。
 %
-% 在多数情况下，并不需要修改配置文件，\CTeX{} 宏集的默认设置已经能满足大多数用
-% 户的需要。不恰当地修改 \CTeX{} 宏集的默认行为也可能导致同一文件在别处无法正
+% 在多数情况下，并不需要修改配置文件，\CTeX\ 宏集的默认设置已经能满足大多数用
+% 户的需要。不恰当地修改 \CTeX\ 宏集的默认行为也可能导致同一文件在别处无法正
 % 常编译或排版效果完全不同，因此修改应该慎重。
 %
 % 但在一些情况下，直接修改配置文件仍是必要的，例如：
 % \begin{itemize}
 % \item 系统没有安装默认设置的字体文件，无法编译。
-% \item 需要经常编译来自其他系统的中文 \TeX{} 文件，但对方的操作系统或默认设置
+% \item 需要经常编译来自其他系统的中文 \TeX\ 文件，但对方的操作系统或默认设置
 % 与本机不同。
 % \end{itemize}
 %
-% 与 \CTeX{} 宏集的源代码一样，配置文件采用 \LaTeXiii{} 的语法编写。
+% 与 \CTeX\ 宏集的源代码一样，配置文件采用 \LaTeXiii\ 的语法编写。
 %
-% \CTeX{} 宏集的配置文件随宏包其他文件一起安装在 \TeX{} 系统 TDS 目录树中，文
-% 件后缀是 \file{.cfg}。为了避免本地配置文件内容因 \CTeX{} 宏集的更新而丢失，
+% \CTeX\ 宏集的配置文件随宏包其他文件一起安装在 \TeX\ 系统 TDS 目录树中，文
+% 件后缀是 \file{.cfg}。为了避免本地配置文件内容因 \CTeX\ 宏集的更新而丢失，
 % 不要直接修改系统 TDS 目录树中的配置文件，而应该将系统自带的配置文件复制到本
 % 地的或用户私有的 TDS 目录树中修改，并运行 \bashcmd{texhash} 命令刷新文件名数据库。
 %
-% 例如对于 \TeX{} Live，系统自带的配置文件就在 \TeX{} Live 安装目录下的
+% 例如对于 \TeX\ Live，系统自带的配置文件就在 \TeX\ Live 安装目录下的
 % \path{texmf-dist/tex/latex/ctex/config/} 子目录下，可以修改它的副本，保存在
 % 本地 TDS 树的 \path{texmf-local/tex/latex/ctex/} 目录下，或者用户 TDS 树的
 % \path{~/texmf/tex/latex/ctex/} 目录下，作为本地/用户专有的
 % 配置文件。复制配置文件后需要运行 |texhash| 命令使本地配置文件生效。
 %
-% \MiKTeX{} 的配置文件也保存在类似的目录结构中，\MiKTeX{} 管理的
-% 几个 TDS 根目录可以在 \MiKTeX{} Options 设置项中查看到，这里不再赘述。
+% \MiKTeX\ 的配置文件也保存在类似的目录结构中，\MiKTeX\ 管理的
+% 几个 TDS 根目录可以在 \MiKTeX\ Options 设置项中查看到，这里不再赘述。
 %
-% 除了修改本地 \TeX{} 系统中的配置文件，对于特定文档，也可以将修改过的配置文件
+% 除了修改本地 \TeX\ 系统中的配置文件，对于特定文档，也可以将修改过的配置文件
 % 保存在文档的工作目录下。此时配置文件就只对工作目录下的所有文档生效。
 %
 % \subsection{修改宏包默认选项}
@@ -3005,17 +3005,17 @@ Copyright and Licence
 %   % 该设置可以用在安装了 Windows 字体的非 Windows 系统中。
 %   \ctex_set:nn { option } { fontset = windows }
 % \end{ctexexam}
-% 如上例所示，宏包选项通常使用 \LaTeXiii{} 的 \cs{ctex_set:nn} 命令完成键值设置，
+% 如上例所示，宏包选项通常使用 \LaTeXiii\ 的 \cs{ctex_set:nn} 命令完成键值设置，
 % 第一个参数是固定的子模块 |option|，第二个参数中是用户定义的新的默认宏包选项。
 %
-% \file{ctexopts.cfg} 中的设置将在 \CTeX{} 宏集的开始处，定义过宏包选项之后，
+% \file{ctexopts.cfg} 中的设置将在 \CTeX\ 宏集的开始处，定义过宏包选项之后，
 % \tn{ProcessKeysOptions} 命令之前生效。最好只使用此配置文件修改宏包默认选项。
 %
 % \subsection{宏包载入后的配置}
 %
 % 配置文件 \file{ctex.cfg} 将在宏包的末尾被载入生效。可以用它完成任意的设置，
 % 或是覆盖已有的定义。随系统安装的配置文件除版本信息外没有实际内容，注意配置文
-% 件中也使用 \LaTeXiii{} 语法。
+% 件中也使用 \LaTeXiii\ 语法。
 %
 % \begin{ctexexam}
 %   % 简单的 ctex.cfg 内容示例。
@@ -3039,7 +3039,7 @@ Copyright and Licence
 %
 % \subsection{配置标题中文翻译}
 %
-% 由于 \CTeX{} 宏集需要同时支持 GBK 和 UTF-8 两种编码，因此对标题的中文翻译写
+% 由于 \CTeX\ 宏集需要同时支持 GBK 和 UTF-8 两种编码，因此对标题的中文翻译写
 % 在两个配置文件当中：\file{ctex-name-gbk.cfg} 和 \file{ctex-name-utf8.cfg}。
 % 两个文件的设置相同，只是编码不同。
 %
@@ -3048,15 +3048,15 @@ Copyright and Licence
 % \subsection{自定义字体集}
 %
 % \ref{subs:options-CJK-font}~节介绍的用于 |fontset| 选项的自定义字库文件，
-% 类似于 \CTeX{} 宏集的配置文件，也应该与其他本地配置文件一起保存在本地
+% 类似于 \CTeX\ 宏集的配置文件，也应该与其他本地配置文件一起保存在本地
 % \texttt{TDS} 目录树下，并可以配合 \file{ctexopts.cfg} 等配置文件使用。
 %
 % \section{第三方宏包兼容}
 % \label{sec:third-party}
 %
-% \CTeX{} 宏集为使 \tn{labelformat} 功能与章节标题设置兼容，对 \pkg{cleveref}
+% \CTeX\ 宏集为使 \tn{labelformat} 功能与章节标题设置兼容，对 \pkg{cleveref}
 % 等宏包进行了补丁。由于 \pkg{cleveref} 长期未维护（CTAN 上仍为 0.21.4），与新版
-% \LaTeX{} 内核和 \pkg{hyperref} 存在兼容问题，\CTeX{} 提供了选项以控制补丁行为。
+% \LaTeX\ 内核和 \pkg{hyperref} 存在兼容问题，\CTeX\ 提供了选项以控制补丁行为。
 %
 % \begin{function}[EXP, added = 2026-04-24]{patch/cleveref}
 %   \begin{syntax}
@@ -3066,13 +3066,13 @@ Copyright and Licence
 %   该补丁在 \pkg{cleveref} 的 \tn{refstepcounter} 变体中注入 \tn{expandafter}，
 %   以确保 \tn{labelformat} 格式化后的标签能正确展开。
 %
-%   当该补丁与上游 \LaTeX{} 内核或 \pkg{hyperref} 的更新产生冲突时，
+%   当该补丁与上游 \LaTeX\ 内核或 \pkg{hyperref} 的更新产生冲突时，
 %   可以将此选项设为 |false| 以关闭补丁。
 %
 %   \textbf{注意：}当同时使用 \pkg{hyperref} 和 \pkg{cleveref} 时，|\appendix|
 %   之后的交叉引用类型可能不正确（例如，\texttt{appendix} 退化为
-%   \texttt{chapter}）。这是上游 \LaTeX{} 内核 \texttt{firstaid} 对
-%   \pkg{cleveref} 补丁不完整所致，与 \CTeX{} 无关。
+%   \texttt{chapter}）。这是上游 \LaTeX\ 内核 \texttt{firstaid} 对
+%   \pkg{cleveref} 补丁不完整所致，与 \CTeX\ 无关。
 %   可以使用以下方法规避：
 % \begin{ctexexam}
 %   \AddToHook{cmd/appendix/before}{%
@@ -3095,7 +3095,7 @@ Copyright and Licence
 %
 % \subsection{\CTeX\ 0.9--\CTeX\ 1.0d}
 %
-% 在 2009 年在 ctex-kit 项目成立后，新增了 \XeTeX{} 引擎的支持，并增加了不少控
+% 在 2009 年在 ctex-kit 项目成立后，新增了 \XeTeX\ 引擎的支持，并增加了不少控
 % 制字体的命令和选项。
 %
 % 这里主要介绍新版本 \CTeX 宏包相对 1.02d 版本（2014/06/09）的兼容性。
@@ -3124,7 +3124,7 @@ Copyright and Licence
 % \opt{indent} 和 \opt{noindent} 什么也不做，过时选项。
 %
 % 在中文版式下，\pkg{ctex} 宏包的相关功能在与标准文档类及其衍生文档类联用时
-% 默认打开。\CTeX{} 文档类的相关功能由章节标题的 \opt{afterindent} 选项的值
+% 默认打开。\CTeX\ 文档类的相关功能由章节标题的 \opt{afterindent} 选项的值
 % 来确定。
 % \end{function}
 %
@@ -3185,19 +3185,19 @@ Copyright and Licence
 %
 % \begin{function}{fntef}
 % 旧版本的 \opt{fntef} 选项用于统一 \pkg{CCTfntef} 与 \pkg{CJKfntef} 的界面，
-% 新版本 \CTeX{} 宏集不再支持 \pkg{CCT}，也不再自动载入 \pkg{CJKfntef} 或
+% 新版本 \CTeX\ 宏集不再支持 \pkg{CCT}，也不再自动载入 \pkg{CJKfntef} 或
 % \pkg{xeCJKfntef} 宏包，而仅在其末尾做适当格式调整。
 %
 % \opt{fntef} 选项过时，因兼容性保留，功能是根据引擎载入 \pkg{CJKfntef}
-% (\pdfTeX{}) 或 \pkg{xeCJKfntef} (\XeTeX{}) 宏包。
+% (\pdfTeX) 或 \pkg{xeCJKfntef} (\XeTeX) 宏包。
 % \end{function}
 %
 % \begin{function}{\CTEXunderdot, \CTEXunderline, \CTEXunderdblline,
 %   \CTEXunderwave, \CTEXsout, \CTEXxout, CTEXfilltwosides}
-% 在调用 \opt{fntef} 宏包选项的同时，旧版本 \CTeX{} 宏包由于需要支持 \pkg{CCT}
+% 在调用 \opt{fntef} 宏包选项的同时，旧版本 \CTeX\ 宏包由于需要支持 \pkg{CCT}
 % 系统，会将以 |\CJK| 开头的 \tn{CJKunderline} 等宏换名为以 |\CTEX| 开头的
-% \tn{CTEXunderline} 等宏。此功能在新版本的 \CTeX{} 宏集中已失去意义。此外，
-% 在 \pdfTeX{} 引擎下，用于设置格式的 \tn{CJKunderdotbasesep} 等宏也被更名为
+% \tn{CTEXunderline} 等宏。此功能在新版本的 \CTeX\ 宏集中已失去意义。此外，
+% 在 \pdfTeX\ 引擎下，用于设置格式的 \tn{CJKunderdotbasesep} 等宏也被更名为
 % \tn{CTEXunderdotbasesep} 等宏。
 %
 % 在新版本中，上述由 \opt{fntef} 衍生的相关命令和环境均被移除。
@@ -3299,7 +3299,7 @@ Copyright and Licence
 % \CTeX\ 2.5 有一些比较大的变动。
 %
 % \begin{function}[label =]{UTF8, GBK}
-%   (pdf)\LaTeX{} 格式下，文档编码初始值统一设置成 UTF-8。因此，仍旧使用 GBK
+%   (pdf)\LaTeX\ 格式下，文档编码初始值统一设置成 UTF-8。因此，仍旧使用 GBK
 %   编码的文档，需要在文档类或宏包选项中显式指定 \opt{GBK}。
 % \end{function}
 %
@@ -3332,20 +3332,20 @@ Copyright and Licence
 %   新的语法是将可选项放在字体名之后的花括号之内。
 % \end{function}
 %
-% 除了以上列出的选项以外，当用户使用 \CTeX{} 系列文档类，且使用 \LaTeX 或
+% 除了以上列出的选项以外，当用户使用 \CTeX\ 系列文档类，且使用 \LaTeX 或
 % \upLaTeX 编译时，若用户没有在文档类选项中显式指定 |dvips|/|dvipdfmx|/|dvisvgm|
 % 等驱动选项，则文档类指定默认驱动为 \dvipdfmx。
 %
 % \section{宏集依赖情况与手工安装方法}
 % \label{sec:dep-ins}
 %
-% 本节介绍 \CTeX{} 宏集的依赖情况，并介绍手工编译安装的具体方法。
+% 本节介绍 \CTeX\ 宏集的依赖情况，并介绍手工编译安装的具体方法。
 % 通常用户只需参照第 \ref{subsec:easy-ins}~节介绍的方法，使用发行版自带的包管理器安装
 % 本宏集。
 %
-% \CTeX{} 宏集有两个源文件：\file{ctex.dtx}、\file{ctexpunct.spa}。
-% 使用不同的编译方式时，\CTeX{} 依赖的宏包略有不同。在手工安装 \CTeX{} 宏集之前，请确保
-% 你的 \TeX{} 发行版中已经正确安装了这些宏包。\CTeX{} 依赖宏包的详情叙述如下：
+% \CTeX\ 宏集有两个源文件：\file{ctex.dtx}、\file{ctexpunct.spa}。
+% 使用不同的编译方式时，\CTeX\ 依赖的宏包略有不同。在手工安装 \CTeX\ 宏集之前，请确保
+% 你的 \TeX\ 发行版中已经正确安装了这些宏包。\CTeX\ 依赖宏包的详情叙述如下：
 %
 % \begin{itemize}
 %   \item \pkg{expl3}、\pkg{xparse} 和 \pkg{l3keys2e} 宏包。它们属于 \pkg{l3kernel}
@@ -3365,14 +3365,14 @@ Copyright and Licence
 %     \item \pkg{kvsetkeys} 宏包。
 %     \item \pkg{keyval} 宏包，\pkg{graphics} 宏集。
 %   \end{itemize}
-%   \item[\ding{229}] 以上是使用 \pdfLaTeX{} 或 \LaTeX{} + \dvipdfmx{} 的编译方式所需要
+%   \item[\ding{229}] 以上是使用 \pdfLaTeX\ 或 \LaTeX\ + \dvipdfmx\ 的编译方式所需要
 %   的依赖项，其中 \pkg{zhmCJK} 是可选的。
 %   \item \pkg{xeCJK} 宏集，它还依赖
 %   \begin{itemize}
 %     \item \pkg{xtemplate} 宏包，它属于 \pkg{l3packages} 宏集。
 %     \item \pkg{fontspec} 宏包。
 %   \end{itemize}
-%   \item[\ding{229}] 以上是使用 \XeLaTeX{} 编译时的依赖项。
+%   \item[\ding{229}] 以上是使用 \XeLaTeX\ 编译时的依赖项。
 %   \item \pkg{luatexja} 宏包，它还依赖
 %   \begin{itemize}
 %     \item \pkg{adobemapping} 宏包。
@@ -3388,35 +3388,35 @@ Copyright and Licence
 %     \item \pkg{chinese-jfm} 宏包。
 %   \end{itemize}
 %   \item \pkg{fontspec} 宏包。
-%   \item[\ding{229}] 以上是使用 \LuaLaTeX{} 编译时的依赖项。
+%   \item[\ding{229}] 以上是使用 \LuaLaTeX\ 编译时的依赖项。
 %   \item \pkg{zhmetrics-uptex} 宏包。
-%   \item[\ding{229}] 以上是使用 \upLaTeX{} 编译时的依赖项。
+%   \item[\ding{229}] 以上是使用 \upLaTeX\ 编译时的依赖项。
 % \end{itemize}
 %
-% 出于一些原因，\pkg{zhmCJK} 尚未被收入 \TeXLive{} 和 \MiKTeX。因此，若
-% 你希望使用 \pkg{zhmCJK} 作为 \CTeX{} 宏集的底层中文支持方式，那么你需要自行安装该宏包。
+% 出于一些原因，\pkg{zhmCJK} 尚未被收入 \TeXLive\ 和 \MiKTeX。因此，若
+% 你希望使用 \pkg{zhmCJK} 作为 \CTeX\ 宏集的底层中文支持方式，那么你需要自行安装该宏包。
 % \pkg{zhmCJK} 的安装较为复杂。我们建议你
 % \begin{enumerate}
 %   \item 从 CTAN 下载 \pkg{zhmCJK} 宏包的
 %   \href{http://mirrors.ctan.org/install/language/chinese/zhmcjk.tds.zip}
 %   {TDS 安装包}，
-%   \item 按目录结构将文件复制到 \TeX{} 发行版的本地 TDS 根目录，
-%   \item 最后执行 \bashcmd{texhash} 刷新 \TeX{} 发行版的 ls-R 数据库以完成安装。
+%   \item 按目录结构将文件复制到 \TeX\ 发行版的本地 TDS 根目录，
+%   \item 最后执行 \bashcmd{texhash} 刷新 \TeX\ 发行版的 ls-R 数据库以完成安装。
 % \end{enumerate}
 % 其他细节，可参照其
 % \href{http://mirrors.ctan.org/language/chinese/zhmcjk/zhmCJK.pdf}{宏包手册}
 % 中第 3 节的指导。
 %
-% \emph{\CTeX{} 宏集已被 \TeXLive{} 和 \MiKTeX{} 收录，若无特别理由，
+% \emph{\CTeX\ 宏集已被 \TeXLive\ 和 \MiKTeX\ 收录，若无特别理由，
 % 我们强烈建议用户使用包管理器安装本宏集。}
 %
 % 若要手工安装，请遵循如下步骤：
 % \begin{enumerate}
-%   \item 从 CTAN 下载 \CTeX{} 宏集的
+%   \item 从 CTAN 下载 \CTeX\ 宏集的
 %   \href{http://mirrors.ctan.org/install/language/chinese/ctex.tds.zip}
 %   {TDS 安装包}，
-%   \item 按目录结构将文件复制到 \TeX{} 发行版的本地 TDS 根目录，
-%   \item 最后执行 \bashcmd{texhash} 刷新 \TeX{} 发行版的 ls-R 数据库以完成安装。
+%   \item 按目录结构将文件复制到 \TeX\ 发行版的本地 TDS 根目录，
+%   \item 最后执行 \bashcmd{texhash} 刷新 \TeX\ 发行版的 ls-R 数据库以完成安装。
 % \end{enumerate}
 %
 % \section{开发人员}
@@ -3441,7 +3441,7 @@ Copyright and Licence
 % \begin{thebibliography}{9}
 % \bibitem{knuthtex1986}
 % \textsc{Donald~Ervin Knuth}.
-% \newblock \textit{The {{\TeX{}book}}}, \textit{Computers \& Typesetting},
+% \newblock \textit{The {{\TeX book}}}, \textit{Computers \& Typesetting},
 %   volume~A.
 % \newblock Addison-Wesley, 1986
 %
@@ -3489,12 +3489,12 @@ Copyright and Licence
 %<*class|ctex>
 %    \end{macrocode}
 %
-% \changes{v2.3}{2015/12/20}{与 \LaTeXiii{} (2015/12/20) 同步。}
+% \changes{v2.3}{2015/12/20}{与 \LaTeXiii\ (2015/12/20) 同步。}
 % \changes{v2.4.10}{2017/07/19}{常数 \cs{c_minus_one} 已过时。}
 % \changes{v2.4.10}{2017/07/22}{使用 \texttt{lazy} 函数对 Boolean 表达式
-% 进行最小化运算（\LaTeXiii{} 2017/07/19）。}
-% \changes{v2.6.0}{2024/04/20}{提升 \LaTeXiii{} 版本至 2022/10/09。}
-% \changes{v2.6.0}{2026/05/03}{提升 \LaTeXiii{} 最低版本要求至 2025/10/09。}
+% 进行最小化运算（\LaTeXiii\ 2017/07/19）。}
+% \changes{v2.6.0}{2024/04/20}{提升 \LaTeXiii\ 版本至 2022/10/09。}
+% \changes{v2.6.0}{2026/05/03}{提升 \LaTeXiii\ 最低版本要求至 2025/10/09。}
 %
 % 检查 \pkg{expl3} 的版本。
 %    \begin{macrocode}
@@ -3510,7 +3510,7 @@ Copyright and Licence
 %    \end{macrocode}
 %
 % \begin{variable}{\c_@@_engine_str,\c_@@_engine_file_str}
-% 引擎检查。目前 \LaTeXiii{} 将 \ApTeX{} 识别为 \upTeX。
+% 引擎检查。目前 \LaTeXiii\ 将 \ApTeX\ 识别为 \upTeX。
 %    \begin{macrocode}
 \str_const:Nx \c_@@_engine_str
   { \cs_if_exist:NTF \ngostype { aptex } { \c_sys_engine_str } }
@@ -3663,7 +3663,7 @@ Copyright and Licence
 % \end{macro}
 %
 % \begin{macro}[int]{\ctex_if_preamble:TF}
-% 测试是否在 \LaTeXe{} 的导言区。在宏包内部初始为真，文档最开始位置再设置为假。
+% 测试是否在 \LaTeXe\ 的导言区。在宏包内部初始为真，文档最开始位置再设置为假。
 % 注意，钩子 \cs{ctex_after_end_preamble:n} 在 \tn{AtBeginDocument} 之后执行，
 % 可以与 \tn{@onlypreamble} 的行为一致。
 %    \begin{macrocode}
@@ -4196,7 +4196,7 @@ Copyright and Licence
 %</class|style>
 %    \end{macrocode}
 %
-% \pdfLaTeX{} 下，如果没有显式指定编码为 |UTF8|，则给出警告信息。
+% \pdfLaTeX\ 下，如果没有显式指定编码为 |UTF8|，则给出警告信息。
 %    \begin{macrocode}
 %<*class|ctex>
 \msg_new:nnn { ctex } { pdftex-utf8 }
@@ -4249,14 +4249,14 @@ Copyright and Licence
 %
 % \subsubsection{\pkg{ctexbackend.cfg}}
 %
-% 对于 \XeLaTeX{}/\pdfLaTeX{}/\LuaLaTeX{} 等默认直接输出 PDF 的编译方式，用户
-% 无需为涉及驱动的宏包指定驱动选项。对于 \LaTeX 和 \upLaTeX{} 等默认不直接输出 PDF 的编译方式，
+% 对于 \XeLaTeX/\pdfLaTeX/\LuaLaTeX\ 等默认直接输出 PDF 的编译方式，用户
+% 无需为涉及驱动的宏包指定驱动选项。对于 \LaTeX 和 \upLaTeX\ 等默认不直接输出 PDF 的编译方式，
 % 用户则需要指定驱动选项。
 %
-% 由于历史遗留问题，在使用 \LaTeX{} 或 \upLaTeX{} 等编译时，
+% 由于历史遗留问题，在使用 \LaTeX\ 或 \upLaTeX\ 等编译时，
 % 大多数涉及驱动的宏包选定的默认输出驱动都是 Dvips。
-% 考虑当前实际使用频率，以及考虑到 \CTeX{} 宏集对中文支持的默认方式，
-% 我们在用户使用 \CTeX{} 系列文档类时，将默认的输出驱动改为 \dvipdfmx。
+% 考虑当前实际使用频率，以及考虑到 \CTeX\ 宏集对中文支持的默认方式，
+% 我们在用户使用 \CTeX\ 系列文档类时，将默认的输出驱动改为 \dvipdfmx。
 %
 % 具体来说，如果 |dvips|，|dvipdfmx|，|dvisvgm| 等驱动没有在文档类的全局选项中被明确指定，
 % 我们就在 \tn{@classoptionslist} 开头加入 |dvipdfmx|。
@@ -4291,8 +4291,8 @@ Copyright and Licence
 % \subsubsection{\pkg{ctex-engine-pdftex.def}}
 %
 % \begin{macro}[int]{\ctex_set_zhmap:n}
-% 设置 \upTeX{} 字体映射，同时作用于 \tn{AtBeginDvi} 与
-% \tn{AtBeginShipoutFirst}。该宏对 \pdfTeX{} 和 \upTeX{} 均有用。
+% 设置 \upTeX\ 字体映射，同时作用于 \tn{AtBeginDvi} 与
+% \tn{AtBeginShipoutFirst}。该宏对 \pdfTeX\ 和 \upTeX\ 均有用。
 % \tn{AtBeginDvi} 直接将 \tn{special} 保存到盒子中，
 % \tn{AtBeginShipoutFirst} 是保存到到宏中，并且不展开参数。
 %
@@ -4331,7 +4331,7 @@ Copyright and Licence
 %<*pdftex>
 %    \end{macrocode}
 %
-% \changes{v2.1}{2015/05/18}{给 \pdfLaTeX{} 下的非 UTF-8 编码 CJK 字体族加上 CMap。}
+% \changes{v2.1}{2015/05/18}{给 \pdfLaTeX\ 下的非 UTF-8 编码 CJK 字体族加上 CMap。}
 %
 % \begin{variable}{\c_@@_cmap_encoding_seq}
 % 需要加上 CMap 的 CJK 字体编码。
@@ -4398,7 +4398,7 @@ Copyright and Licence
 % \end{macro}
 %
 % \begin{macro}[int]{\DeclareFontFamily}
-% 只在 \pdfLaTeX{} 下加 CMap。如 \pkg{cmap} 宏包被引入，则不重复设置。
+% 只在 \pdfLaTeX\ 下加 CMap。如 \pkg{cmap} 宏包被引入，则不重复设置。
 %    \begin{macrocode}
 \sys_if_output_pdf:T
   {
@@ -5171,7 +5171,7 @@ Copyright and Licence
 %
 % \changes{v2.3}{2015/09/26}{更新 \pkg{unicode-math} 宏包补丁。}
 %
-% 在 \LaTeX{} 下，\pkg{LuaTeX-ja} 对 \pkg{fontspec}、\pkg{xunicode}、\pkg{unicode-math}
+% 在 \LaTeX\ 下，\pkg{LuaTeX-ja} 对 \pkg{fontspec}、\pkg{xunicode}、\pkg{unicode-math}
 % 和 \pkg{listings} 打了补丁。其中前三个是把 \tn{char} 换成 \tn{ltjalchar}，确保
 % 字符是 ALchar 类。我们这里用 \pkg{xunicode-addon} 来处理 \pkg{xunicode}。
 %    \begin{macrocode}
@@ -5581,7 +5581,7 @@ Copyright and Licence
 % 以下内容来自 \file{lltjfont.sty}，目的是让汉字可以在数学环境中直接使用。
 %
 % \begin{macro}[int]{\ctex_ltj_if_jfont:nTF}
-% 参数 |#1| 是一个 \LaTeXe{} 编码名称或者字体命令。\LaTeXe{} 字体命令的一般形式是：
+% 参数 |#1| 是一个 \LaTeXe\ 编码名称或者字体命令。\LaTeXe\ 字体命令的一般形式是：
 % \begin{quote}\ttfamily\small
 %   \textbackslash\meta{encoding}/\meta{family}/\meta{series}/\meta{shape}
 % \end{quote}
@@ -6659,7 +6659,7 @@ Copyright and Licence
 % \changes{v2.6.0}{2026/04/27}{修复内联 \tn{verb} 前 \opt{xkanjiskip} 丢失的问题
 %   （移植 \pkg{lltjcore} 对 \tn{verb} 和 \tn{do@noligs} 的修复）。}
 %
-% \pkg{LuaTeX-ja} 的 \file{lltjcore.sty} 会将 \LaTeX{} 的 \tn{verb} 中
+% \pkg{LuaTeX-ja} 的 \file{lltjcore.sty} 会将 \LaTeX\ 的 \tn{verb} 中
 % \tn{null}（即 |\hbox{}|）替换为 |\vadjust{}|，因为空 |\hbox{}| 会阻断
 % \opt{xkanjiskip} 的自动插入。由于 \pkg{ctex} 禁用了 \pkg{ltj-latex}，
 % 这里需要自行复制该修复。
@@ -6680,7 +6680,7 @@ Copyright and Licence
 %    \end{macrocode}
 %
 % \begin{macro}{\@@@@italiccorr}
-% \LaTeX{} 的倾斜校正也要重新定义。
+% \LaTeX\ 的倾斜校正也要重新定义。
 %    \begin{macrocode}
 \cs_set_eq:NN \@@@@italiccorr \/
 %    \end{macrocode}
@@ -6733,10 +6733,10 @@ Copyright and Licence
 %    \end{macrocode}
 %
 % \begin{macro}[int]{\em}
-% \changes{v2.4.2}{2016/05/15}{兼容 \upLaTeX{} 2016/05/07u00 的定义。}
-% 取消 \upLaTeX{} 对 \tn{em} 使用 |\mcfamily|、|\gtfamily| 命令的重定义，恢复
-% \LaTeXe{} 对 \tn{em} 的原始定义。如果用户已经重定义了 \tn{em}，则新定义保持
-% 不变。\upLaTeX{} 2016/05/07u00 的定义有所变化，这一行为可以由用户通过 \pkg{platexrelease}
+% \changes{v2.4.2}{2016/05/15}{兼容 \upLaTeX\ 2016/05/07u00 的定义。}
+% 取消 \upLaTeX\ 对 \tn{em} 使用 |\mcfamily|、|\gtfamily| 命令的重定义，恢复
+% \LaTeXe\ 对 \tn{em} 的原始定义。如果用户已经重定义了 \tn{em}，则新定义保持
+% 不变。\upLaTeX\ 2016/05/07u00 的定义有所变化，这一行为可以由用户通过 \pkg{platexrelease}
 % 包改变，需要分支处理。
 %    \begin{macrocode}
 \ctex_patch_cmd_once:NnnnTF \em
@@ -6753,7 +6753,7 @@ Copyright and Licence
 %    \end{macrocode}
 % \end{macro}
 %
-% \changes{v2.4}{2016/04/24}{正确设置 \upTeX{} 下字体命令。}
+% \changes{v2.4}{2016/04/24}{正确设置 \upTeX\ 下字体命令。}
 % \begin{macro}[int]{\ctex_set_upfamily:nnn}
 % 将 NFSS 字体族 |#1| 设置为 JFM 字体名 |#2|，粗体形式字体名 |#3|。其中字体名
 % 形如 |upzhserif|，不包括表示方向的后缀 |-h| 与 |-v|。粗体字体名为空时不设置该
@@ -6777,7 +6777,7 @@ Copyright and Licence
 % \end{macro}
 %
 % \begin{macro}[int]{\ctex_set_upmap:nnn}
-% 设置 \upTeX{} 字体映射。|#1| 是形如 |upserif| 的 PS TFM 字体名，不带表示粗体
+% 设置 \upTeX\ 字体映射。|#1| 是形如 |upserif| 的 PS TFM 字体名，不带表示粗体
 % 的后缀 |b| 与表示排版方向的后缀 |-h| 与 |-v|。|#2| 与 |#3| 是普通与粗体的实际
 % 字体名。
 %    \begin{macrocode}
@@ -6798,7 +6798,7 @@ Copyright and Licence
 % \end{macro}
 %
 % \begin{macro}[int]{\ctex_set_upmap_unicode:nnn}
-% 设置 \upTeX{} 字体映射，使用 |unicode| CMap。参数同上。
+% 设置 \upTeX\ 字体映射，使用 |unicode| CMap。参数同上。
 %    \begin{macrocode}
 \cs_new_protected:Npn \ctex_set_upmap_unicode:nnn #1#2#3
   {
@@ -6817,7 +6817,7 @@ Copyright and Licence
 % \end{macro}
 %
 % \begin{macro}[int]{\ctex_set_upfonts:nnnnnn}
-% 设置 \upTeX{} 基本字体映射，按 \pkg{zhmetrics-uptex} 的定义，依次设置衬线体
+% 设置 \upTeX\ 基本字体映射，按 \pkg{zhmetrics-uptex} 的定义，依次设置衬线体
 % 正、粗、意大利，无衬线体正、粗，等宽体正——共 6 种字体，并分横排及直排。
 %    \begin{macrocode}
 \cs_new_protected:Npn \ctex_set_upfonts:nnnnnn #1#2#3#4#5#6
@@ -6840,7 +6840,7 @@ Copyright and Licence
 %
 % \changes{v2.4.7}{2016/12/27}{依赖 \pkg{pxeverysel} 宏包。}
 %
-% \pkg{everysel} 宏包（2011/10/28）未考虑 \upLaTeX{} 对 \tn{selectfont} 的修
+% \pkg{everysel} 宏包（2011/10/28）未考虑 \upLaTeX\ 对 \tn{selectfont} 的修
 % 改，需要引入 \pkg{pxeverysel} 宏包。
 %    \begin{macrocode}
 \bool_if:NT \c_@@_everysel_loaded_bool
@@ -6933,7 +6933,7 @@ Copyright and Licence
 %    \end{macrocode}
 %
 % \changes{v2.4}{2016/02/15}{正确更新 \pkg{CJK} 包的 \tn{CJKfamilydefault}。}
-% \changes{v2.4.1}{2016/04/26}{正确更新 \upLaTeX{} 的 \tn{CJKfamilydefault}。}
+% \changes{v2.4.1}{2016/04/26}{正确更新 \upLaTeX\ 的 \tn{CJKfamilydefault}。}
 %
 % \begin{macro}[int]{\ctex_update_default_family:}
 % 在导言区结束，如果 \tn{CJKfamilydefault} 没有被更改，则在此时根据西文字体的情况
@@ -6958,8 +6958,8 @@ Copyright and Licence
         \group_end:
       }
 %    \end{macrocode}
-% 使用 \LuaLaTeX{} 时，自动调整得到的 \tn{CJKfamilydefault} 可能没有定义，需要
-% 确认它的存在性。使用 \pkg{CJK} 宏包或 \upLaTeX{}
+% 使用 \LuaLaTeX\ 时，自动调整得到的 \tn{CJKfamilydefault} 可能没有定义，需要
+% 确认它的存在性。使用 \pkg{CJK} 宏包或 \upLaTeX\
 % 时，\texttt{C19rm}、\texttt{JY2rm} 等总是有定义的，不需要确认。
 %    \begin{macrocode}
 %<luatex>    \ctex_ltj_ensure_default_family:
@@ -7018,7 +7018,7 @@ Copyright and Licence
 %
 % \changes{v2.5.7}{2021/06/06}{禁用 \dvipdfmx\ 驱动的 \opt{unicode} 书签设置。}
 %
-% 在 \pdfTeX{} 下使用 \texttt{GBK} 编码，\dvipdfmx{} 驱动可以直接用它的
+% 在 \pdfTeX\ 下使用 \texttt{GBK} 编码，\dvipdfmx\ 驱动可以直接用它的
 % \tn{special} 命令，其他模式用 \pkg{xCJK2uni} 宏包处理。使用 \texttt{UTF-8} 编
 % 码时，\pkg{CJKutf8} 已经处理了书签问题，但仍需要设置 \opt{pdfencoding} 为
 % \opt{unicode}，目的是在书签的开头写入 BOM (|\376\377|)，提示这是
@@ -7065,8 +7065,8 @@ Copyright and Licence
 %</xetex|luatex>
 %    \end{macrocode}
 %
-% 我们假定 \upTeX{} 使用 \dvipdfmx{} 驱动输出，于是使用与 \pdfTeX{} 类似的设
-% 置。注意 \upTeX{} 需要使用 UTF8-UTF16 的编码转换。
+% 我们假定 \upTeX\ 使用 \dvipdfmx\ 驱动输出，于是使用与 \pdfTeX\ 类似的设
+% 置。注意 \upTeX\ 需要使用 UTF8-UTF16 的编码转换。
 %    \begin{macrocode}
 %<*uptex|aptex>
 \@ifpackageloaded { hyperref }
@@ -7102,7 +7102,7 @@ Copyright and Licence
 % \tn{CTEXunderdblline}、\tn{CTEXunderwave}、\tn{CTEXsout}、\tn{CTEXxout}、
 % \env{CTEXfilltwosides} 等命令和环境。}
 %
-% 对 \pdfTeX{} 与 \XeTeX{} 引擎，分别在 \pkg{CJKfntef}、\pkg{xeCJKfntef} 宏包
+% 对 \pdfTeX\ 与 \XeTeX\ 引擎，分别在 \pkg{CJKfntef}、\pkg{xeCJKfntef} 宏包
 % 的末尾关闭彩色显式等多余格式。
 %
 %    \begin{macrocode}
@@ -7137,7 +7137,7 @@ Copyright and Licence
 % \subsubsection{\tn{ccwd} 的更新}
 %
 % \begin{macro}[int]{\ctex_update_ccwd:,\ccwd}
-% \changes{v2.4.1}{2016/04/29}{正确设置 \upTeX{} 下的 \tn{ccwd}。}
+% \changes{v2.4.1}{2016/04/29}{正确设置 \upTeX\ 下的 \tn{ccwd}。}
 %    \begin{macrocode}
 \cs_new_protected:Npn \ctex_update_ccwd:
 %<*pdftex|xetex>
@@ -7214,12 +7214,12 @@ Copyright and Licence
 % \begin{macro}[int]{\ctex_update_em_unit:}
 % 将当前汉字的宽度保存到 \tn{ccwd} 中备用。不采用 \texttt{1em}，因为这时的
 % \texttt{1em} 实际上来自西文字体的信息，未必等于汉字的宽度，这似乎在传统的
-% \file{.tfm} 字体上表现更明显。在 \pdfTeX{} 和 \XeTeX{} 下，直接使用 |\f@size\p@|
+% \file{.tfm} 字体上表现更明显。在 \pdfTeX\ 和 \XeTeX\ 下，直接使用 |\f@size\p@|
 % 作为汉字的宽度，这应该对大多数汉字字体都成立，但不适用于诸如“方正兰亭黑长”之类
-% 的特殊字体。在 \XeTeX{} 可以用 \tn{fontcharwd} 来改进。而在 \pdfTeX{} 下，若使用
+% 的特殊字体。在 \XeTeX\ 可以用 \tn{fontcharwd} 来改进。而在 \pdfTeX\ 下，若使用
 % \pkg{zhmetrics} 技术，所有的汉字共享同一个 \file{.tfm}，\tn{fontcharwd} 也就没有
-% 意义。在 \LuaTeX{} 下，\pkg{LuaTeX-ja} 总是按照 JFM 中的设置输出汉字的宽度，可以
-% 直接用 \tn{zw} 作为汉字宽度。\upTeX{} 可以直接使用原生的长度单位 |zw|。
+% 意义。在 \LuaTeX\ 下，\pkg{LuaTeX-ja} 总是按照 JFM 中的设置输出汉字的宽度，可以
+% 直接用 \tn{zw} 作为汉字宽度。\upTeX\ 可以直接使用原生的长度单位 |zw|。
 %    \begin{macrocode}
 \cs_new_protected:Npn \ctex_update_em_unit:
 %<pdftex|xetex>  { \dim_set:Nn \ccwd { \f@size \p@ } }
@@ -7334,13 +7334,13 @@ Copyright and Licence
 %</luatex>
 %    \end{macrocode}
 %
-% \changes{v2.4.1}{2016/05/01}{随字体更新 \upTeX{} 的 \tn{xkanjiskip}。}
+% \changes{v2.4.1}{2016/05/01}{随字体更新 \upTeX\ 的 \tn{xkanjiskip}。}
 %
 % \begin{macro}[int]{\ctex_update_xkanjiskip:}
 % \begin{variable}{\l_@@_xkanjiskip_skip}
-% \upTeX{} 和 \pkg{LuaTeX-ja} 对 \tn{xkanjiskip} 都是即时赋值。单位 \opt{zw} 与字体相关，因此
+% \upTeX\ 和 \pkg{LuaTeX-ja} 对 \tn{xkanjiskip} 都是即时赋值。单位 \opt{zw} 与字体相关，因此
 % 需要每次 \tn{selectfont} 的时候更新一次 \tn{xkanjiskip}。如果用户设置过
-% \tn{xkanjiskip}，就不更新。注意，同 \TeX{} 的 \tn{baselineskip} 一样，如果在
+% \tn{xkanjiskip}，就不更新。注意，同 \TeX\ 的 \tn{baselineskip} 一样，如果在
 % 一个段落内多次设置了 \tn{kanjiskip} 或 \tn{xkanjiskip}，只有最后的设置会影响
 % 全段。
 %    \begin{macrocode}
@@ -7407,7 +7407,7 @@ Copyright and Licence
 %
 % \begin{macro}{space}
 % 在导言区或正文中设置忽略空格方式。
-% \pdfTeX{} 和 \XeTeX{} 下初始设置为 \opt{auto}，\LuaTeX{}、\upTeX{} 下是无效
+% \pdfTeX\ 和 \XeTeX\ 下初始设置为 \opt{auto}，\LuaTeX、\upTeX\ 下是无效
 % 选项。
 %    \begin{macrocode}
 \ctex_define:n
@@ -7436,7 +7436,7 @@ Copyright and Licence
 %
 % \begin{macro}{punct}
 % 在导言区或正文中设置标点符号输出格式。\pkg{LuaTeX-ja} 设置的是字体的默认 \texttt{JFM}，
-% 只会影响到之后设置的字体。\upTeX{} 暂时无效。
+% 只会影响到之后设置的字体。\upTeX\ 暂时无效。
 %    \begin{macrocode}
 \ctex_define:n
   {
@@ -7457,8 +7457,8 @@ Copyright and Licence
 %
 % \begin{macro}{experiment,experiment/CJKecglue}
 % 实验性选项。\opt{experiment/CJKecglue} 用于统一设置 CJK 文字与西文之间的间距。
-% \XeTeX{} 下转发给 \pkg{xeCJK}，\LuaTeX{} 和 \upTeX{} 下设置 |xkanjiskip|，
-% \pdfTeX{} 下不支持。
+% \XeTeX\ 下转发给 \pkg{xeCJK}，\LuaTeX\ 和 \upTeX\ 下设置 |xkanjiskip|，
+% \pdfTeX\ 下不支持。
 %    \begin{macrocode}
 \ctex_define:n
   { experiment .meta:nn = { ctex / experiment } {#1} }
@@ -7710,7 +7710,7 @@ Copyright and Licence
     \dim_compare:nNnTF \ccwd > \c_zero_dim
 %    \end{macrocode}
 % 伸展量保证行内的剩余空白能够被均匀地填充到汉字之间，收缩的最大限度是让当前行
-% 还能够再挤下一个汉字并且不会出现负间距。由 \TeX{} 决定伸展还是收缩。
+% 还能够再挤下一个汉字并且不会出现负间距。由 \TeX\ 决定伸展还是收缩。
 %    \begin{macrocode}
       {
         \dim_set:Nn \l_@@_tmp_dim
@@ -7739,7 +7739,7 @@ Copyright and Licence
     \ctex_update_ccglue:
 %    \end{macrocode}
 % 字距设置得比较大时，为了尽量保证段首缩进能够与下一行对齐，应该需要相应地加上
-% 或者减去伸缩值。但是这里并不清楚 \TeX{} 是伸展还是收缩，之前以“当前行是否还
+% 或者减去伸缩值。但是这里并不清楚 \TeX\ 是伸展还是收缩，之前以“当前行是否还
 % 放得下一个汉字”为标准加上或减去伸缩值的做法也未必与实际结果一致，所以只好还
 % 是设置为 |2\ccwd|。
 %    \begin{macrocode}
@@ -7920,7 +7920,7 @@ Copyright and Licence
 %
 % \subsection{中文化的标题结构}
 %
-% 本节内容在 \CTeX{} 文档类或打开 \opt{heading} 选项下生效。
+% 本节内容在 \CTeX\ 文档类或打开 \opt{heading} 选项下生效。
 %    \begin{macrocode}
 %<*class|heading>
 %    \end{macrocode}
@@ -8056,7 +8056,7 @@ Copyright and Licence
 %
 % \begin{macro}[int]{\ctex_assign_heading_name:nn}
 % \begin{macro}{\@@_assign_heading_name:nnn}
-% \opt{name} 的值是一个至多两个元素的逗号分隔列表。由于 \LaTeXiii{} 的
+% \opt{name} 的值是一个至多两个元素的逗号分隔列表。由于 \LaTeXiii\ 的
 % \texttt{clist} 总是会自动忽略空元素，所以设置 |name={,章}| 后，第一个元素将会
 % 是“章”，必须用空的分组保护空元素：|name={{},章}|，这在使用中有些许不便。我们
 % 可以改用 \texttt{seq} 或者手写函数解析参数来加以改进。为实现的简单起见，这里用
@@ -8174,7 +8174,7 @@ Copyright and Licence
 % \begin{macro}[int]{\CTEX@fixheadingskip}
 % 抑制行间粘连，修正标题前后的多余间距。事实上，减掉 \tn{parskip}，有一定的风险。
 % 如果接下来的内容不会进入水平模式（例如在 \opt{format} 选项中使用 \tn{hrule} 或者 \tn{hbox}），
-% \TeX{} 就不会加上 \tn{parskip}。这时候就需要用户把 \tn{parskip} 加到 \opt{beforeskip}
+% \TeX\ 就不会加上 \tn{parskip}。这时候就需要用户把 \tn{parskip} 加到 \opt{beforeskip}
 % 或者 \opt{afterskip} 作为修正。
 %    \begin{macrocode}
 \cs_new_protected:Npn \CTEX@fixheadingskip
@@ -8944,7 +8944,7 @@ Copyright and Licence
 % \end{macro}
 %
 % \begin{variable}{\c_@@_headings_cs_seq}
-% 保存内部标题命令的 \CTeX{} 定义，用于随后比较。
+% 保存内部标题命令的 \CTeX\ 定义，用于随后比较。
 %    \begin{macrocode}
 \seq_const_from_clist:Nn \c_@@_headings_cs_seq
 %<article>  { part , spart , sect , ssect }
@@ -8960,7 +8960,7 @@ Copyright and Licence
 % \begin{macro}[int]{\CTEX@hyperheadinghook}
 % \pkg{hyperref} 会重定义内部标题命令，目的在于为没有编号的标题设置锚点（这一功能受他的
 % \opt{implicit} 选项的控制）。我们在上面对标题命令的修改已经包含这一功能，如果这些标题命令在
-% \pkg{hyperref} 载入之前没有被修改过，则恢复 \CTeX{} 的定义。
+% \pkg{hyperref} 载入之前没有被修改过，则恢复 \CTeX\ 的定义。
 %    \begin{macrocode}
 \cs_new_protected:Npn \CTEX@hyperheadinghook
   {
@@ -9043,9 +9043,9 @@ Copyright and Licence
 %   \Arg{left}\Arg{right}\Arg{before}\Arg{after}\Arg{afterindent}
 % \end{quote}
 % 其中 \meta{afterindent} 为 |1| 或 |0|，分别对应是否保留段首缩进。
-% 我们需要根据 \CTeX{} 的 \opt{runin} 和 \opt{afterindent} 选项调整
+% 我们需要根据 \CTeX\ 的 \opt{runin} 和 \opt{afterindent} 选项调整
 % |\ttlh@|\meta{shape} 和 \meta{afterindent}。注意，由 \tn{ttl@extract} 得的
-% \meta{before} 和 \meta{after} 的值总是非负的，而 \CTeX{} 的 \opt{beforeskip}
+% \meta{before} 和 \meta{after} 的值总是非负的，而 \CTeX\ 的 \opt{beforeskip}
 % 和 \opt{afterskip} 是可以取负值的，但我们不打算调整它们了。
 % 如果使用了 \pkg{titlesec} 的 \opt{indentafter} 等选项，也不需要调整
 % |\ttls@|\meta{section}。
@@ -9123,7 +9123,7 @@ Copyright and Licence
   }
 %    \end{macrocode}
 %
-% \changes{v2.4.4}{2016/09/13}{使用 \pkg{titlesec} 时，章节目录也使用 \CTeX{} 的编号。}
+% \changes{v2.4.4}{2016/09/13}{使用 \pkg{titlesec} 时，章节目录也使用 \CTeX\ 的编号。}
 % 让编译时终端显示  \tn{CTEXthechapter}，目录使用 |\CTEXtheXXX| 编号。
 %    \begin{macrocode}
 \ctex_at_end_package:nn { titlesec }
@@ -9601,7 +9601,7 @@ Copyright and Licence
 % 关于标签引用的宏包可能会修改 \tn{refstepcounter}。其中 \pkg{cleveref} 和
 % \pkg{hyperref} 宏包都会保存之前的定义，并且它们都要求尽可能晚的被载入，所以
 % 对我们上述的修改影响不大。需要注意的是 \pkg{varioref} 宏包，如果它在
-% \CTeX{} 之后被载入，我们之前的修改将会被覆盖。
+% \CTeX\ 之后被载入，我们之前的修改将会被覆盖。
 % 较新版 \LaTeX \ 内核已经包含 \tn{labelformat}，可以直接使用。
 %    \begin{macrocode}
 \cs_new_protected:Npn \ctex_varioref_hook:
@@ -9615,7 +9615,7 @@ Copyright and Licence
 %
 % \begin{macro}{\ctex_fix_varioref_label:n}
 % \pkg{varioref} 宏包的 \tn{labelformat} 实际上是定义一个以 |\the<#1>| 为参数的宏
-% |\p@<#1>|。\LaTeX{} 在定义计数器 |<#1>| 时，都会将 |\p@<#1>| 初始化为 \tn{@empty}。
+% |\p@<#1>|。\LaTeX\ 在定义计数器 |<#1>| 时，都会将 |\p@<#1>| 初始化为 \tn{@empty}。
 % 如果这个宏非空，说明用户自定义了标签格式，我们就不再修改。这里不能使用
 % \cs{exp_args:Nnc}，因为 \texttt{c} 这种展开格式不会将参数放在花括号内。而
 % \tn{labelformat} 的定义是
@@ -9637,14 +9637,14 @@ Copyright and Licence
 % \changes{v2.5.7}{2021/06/04}{同时兼容 \pkg{cleveref} 和 \cls{beamer}。}
 %
 % \begin{macro}{patch/cleveref}
-% \pkg{cleveref} 宏包长期未维护，与较新的 \LaTeX{} 内核和 \pkg{hyperref}
-% 存在兼容问题。\CTeX{} 提供了对 \pkg{cleveref} 的补丁，但用户也可以选择
+% \pkg{cleveref} 宏包长期未维护，与较新的 \LaTeX\ 内核和 \pkg{hyperref}
+% 存在兼容问题。\CTeX\ 提供了对 \pkg{cleveref} 的补丁，但用户也可以选择
 % 关闭它。
 %
 % 当同时使用 \pkg{hyperref} 和 \pkg{cleveref} 时，|\appendix| 之后的交叉引用
 % 类型可能不正确（例如，\texttt{appendix} 退化为 \texttt{chapter}）。
-% 这是上游 \LaTeX{} 内核 \texttt{firstaid} 对 \pkg{cleveref} 补丁不完整所致，
-% 与 \CTeX{} 无关。可以使用以下方法规避：
+% 这是上游 \LaTeX\ 内核 \texttt{firstaid} 对 \pkg{cleveref} 补丁不完整所致，
+% 与 \CTeX\ 无关。可以使用以下方法规避：
 % \begin{verbatim}
 %   \AddToHook{cmd/appendix/before}{%
 %     \crefalias{chapter}{appendix}%
@@ -10565,7 +10565,7 @@ Copyright and Licence
 %   \DeclareRobustCommand\CTeX{$\mathbb{C}$\kern-.05em\TeX}
 % \end{verbatim}
 % 然而 \tn{mathbb} 未必有定义，这里就不采用它了，只定义最简单的形式。
-% \CTeX{} 可以直接用在 PDF 书签中。
+% \CTeX\ 可以直接用在 PDF 书签中。
 %    \begin{macrocode}
 \NewDocumentCommand \CTeX { }
   { C \TeX }
@@ -10816,8 +10816,8 @@ Copyright and Licence
 %<tt&c70>\DeclareFontFamily{C70}{tt}{\hyphenchar\font\m@ne}
 %    \end{macrocode}
 %
-% \changes{v2.4}{2016/04/25}{提供 \upLaTeX{} 的 NFSS 字体定义。}
-% \upLaTeX{} 使用的字体族。\upLaTeX 在 NFSS 下使用字体编码 |JY2| 和 |JT2| 来分别
+% \changes{v2.4}{2016/04/25}{提供 \upLaTeX\ 的 NFSS 字体定义。}
+% \upLaTeX\ 使用的字体族。\upLaTeX 在 NFSS 下使用字体编码 |JY2| 和 |JT2| 来分别
 % 表示横排与直排的日文。
 %    \begin{macrocode}
 %<rm&jy2>\DeclareKanjiFamily{JY2}{zhrm}{}
@@ -11312,7 +11312,7 @@ Copyright and Licence
 %
 % \changes{v2.4.14}{2018/05/01}{配置 \opt{macnew} 的默认字体设置。}
 % \changes{v2.5}{2019/11/05}{为 \opt{macnew} 增加粗楷体、隶书和圆体的定义。}
-% \changes{v2.5}{2019/11/07}{允许 \opt{macnew} 在 \LaTeX{} 和 \upLaTeX{} 下使用。}
+% \changes{v2.5}{2019/11/07}{允许 \opt{macnew} 在 \LaTeX\ 和 \upLaTeX\ 下使用。}
 %
 % |macold| 的设置参考了
 % \href{https://github.com/CTeX-org/ctex-kit/wiki/OS-X-Mavericks-(10.9)-预装的主要简体中文字体}^^A
@@ -11565,7 +11565,7 @@ Copyright and Licence
 % \paragraph{\opt{ubuntu}}
 %
 % \changes{v2.5}{2019/11/07}{\opt{ubuntu} 改用思源（Noto CJK）和文鼎字库，不再
-% 支持使用 \pdfLaTeX{} 编译。}
+% 支持使用 \pdfLaTeX\ 编译。}
 %
 %    \begin{macrocode}
 %<*ubuntu>
@@ -11726,7 +11726,7 @@ Copyright and Licence
 % \changes{v2.4.14}{2018/05/01}{为 \opt{macnew} 配置字体命令。}
 %
 % \begin{macro}{\songti,\heiti,\fangsong,\kaishu,\lishu,\youyuan,\yahei,\pingfang}
-% 使用 \upLaTeX{} 编译时，\opt{macnew} 字库中由于传统黑体（黑体-简）无法使用，
+% 使用 \upLaTeX\ 编译时，\opt{macnew} 字库中由于传统黑体（黑体-简）无法使用，
 % 我们用苹方来代替。同时 \tn{yahei}、\tn{pingfang} 命令被设置为与 \tn{heiti} 相同。
 %    \begin{macrocode}
 %<*!mac>
@@ -11824,7 +11824,7 @@ Copyright and Licence
 % \end{macro}
 %
 % \begin{macro}[int]{\ProvidesFile}
-% 提供非 \LaTeX{} 格式下的 \tn{ProvidesFile}。
+% 提供非 \LaTeX\ 格式下的 \tn{ProvidesFile}。
 %    \begin{macrocode}
 \begingroup
 \expandafter\ifx\csname ProvidesFile\endcsname\relax
@@ -12163,7 +12163,7 @@ Copyright and Licence
 % \changes{v2.5.2}{2020/05/05}{\file{ctexspamacro.tex} 更名为 \file{ctex-spa-macro.tex}。}
 % \changes{v2.6.0}{2026/04/30}{修复了 \TeX\ tree 字体无法制作 \file{.spa} 文件的问题。}
 %
-% 我们通过 \XeTeX{} 的 \tn{XeTeXglyphbounds} 取得字体中标点符号的边界信息，为
+% 我们通过 \XeTeX\ 的 \tn{XeTeXglyphbounds} 取得字体中标点符号的边界信息，为
 % \pkg{CJKpunct} 宏包制作 \file{spa}。
 %
 %    \begin{macrocode}
@@ -12312,7 +12312,7 @@ Copyright and Licence
 %</macro>
 %    \end{macrocode}
 %
-% 下面是 \CTeX{} 定义的一些字体。
+% 下面是 \CTeX\ 定义的一些字体。
 %    \begin{macrocode}
 %<*make>
 \input ctex-spa-macro %
@@ -12799,7 +12799,7 @@ Copyright and Licence
 % \end{macro}
 %
 % \begin{macro}[int]{\ctex_patch_cmd:Nnn}
-% 快捷方式，在补丁的时候关闭 \LaTeXiii{} 语法和设置 |@| 为字母类，补丁失败时给出警告。
+% 快捷方式，在补丁的时候关闭 \LaTeXiii\ 语法和设置 |@| 为字母类，补丁失败时给出警告。
 %    \begin{macrocode}
 \cs_new_protected:Npn \ctex_patch_cmd:Nnn #1
   {

--- a/ctex/ctex.dtx
+++ b/ctex/ctex.dtx
@@ -578,15 +578,15 @@ Copyright and Licence
 %
 % \fi
 %
-% \changes{v2.0}{2014/03/06}{应用 \LaTeXiii\ 重新整理代码。}
+% \changes{v2.0}{2014/03/06}{应用 \LaTeXiii{} 重新整理代码。}
 % \changes{v2.6.0}{2026/05/04}{文档字体统一为 Noto CJK 系列（\#686）。}
 % \changes{v2.0}{2014/03/12}{删除 \file{c19gbsn.fd} 和 \file{c19gkai.fd}。}
 % \changes{v2.1}{2015/05/18}{将章节标题设置功能提取到可以独立使用的宏包
 %   \pkg{ctexheading} 中。}
 % \changes{v2.2}{2015/06/24}{不再依赖 \pkg{etoolbox} 宏包。}
 % \changes{v2.4}{2015/02/19}{加强 \pkg{beamer} 宏包支持。}
-% \changes{v2.4.12}{2018/01/13}{同步 \LaTeXiii\ 2017/12/16。}
-% \changes{v2.4.15}{2019/03/23}{同步 \LaTeXiii\ 2019/03/05。}
+% \changes{v2.4.12}{2018/01/13}{同步 \LaTeXiii{} 2017/12/16。}
+% \changes{v2.4.15}{2019/03/23}{同步 \LaTeXiii{} 2019/03/05。}
 % \changes{v2.5.1}{2020/05/02}{\pkg{zhconv} 更名为 \pkg{ctex-zhconv}。}
 %
 % \CheckSum{6916}
@@ -609,17 +609,17 @@ Copyright and Licence
 %
 % \GetFileId{ctex.sty}
 %
-% \title{\bfseries \CTeX\ 宏集手册}
+% \title{\bfseries \CTeX{} 宏集手册}
 % \author{\href{http://www.ctex.org}{CTEX.ORG}}
 % \date{\filedate\qquad\fileversion\thanks{\ctexkitrev{\ExplFileVersion}.}}
 % \maketitle
 %
 % \begin{abstract}
-% \CTeX\ 宏集是面向中文排版的通用 \LaTeX\ 排版框架，为中文 \LaTeX\ 文档
+% \CTeX{} 宏集是面向中文排版的通用 \LaTeX{} 排版框架，为中文 \LaTeX{} 文档
 % 提供了汉字输出支持、标点压缩、字体字号命令、标题文字汉化、中文版式调整、数字
 % 日期转换等支持功能，可适应论文、报告、书籍、幻灯片等不同类型的中文文档。
 %
-% \CTeX\ 宏集支持 \LaTeX、\pdfLaTeX、\XeLaTeX、\LuaLaTeX、\upLaTeX\ 等多种不同
+% \CTeX{} 宏集支持 \LaTeX、\pdfLaTeX、\XeLaTeX、\LuaLaTeX、\upLaTeX{} 等多种不同
 % 的编译方式，并为它们提供了统一的界面。主要功能由宏包 \pkg{ctex} 以及中文文档类
 % \cls{ctexart}、\cls{ctexrep}、\cls{ctexbook} 和 \cls{ctexbeamer} 实现。
 % \end{abstract}
@@ -635,7 +635,7 @@ Copyright and Licence
 %
 % \subsection*{历史}
 %
-% \CTeX\ 宏集的源头有两个：一是王磊编写的 \cls{cjkbook} 文档类，二是吴凌云编写的
+% \CTeX{} 宏集的源头有两个：一是王磊编写的 \cls{cjkbook} 文档类，二是吴凌云编写的
 % \file{GB.cap}。
 % 这些工作没有经过认真系统的设计，也没有用户文档，不利于维护和改进。
 %
@@ -645,64 +645,64 @@ Copyright and Licence
 %
 % 2009 年 5 月，我们在 Google Code 建立了 ctex-kit 项目^^A
 % \footnote{\nolinkurl{http://code.google.com/p/ctex-kit/}，该链接现已失效。}，
-% 对 \pkg{ctex} 宏包及相关脚本进行了整合，并加入了对 \XeTeX\ 引擎的支持。
+% 对 \pkg{ctex} 宏包及相关脚本进行了整合，并加入了对 \XeTeX{} 引擎的支持。
 % 在开发新版本时，考虑到合作开发和调试的方便，我们放弃了 \pkg{doc} 和 \pkg{DocStrip}，
 % 采取了直接编写宏包代码的方式。
 %
-% 2014 年 3 月，为了适应 \LaTeX\ 的最新发展，特别是 \LaTeXiii\ 的逐渐成熟，李清用
-% \LaTeXiii\ 重构了整个宏包的代码，并重新使用 \pkg{doc} 和 \pkg{DocStrip} 工具进行代码
-% 的管理，升级版本号为 2.0，并改称 \CTeX\ 宏集。
+% 2014 年 3 月，为了适应 \LaTeX{} 的最新发展，特别是 \LaTeXiii{} 的逐渐成熟，李清用
+% \LaTeXiii{} 重构了整个宏包的代码，并重新使用 \pkg{doc} 和 \pkg{DocStrip} 工具进行代码
+% 的管理，升级版本号为 2.0，并改称 \CTeX{} 宏集。
 %
 % 2015 年 3 月，由于 Google Code 即将停止服务，ctex-kit 项目迁移至
 % \href{https://github.com/CTeX-org/ctex-kit}{GitHub}^^A
 % \footnote{\url{https://github.com/CTeX-org/ctex-kit}}。
 %
-% 最初，Knuth 在设计开发 \TeX\ 的时候没有考虑到多国文字支持，特别是对多字节的中日韩
-% 表意文字的支持。这使得 \TeX\ 以至后来的 \LaTeX\ 对中文的支持一直不是很好。即使在
-% \pkg{CJK} 宏包解决了中文字符处理的问题以后，中文用户使用 \LaTeX\ 仍然要面对许
+% 最初，Knuth 在设计开发 \TeX{} 的时候没有考虑到多国文字支持，特别是对多字节的中日韩
+% 表意文字的支持。这使得 \TeX{} 以至后来的 \LaTeX{} 对中文的支持一直不是很好。即使在
+% \pkg{CJK} 宏包解决了中文字符处理的问题以后，中文用户使用 \LaTeX{} 仍然要面对许
 % 多困难。
 % 这些困难里，以章节标题的中文化为最。由于中文和西文书写习惯的差异，用户很难使用标准
 % 文档类中的代码结构来表达中文标题。于是，用户不得不对标准文档类做较大的修改。
 % 除此之外，日期格式、首行缩进、中文字号和字距等细节问题，也需要精细的调校。
-% 我们设计 \CTeX\ 宏集的目的之一就是解决这些 \LaTeX\ 文档的汉化难题。
+% 我们设计 \CTeX{} 宏集的目的之一就是解决这些 \LaTeX{} 文档的汉化难题。
 %
-% 另一方面，随着 \TeX\ 引擎和 \LaTeX\ 宏包的不断发展，\LaTeX\ 的中文支持方式从早期的
+% 另一方面，随着 \TeX{} 引擎和 \LaTeX{} 宏包的不断发展，\LaTeX{} 的中文支持方式从早期的
 % 专用系统（如 \pkg{CCT}）发展为适用于不同引擎的多种方式^^A
-% \footnote{比如：\pdfTeX\ 引擎下的 \pkg{CJK}、\pkg{zhmCJK}宏包，
-% \XeTeX\ 引擎下的 \pkg{xeCJK} 宏包和 \LuaTeX\ 引擎下的 \pkg{LuaTeX-ja} 宏包。}。
+% \footnote{比如：\pdfTeX{} 引擎下的 \pkg{CJK}、\pkg{zhmCJK}宏包，
+% \XeTeX{} 引擎下的 \pkg{xeCJK} 宏包和 \LuaTeX{} 引擎下的 \pkg{LuaTeX-ja} 宏包。}。
 % 这些方式的适用情况和使用方式有不少细节上的差异，同时操作系统的不同、语言环境的不同等
-% 客观情况又进一步带来了更多的细节差异。我们设计 \CTeX\ 宏集的另一个主要目的就是
+% 客观情况又进一步带来了更多的细节差异。我们设计 \CTeX{} 宏集的另一个主要目的就是
 % 尽可能消除这些差异带来的影响，使用户能够以一个统一的接口来使用不同的中文支持方式，
 % 使得同一份文档能够在不同环境下交换使用。
 %
-% \CTeX\ 宏集的许多实现细节离不开热心朋友们在 \nolinkurl{bbs.ctex.org} 论坛^^A
-% \footnote{2018 年，\CTeX\ 论坛因故无限期关闭，此链接现已失效。}^^A
+% \CTeX{} 宏集的许多实现细节离不开热心朋友们在 \nolinkurl{bbs.ctex.org} 论坛^^A
+% \footnote{2018 年，\CTeX{} 论坛因故无限期关闭，此链接现已失效。}^^A
 % 上的讨论，在此对参与讨论的朋友们表示感谢。
 %
 % \subsection*{关于宏集名字的说明}
 %
-% \CTeX\ 之名是英文单词 China（中国）或 Chinese（中文）的首字母“C”与 “\TeX”
+% \CTeX{} 之名是英文单词 China（中国）或 Chinese（中文）的首字母“C”与 “\TeX{}”
 % 结合而成的。在纯文本环境下，该名字应写作“CTeX”。
 %
-% \CTeX\ 宏集是由 \href{https://github.com/CTeX-org}{\CTeX\ 社区}发起并维护的
-% \LaTeX\ \emph{宏包和文档类的集合}。
-% 社区另有发布名为 \href{http://www.ctex.org/CTeX}{\CTeX\ 套装}^^A
-% 的 \TeX\ 发行版，与本文档所述的 \CTeX\ 宏集并非是同一事物。
+% \CTeX{} 宏集是由 \href{https://github.com/CTeX-org}{\CTeX{} 社区}发起并维护的
+% \LaTeX{} \emph{宏包和文档类的集合}。
+% 社区另有发布名为 \href{http://www.ctex.org/CTeX}{\CTeX{} 套装}^^A
+% 的 \TeX{} 发行版，与本文档所述的 \CTeX{} 宏集并非是同一事物。
 %
 % \pkg{ctex} 则是本宏集中的 \pkg{ctex.sty} 的名字。这一完全小写的名称，在过去
-% 也被用来指代整个 \CTeX\ 宏集，不过现在则特指 \pkg{ctex.sty} 这一宏包。
+% 也被用来指代整个 \CTeX{} 宏集，不过现在则特指 \pkg{ctex.sty} 这一宏包。
 % 在不引起歧义的情况下，它也可以沿用过去的习惯，代指整个宏集。
 %
 % \section{简明教程}
 %
-% \subsection{\CTeX\ 宏集的组成}
+% \subsection{\CTeX{} 宏集的组成}
 %
-% 为了适应用户不同的需求，我们将 \CTeX\ 宏集的主要功能设计安排在四个中文文档类和
+% 为了适应用户不同的需求，我们将 \CTeX{} 宏集的主要功能设计安排在四个中文文档类和
 % 三个宏包当中，具体的组成见表~\ref{tab:ctex}。
 %
 % \begin{table}[htbp]
 % \centering
-% \caption{\CTeX\ 宏集的组成}\label{tab:ctex}
+% \caption{\CTeX{} 宏集的组成}\label{tab:ctex}
 % \begin{tabularx}{\linewidth}{llX}
 % \toprule
 %   类别   & 文件 & 说明 \\
@@ -719,23 +719,23 @@ Copyright and Licence
 %   宏包   & \file{ctex.sty}        & 提供全部功能，但\emph{默认不开启章节标题设置功能}，
 %                                     需要使用 \opt{heading} 选项来开启 \\
 %          & \file{ctexsize.sty}    & 定义和调整中文字号，可以在 \pkg{ctex} 宏包
-%                                     或 \CTeX\ 中文文档类之外单独调用 \\
+%                                     或 \CTeX{} 中文文档类之外单独调用 \\
 %          & \file{ctexheading.sty} & 提供章节标题设置功能（见 \ref{sec:secstyle}
-%                                     节），可以在 \pkg{ctex} 宏包或 \CTeX\ 中文
+%                                     节），可以在 \pkg{ctex} 宏包或 \CTeX{} 中文
 %                                     文档类之外单独调用 \\
 % \bottomrule
 % \end{tabularx}
 % \end{table}
 %
-% \subsection{\CTeX\ 宏集的安装和更新}
+% \subsection{\CTeX{} 宏集的安装和更新}
 % \label{subsec:easy-ins}
-% 最常见的 \TeX\ 发行版（\TeXLive\ 和 \MiKTeX）已收录 \CTeX\ 宏集及其依赖的宏包和宏集。
+% 最常见的 \TeX{} 发行版（\TeXLive{} 和 \MiKTeX{}）已收录 \CTeX{} 宏集及其依赖的宏包和宏集。
 % \footnote{\pkg{zhmCJK} 宏包是个例外。当用户显式指定选项 \opt{zhmap = zhmCJK} 时，^^A
-% \CTeX\ 宏集依赖它。由于，它没有被 \TeXLive\ 和 \MiKTeX\ 收录，用户可能需要遵照其说明文档
-% 自行安装。}如果本地安装 \TeXLive\ 或 \MiKTeX\ 不是完整版本，则可能需要通过这
+% \CTeX{} 宏集依赖它。由于，它没有被 \TeXLive{} 和 \MiKTeX{} 收录，用户可能需要遵照其说明文档
+% 自行安装。}如果本地安装 \TeXLive{} 或 \MiKTeX{} 不是完整版本，则可能需要通过这
 % 两个发行版提供的\emph{包管理器}来安装宏包。
 %
-% \TeXLive\ 的包管理器是 tlmgr（\TeXLive\ Manager）。用户可以在系统命令行中^^A
+% \TeXLive{} 的包管理器是 tlmgr（\TeXLive{} Manager）。用户可以在系统命令行中^^A
 % \footnote{Windows 系统的命令行是 CMD 命令提示符，你可以使用 Win + R 组合键
 % 打开“运行”对话框，然后输入 cmd 确认打开命令提示符窗口。}执行
 % \begin{frameverb}
@@ -748,47 +748,47 @@ Copyright and Licence
 % \begin{frameverb}
 %   tlmgr install ctex
 % \end{frameverb}
-% 来安装 \CTeX\ 宏集^^A
+% 来安装 \CTeX{} 宏集^^A
 % \footnote{*nix 用户可能需要超级用户权限（sudo）才能正确安装宏集。}。
 %
-% \MiKTeX\ 通常会在缺失宏包时自动完成安装。如需手动安装，可以使用其管理维护
-% 工具 \MiKTeX\ Console。用户可以打开管理器，连接上远程仓库之后，在“Package”
+% \MiKTeX{} 通常会在缺失宏包时自动完成安装。如需手动安装，可以使用其管理维护
+% 工具 \MiKTeX{} Console。用户可以打开管理器，连接上远程仓库之后，在“Package”
 % 选项卡中搜索“ctex”并安装即可。
-% 也可以使用 mpm（\MiKTeX\ Package Manager），在命令行执行
+% 也可以使用 mpm（\MiKTeX{} Package Manager），在命令行执行
 % \begin{frameverb}
 %   mpm --admin --install=ctex
 % \end{frameverb}
-% 来安装 \CTeX\ 宏集。
+% 来安装 \CTeX{} 宏集。
 %
-% 若希望了解 \CTeX\ 宏集具体的依赖情况或手工安装宏集的方法，
+% 若希望了解 \CTeX{} 宏集具体的依赖情况或手工安装宏集的方法，
 % 请参阅第 \ref{sec:dep-ins}~节。
 %
 % 当我们将宏集的新版本发布于 CTAN，且为发行版的远程仓库更新后，用户就可以在本地
 % 通过包管理器获取新版本。
 %
-% 对于 \TeXLive，可以在 tlmgr 的图形界面点击“更新全部已安装的”按钮或者在
+% 对于 \TeXLive{}，可以在 tlmgr 的图形界面点击“更新全部已安装的”按钮或者在
 % 命令行执行
 % \begin{frameverb}
 %   tlmgr update --all
 % \end{frameverb}
 % 来完整更新已安装的宏包。
 %
-% 对于 \MiKTeX，在 \MiKTeX\ Console 中找到“Updates”选项卡，检查更新后即可
+% 对于 \MiKTeX{}，在 \MiKTeX{} Console 中找到“Updates”选项卡，检查更新后即可
 % 选择升级宏包。也可以使用 mpm，在命令行执行
 % \begin{frameverb}
 %   mpm --admin --update
 % \end{frameverb}
 % 来进行更新。
 %
-% \subsection{使用 \CTeX\ 文档类}
+% \subsection{使用 \CTeX{} 文档类}
 %
 % \emph{如果用户需要在三个标准文档类或 \cls{beamer} 的基础上添加中文及版式的支持，
-% 我们建议用户使用 \CTeX\ 宏集提供的四个中文文档类。}
+% 我们建议用户使用 \CTeX{} 宏集提供的四个中文文档类。}
 %
-% \CTeX\ 宏集提供了四个中文文档类：\cls{ctexart}、\cls{ctexrep}、\cls{ctexbook} 和
-% \cls{ctexbeamer}，分别对应 \LaTeX\ 的标准文档类 \cls{article}、\cls{report}、
+% \CTeX{} 宏集提供了四个中文文档类：\cls{ctexart}、\cls{ctexrep}、\cls{ctexbook} 和
+% \cls{ctexbeamer}，分别对应 \LaTeX{} 的标准文档类 \cls{article}、\cls{report}、
 % \cls{book} 和 \cls{beamer}。使用它们的时候，需要将涉及到的所有源文件使用 UTF-8
-% 编码保存\footnote{使用 (pdf)\LaTeX\ 时也能够使用 GBK 编码，但不推荐。（见
+% 编码保存\footnote{使用 (pdf)\LaTeX{} 时也能够使用 GBK 编码，但不推荐。（见
 % \ref{subs:encoding}~节）}。
 %
 % \begin{ctexexam}
@@ -822,33 +822,33 @@ Copyright and Licence
 % \emph{用户在使用非标准文档类及 \cls{beamer} 时，如果需要添加中文及版式的支持，
 % 则可以使用 \pkg{ctex} 宏包。}
 %
-% 对于建立在 \LaTeX\ 标准文档类之上开发的文档类，在使用 \pkg{ctex} 宏包时
+% 对于建立在 \LaTeX{} 标准文档类之上开发的文档类，在使用 \pkg{ctex} 宏包时
 % 加上 \opt{heading} 选项，可以将章节标题设置为中文风格。
 % \begin{ctexexam}
 %   \documentclass{ltxdoc}
 %   \usepackage[heading = true]{ctex}
 %   \begin{document}
 %   \section{简介}
-%   章节标题中文化的 \LaTeX\ 手册。
+%   章节标题中文化的 \LaTeX{} 手册。
 %   \end{document}
 % \end{ctexexam}
 %
 % \section{宏包选项与 \tn{ctexset} 命令}
 % \label{sec:options}
 %
-% \CTeX\ 宏集已经尽可能就中文的行文和版式习惯做了调整和配置，通常而言，这些配置
-% 已经够用。因此，除非必要，我们不建议普通用户修改这些默认配置。如果你认为 \CTeX\ 宏集
+% \CTeX{} 宏集已经尽可能就中文的行文和版式习惯做了调整和配置，通常而言，这些配置
+% 已经够用。因此，除非必要，我们不建议普通用户修改这些默认配置。如果你认为 \CTeX{} 宏集
 % 的默认配置还可以完善，可以在项目主页上^^A
 % \href{https://github.com/CTeX-org/ctex-kit/issues}{提交 issue}，
 % 向我们反映，我们会酌情在后续版本中予以改进。
 %
-% 不过，\CTeX\ 宏集也提供了一系列选项。用户可以使用这些选项来控制 \CTeX\ 宏集的行为。
+% 不过，\CTeX{} 宏集也提供了一系列选项。用户可以使用这些选项来控制 \CTeX{} 宏集的行为。
 % 按形式分类，这些选项有的以传统的方式提供，有的以 \meta{key}|=|\meta{value} 的形式提供。
 % 按指定位置分类，这些选项又可以分为以下三类：
 % \begin{itemize}
-% \item 名字后带有 \rexptarget\rexpstar\ 号的选项，只能作为宏包/文档类选项，需要
+% \item 名字后带有 \rexptarget\rexpstar{} 号的选项，只能作为宏包/文档类选项，需要
 %   在引入宏包/文档类的时候指定；
-% \item 名字后带有 \exptarget\expstar\ 号的选项，只能通过 \CTeX\ 宏集提供的
+% \item 名字后带有 \exptarget\expstar{} 号的选项，只能通过 \CTeX{} 宏集提供的
 %   用户接口 \tn{ctexset} 来设定；
 % \item 名字后不带有特殊符号的选项，既可以作为宏包/文档类选项，也可以通过
 %   \tn{ctexset} 来设定。
@@ -859,7 +859,7 @@ Copyright and Licence
 %   \begin{syntax}
 %     \tn{ctexset} \Arg{键值列表}
 %   \end{syntax}
-% 是 \CTeX\ 宏集的通用控制命令，用来在宏包载入后控制宏包的各项功能。
+% 是 \CTeX{} 宏集的通用控制命令，用来在宏包载入后控制宏包的各项功能。
 % \tn{ctexset} 的参数是一个键值列表，以通用的接口完成各项设置。
 % \end{function}
 %
@@ -873,7 +873,7 @@ Copyright and Licence
 %   }
 % \end{ctexexam}
 %
-% \tn{ctexset} 采用 \LaTeXiii\ 风格的键值设置，支持不同类型的选项与层次化的选
+% \tn{ctexset} 采用 \LaTeXiii{} 风格的键值设置，支持不同类型的选项与层次化的选
 % 项设置，相关示例见 \ref{sec:secstyle}~节。
 %
 % \section{编译方式、编码与中文字库}
@@ -882,14 +882,14 @@ Copyright and Licence
 % \subsection{编译方式}
 % \label{subs:compile}
 %
-% \CTeX\ 宏集会根据用户使用的编译方式\footnote{\LaTeX、\pdfLaTeX、\XeLaTeX、
-% \LuaLaTeX\ 及 \upLaTeX。}，在底层选择不同的中文支持方式（见
+% \CTeX{} 宏集会根据用户使用的编译方式\footnote{\LaTeX、\pdfLaTeX、\XeLaTeX、
+% \LuaLaTeX{} 及 \upLaTeX。}，在底层选择不同的中文支持方式（见
 % 表~\ref{tab:chinese-support}）。
 %
 % \begin{table}[htbp]
 % \centering
 % \begin{threeparttable}
-% \caption{\CTeX\ 宏集的中文支持方式}
+% \caption{\CTeX{} 宏集的中文支持方式}
 % \label{tab:chinese-support}
 % \begin{tabular}{*6c}
 %   \toprule
@@ -899,26 +899,26 @@ Copyright and Licence
 %   \bottomrule
 % \end{tabular}
 % \begin{tablenotes}
-% \item[*] p\LaTeX-ng（或称 \ApLaTeX）与 \upLaTeX\ 兼容。使用 p\LaTeX-ng 编译
-% 时，\pkg{ctex} 采用与 \upLaTeX\ 相同的设置。
+% \item[*] p\LaTeX-ng（或称 \ApLaTeX）与 \upLaTeX{} 兼容。使用 p\LaTeX-ng 编译
+% 时，\pkg{ctex} 采用与 \upLaTeX{} 相同的设置。
 % \end{tablenotes}
 % \end{threeparttable}
 % \end{table}
 %
-% 不同的编译方式和中文支持方式会在一定程度上影响 \CTeX\ 宏集的行为，比如宏包对
+% 不同的编译方式和中文支持方式会在一定程度上影响 \CTeX{} 宏集的行为，比如宏包对
 % 文档编码、字体选择、空格、标点等的处理。具体细节将在本文档后续内容中进行阐述。
 %
 % \subsection{中文编码}
 % \label{subs:encoding}
 %
 % \begin{function}[rEXP,updated=2019-11-10]{GBK, UTF8}
-%   指明编写文档时使用的编码。\CTeX\ 宏集无法检测文档源文件的实际编码格式，因此需要
+%   指明编写文档时使用的编码。\CTeX{} 宏集无法检测文档源文件的实际编码格式，因此需要
 %   用户通过选项声明。如果没有显式指定，则默认采用 UTF-8 编码。
 %
-%   使用 \XeLaTeX、\LuaLaTeX\ 或 \upLaTeX\ 编译时，\CTeX\ 宏集强制使用
-%   UTF-8 编码，此时 \opt{GBK} 选项无效；使用 (pdf)\LaTeX\ 编译时，
-%   \CTeX\ 宏集默认使用 UTF-8 编码，但用户也可以显式声明 \opt{GBK} 选项，
-%   使 \CTeX\ 宏集按 GBK 编码处理文档。
+%   使用 \XeLaTeX{}、\LuaLaTeX{} 或 \upLaTeX{} 编译时，\CTeX{} 宏集强制使用
+%   UTF-8 编码，此时 \opt{GBK} 选项无效；使用 (pdf)\LaTeX{} 编译时，
+%   \CTeX{} 宏集默认使用 UTF-8 编码，但用户也可以显式声明 \opt{GBK} 选项，
+%   使 \CTeX{} 宏集按 GBK 编码处理文档。
 %
 %   用户需要\emph{保证编译方式、源文件编码、宏包编码选项三者一致}。
 %
@@ -929,16 +929,16 @@ Copyright and Licence
 % \subsection{中文字库}
 % \label{subs:options-CJK-font}
 %
-% 以往，为 \LaTeX\ 文档配置中文支持是一件相当繁琐的事情。默认情况下，
-% \CTeX\ 宏集能自动检测用户使用的编译方式（参见 \ref{subs:compile}~节）和
-% 操作系统\footnote{\CTeX\ 宏集现在能够识别 macOS 及 Windows 系统，
+% 以往，为 \LaTeX{} 文档配置中文支持是一件相当繁琐的事情。默认情况下，
+% \CTeX{} 宏集能自动检测用户使用的编译方式（参见 \ref{subs:compile}~节）和
+% 操作系统\footnote{\CTeX{} 宏集现在能够识别 macOS 及 Windows 系统，
 % 并将其他系统统一归为 Linux。}，选择合适的底层支持和字库，从而简化配置过程。
 % 自动配置的情况参见表~\ref{tab:default-font-select}。
 %
 % \begin{table}[htbp]
 % \centering
 % \begin{threeparttable}
-% \caption{\CTeX\ 宏集自动配置字体策略}
+% \caption{\CTeX{} 宏集自动配置字体策略}
 % \label{tab:default-font-select}
 % \begin{tabular}{*{5}{c}}
 %   \toprule
@@ -964,13 +964,13 @@ Copyright and Licence
 %              & \makecell{\pkg{CJK} + \pkg{zhmetrics}\\中易字库 + 微软雅黑\tnote{6}}
 %              & 不可用 \\
 %   \cmidrule(lr){1-5}
-%   \makecell{\LaTeX\ + \\\dvipdfmx}
+%   \makecell{\LaTeX{} + \\\dvipdfmx}
 %              & 不可用
 %              & \makecell{\pkg{CJK} + \pkg{zhmetrics}\\华文字库 + 苹方}
 %              & \makecell{\pkg{CJK} + \pkg{zhmetrics}\\中易字库 + 微软雅黑\tnote{6}}
 %              & \makecell{\pkg{CJK} + \pkg{zhmetrics}\\Fandol 字库} \\
 %   \cmidrule(lr){1-5}
-%   \makecell{\upLaTeX\ + \\\dvipdfmx}
+%   \makecell{\upLaTeX{} + \\\dvipdfmx}
 %              & 不可用
 %              & \makecell{\pkg{zhmetrics-uptex}\\华文字库 + 苹方}
 %              & \makecell{\pkg{zhmetrics-uptex}\\中易字库 + 微软雅黑}
@@ -983,15 +983,15 @@ Copyright and Licence
 %   \item [3] 仅支持 Windows Vista 及以后的 Windows 操作系统。
 %   \item [4] 由马起园、苏杰、黄晨成等人开发的开源中文字体，
 %     参见：\url{https://www.ctan.org/pkg/fandol}。
-%   \item [5] \LuaLaTeX\ 编译时使用 \pkg{LuaTeX-ja} 宏包。对此，
+%   \item [5] \LuaLaTeX{} 编译时使用 \pkg{LuaTeX-ja} 宏包。对此，
 %     第 \ref{sec:lualatex-chinese}~节有特别说明。
 %   \item [6] 微软雅黑字体并不总是有效，这和选项 \opt{zhmap} 的取值有关。
 % \end{tablenotes}
 % \end{threeparttable}
 % \end{table}
 %
-% 通常，由 \CTeX\ 宏集进行的自动配置已经足够使用，无需用户手工干预；但
-% 是 \CTeX\ 仍然提供了一系列选项，供在 \CTeX\ 的自动选择机制因为
+% 通常，由 \CTeX{} 宏集进行的自动配置已经足够使用，无需用户手工干预；但
+% 是 \CTeX{} 仍然提供了一系列选项，供在 \CTeX{} 的自动选择机制因为
 % 意外情况失效，或者在用户有特殊需求的情况下使用。\emph{除非必要，用户不
 % 应使用这些选项。}
 %
@@ -999,7 +999,7 @@ Copyright and Licence
 %   \begin{syntax}
 %     zhmap = <\TTF|zhmCJK>
 %   \end{syntax}
-%   指定字体映射机制。本选项只在使用 (pdf)\LaTeX\ 编译时有意义。
+%   指定字体映射机制。本选项只在使用 (pdf)\LaTeX{} 编译时有意义。
 % \end{function}
 % \begin{optdesc}
 %   \item[true] 这是该选项的默认值。^^A
@@ -1008,8 +1008,8 @@ Copyright and Licence
 %   命令映射到 \file{.ttf} 文件。
 %
 %   \item[false] 使用传统的 CJK 字库（Type 1）^^A
-%   \footnote{使用 (pdf)\LaTeX\ 编译时，如果需要使用自定义的字体映射文件（比如需要
-%     使用 \LaTeX\ + Dvips 编译），或者希望使用 Type1 字库，请禁用本选项。为此，你
+%   \footnote{使用 (pdf)\LaTeX{} 编译时，如果需要使用自定义的字体映射文件（比如需要
+%     使用 \LaTeX{} + Dvips 编译），或者希望使用 Type1 字库，请禁用本选项。为此，你
 %     可能需要安装 CJK 字体。参考 \pkg{zhmetrics} 宏包提供的脚本
 %     \href{https://github.com/CTeX-org/ctex-kit/blob/master/zhmetrics/CTeXFonts.lua}
 %     {\file{CTeXFonts.lua}}。}。
@@ -1024,13 +1024,13 @@ Copyright and Licence
 %   \begin{syntax}
 %     fontset = <adobe|fandol|founder|hanyi|mac|macnew|macold|ubuntu|windows|none|...>
 %   \end{syntax}
-%   指定 \CTeX\ 宏集加载的字库。
+%   指定 \CTeX{} 宏集加载的字库。
 %
-%   如果没有指定 \opt{fontset} 的值，\CTeX\ 宏集将自动检测用户使用的操作系统，配置
+%   如果没有指定 \opt{fontset} 的值，\CTeX{} 宏集将自动检测用户使用的操作系统，配置
 %   相应的字体（参见表~\ref{tab:default-font-select}）。
 % \end{function}
 %
-% \CTeX\ 预定义了以下七种中文字库。
+% \CTeX{} 预定义了以下七种中文字库。
 %
 % \begin{optdesc}
 %   \item[adobe] 使用 Adobe 公司的四款中文字体，\emph{不支持 \pdfLaTeX}。
@@ -1041,41 +1041,41 @@ Copyright and Licence
 %     |macnew| 和 |macold| 两种。
 %   \item[macnew] 使用 El Capitan 或之后的多字重华文字体和苹方字体。
 %     从 macOS~15 (Sequoia) 开始，部分字体（苹方、楷体、仿宋、隶书、圆体）转为
-%     \emph{downloadable}，\CTeX\ 会自动检测可用性：可用时使用，不可用时静默跳过
+%     \emph{downloadable}，\CTeX{} 会自动检测可用性：可用时使用，不可用时静默跳过
 %     或回退。若需要完整的字体集，请在系统字体册中手动下载相关字体。
 %
 %     注意：上述自动检测仅对 |macnew| 字体集中的默认字体生效。
-%     如果需要在 \LuaLaTeX\ 下通过 \tn{setCJKmainfont} 等命令自定义使用
+%     如果需要在 \LuaLaTeX{} 下通过 \tn{setCJKmainfont} 等命令自定义使用
 %     macOS 的 \emph{downloadable} 字体，需要配置 |OSFONTDIR| 环境变量，
 %     将字体目录加入搜索路径。例如，在 shell 配置文件中添加：
 %     \begin{ctexexam}
 %       export OSFONTDIR="/System/Library/Fonts;/Library/Fonts;~/Library/Fonts"
 %     \end{ctexexam}
 %     配置后需运行 |luaotfload-tool --update| 重建字体数据库。
-%     \XeLaTeX\ 不受此限制，因为 \XeTeX\ 自身可通过系统接口发现字体。
+%     \XeLaTeX{} 不受此限制，因为 \XeTeX{} 自身可通过系统接口发现字体。
 %   \item[macold] 使用 Yosemite 或之前的华文字体。
-%   \item[ubuntu] 使用 Ubuntu 系统下的思源宋体、思源黑体和 \TeX\ 发行版自带的
+%   \item[ubuntu] 使用 Ubuntu 系统下的思源宋体、思源黑体和 \TeX{} 发行版自带的
 %     文鼎楷体，\emph{不支持 \pdfLaTeX}。
 %   \item[windows] 使用 Windows 系统下的中易字体和微软雅黑字体。
-%     当使用 (pdf)\LaTeX\ 编译时，微软雅黑仅在以下两种情形有效：
+%     当使用 (pdf)\LaTeX{} 编译时，微软雅黑仅在以下两种情形有效：
 %     安装有 \pkg{zhmCJK} 宏包且选项 \opt{zhmap=zhmCJK} 时，或者
 %     安装有微软雅黑的 Type1 字体且选项 \opt{zhmap=false} 时。
 % \end{optdesc}
 %
-% 如果不想使用 \CTeX\ 预定义的中文字库，可以设置 \opt{fontset} 为下述值之一。
+% 如果不想使用 \CTeX{} 预定义的中文字库，可以设置 \opt{fontset} 为下述值之一。
 %
 % \begin{optdesc}
 %   \item[none] 不配置中文字体，需要用户自己配置。
 %   \item[\meta{name}] 这里 \meta{name} 为自定义的名字。
-%   \CTeX\ 宏集将载入名为 |ctex-fontset-|\meta{name}|.def| 的文件作为字体配置
+%   \CTeX{} 宏集将载入名为 |ctex-fontset-|\meta{name}|.def| 的文件作为字体配置
 %   文件。因此，请先保证文件的存在。可以在当前工作目录或者本地 \texttt{TDS} 目录
 %   树下合适位置建立一个名为 |ctex-fontset-|\meta{name}|.def| 的文件，在这个文件
 %   里面自定义中文字体。然后通过使用 |fontset=|\meta{name} 选项来调用它。字体配置
-%   文件的具体写法可以参考 \CTeX\ 宏集 \texttt{fontset} 目录下的字体配置文件。
+%   文件的具体写法可以参考 \CTeX{} 宏集 \texttt{fontset} 目录下的字体配置文件。
 % \end{optdesc}
 %
 % 注意：\emph{如果希望使用 \tn{ctexset} 在导言区指定字库，则需要先在宏包/文档类选项中指定
-% \opt{fontset = none}}（这会禁用 \CTeX\ 宏集的操作系统检测功能和自动设定字库功能）。例如：
+% \opt{fontset = none}}（这会禁用 \CTeX{} 宏集的操作系统检测功能和自动设定字库功能）。例如：
 % \begin{ctexexam}
 %   \documentclass[fontset = none]{ctexart}
 %   \ctexset{fontset = founder}
@@ -1085,7 +1085,7 @@ Copyright and Licence
 %   \end{document}
 % \end{ctexexam}
 %
-% \CTeX\ 宏集预定义的中文字库还定义了一些字体命令。除了在 \opt{ubuntu} 字库中没有
+% \CTeX{} 宏集预定义的中文字库还定义了一些字体命令。除了在 \opt{ubuntu} 字库中没有
 % \tn{fangsong} 的定义外，所有字库都有以下四个字体命令：
 % \begin{optdesc}
 %   \item[\tn{songti}] 宋体，CJK 等价命令 |\CJKfamily{zhsong}|。
@@ -1128,10 +1128,10 @@ Copyright and Licence
 %   \end{verbatim}
 % \end{function}
 %
-% \CTeX\ 提供两种预设字号系统：
+% \CTeX{} 提供两种预设字号系统：
 %   \begin{optdesc}[itemsep=\medskipamount]
 %     \item[word] 默认值。源自 Microsoft Word / Adobe 等桌面排版软件的字号定义，
-%       亦与 GB/T~40070---2021 国家标准一致。这是 \CTeX\ 历史以来使用的字号体系。
+%       亦与 GB/T~40070---2021 国家标准一致。这是 \CTeX{} 历史以来使用的字号体系。
 %     \item[letterpress] 金属活字排印字号体系，基于严格的倍数关系。
 %       初号/二号/五号/七号形成 $\times 2$ 等比序列（$42:21:10.5:5.25$），
 %       一号/四号形成 $\times 2$ 序列（$28:14$），
@@ -1159,7 +1159,7 @@ Copyright and Licence
 %
 % 用户也可以定义自己的字号系统。将字号数据保存在
 % |ctex-fontsize-|\meta{name}|.def| 文件中，
-% 放到工作目录或 \TeX\ 目录树（TDS）中，然后指定
+% 放到工作目录或 \TeX{} 目录树（TDS）中，然后指定
 % |experiment/font-size-system=|\meta{name} 即可。
 % 自定义文件应使用 \cs{ctex_save_font_size:nn} 为每个字号注册数据。
 % 例如：
@@ -1193,7 +1193,7 @@ Copyright and Licence
 %   \end{syntax}
 %   将文章默认字号（\tn{normalsize}）设置为小四号字或五号字，
 %   具体情况见表~\ref{tab:fontsize}。\opt{false} 禁用本功能。
-%   本选项可以用于四个 \CTeX\ 文档类和 \pkg{ctex} 宏包，
+%   本选项可以用于四个 \CTeX{} 文档类和 \pkg{ctex} 宏包，
 %   也可以用于 \pkg{ctexsize} 宏包。
 %
 %   该选项的默认值与 \opt{scheme} 的取值有关。
@@ -1230,17 +1230,17 @@ Copyright and Licence
 %\end{table}
 %
 % \begin{function}[rEXP]{10pt, 11pt, 12pt}
-%   \CTeX\ 文档类是在 \LaTeX\ 标准文档类之上开发的。因此，除了可以使用 \CTeX\
+%   \CTeX{} 文档类是在 \LaTeX{} 标准文档类之上开发的。因此，除了可以使用 \CTeX{}
 %   宏包定义的字号选项之外，还可以使用标准文档类的同类选项（\opt{10pt}、\opt{11pt}
-%   和 \opt{12pt}）。在使用这些来自标准文档类的选项的时候，\CTeX\ 文档类的字号
+%   和 \opt{12pt}）。在使用这些来自标准文档类的选项的时候，\CTeX{} 文档类的字号
 %   选项会被抑制。亦即，在 \opt{zihao} 选项之后设置 \opt{10pt} 选项，
 %   \opt{zihao} 选项将不再起作用。
 % \end{function}
 %
-% 标准文档类的其他选项在 \CTeX\ 文档类中依旧有效。例如，设置纸张大小和方向的
+% 标准文档类的其他选项在 \CTeX{} 文档类中依旧有效。例如，设置纸张大小和方向的
 % \opt{a4paper} 和 \opt{landscape}，设置单双面的 \opt{oneside} 和
-% \opt{twoside} 等。\CTeX\ 会将这些选项传给标准文档类^^A
-% \footnote{事实上，\LaTeX\ 在文档类中的选项是全局设定的，除了对使用的文档类有
+% \opt{twoside} 等。\CTeX{} 会将这些选项传给标准文档类^^A
+% \footnote{事实上，\LaTeX{} 在文档类中的选项是全局设定的，除了对使用的文档类有
 % 影响外，也可能会影响到随后使用的宏包。如果这些宏包中有某些选项出现在文档类的
 % 选项列表中，那么该选项将会被自动激活。}。
 %
@@ -1253,13 +1253,13 @@ Copyright and Licence
 %   \end{syntax}
 %   本选项只能在调用 \pkg{ctex.sty} 时作为宏包选项使用。
 %
-%   \CTeX\ 宏集提供了一套用于修改文档章节标题格式的接口。该选项用于选择是否
+%   \CTeX{} 宏集提供了一套用于修改文档章节标题格式的接口。该选项用于选择是否
 %   启用该功能。详细的设置方法请参见第 \ref{subs:pagestyle}~节和第 \ref{sec:secstyle}~节。
 % \end{function}
 %
-% \CTeX\ 宏集提供的四个文档类总是启用该功能。如果在 \pkg{ctex.sty} 下启用该选项，
-% 将会检查当前是否使用 \LaTeX\ 标准文档类。
-% 若然，则该选项将会使得 \pkg{ctex.sty} 宏包的行为和 \CTeX\ 宏集提供的
+% \CTeX{} 宏集提供的四个文档类总是启用该功能。如果在 \pkg{ctex.sty} 下启用该选项，
+% 将会检查当前是否使用 \LaTeX{} 标准文档类。
+% 若然，则该选项将会使得 \pkg{ctex.sty} 宏包的行为和 \CTeX{} 宏集提供的
 % 四个中文文档类\emph{完全}一致；若不然，则会根据 \tn{chapter}
 % 是否有定义来使用 \cls{ctexbook} 或者 \cls{ctexart} 的标题设置。
 %
@@ -1277,7 +1277,7 @@ Copyright and Licence
 %   具体格式可参考 \ref{subsec:sec-spacing}~小节中的 \opt{runin} 和 \opt{afterskip} 选项。
 %
 %   注意，上述两个选项只有在非 \cls{beamer} 文档类下 \opt{heading} 选项启用的时候
-%   才有意义。亦即，只有在使用除了 \cls{ctexbeamer} 的三个 \CTeX\ 文档类或启用了
+%   才有意义。亦即，只有在使用除了 \cls{ctexbeamer} 的三个 \CTeX{} 文档类或启用了
 %   \opt{heading} 的 \pkg{ctex.sty} 的时候才有意义。
 % \end{function}
 %
@@ -1295,7 +1295,7 @@ Copyright and Licence
 %       整行距为 |1.3|；汉化文档中的标题名字（如“图”、“表”、“目录”和“参
 %       考文献”等，见 \ref{subs:capname}~节）；
 %       在 \opt{heading = true} 的情况下^^A
-%       \footnote{使用 \CTeX\ 文档类，或者使用 \pkg{ctex} 宏包且开启该选项时。}^^A
+%       \footnote{使用 \CTeX{} 文档类，或者使用 \pkg{ctex} 宏包且开启该选项时。}^^A
 %       （\ref{subs:options-heading}~节），还会将章节标题的风格修改为
 %       中文样式（见 \ref{sec:secstyle}~节）。
 %
@@ -1303,7 +1303,7 @@ Copyright and Licence
 %       联用时，会载入 \pkg{indentfirst} 宏包，以实现章节标题后的段首缩进。
 %     \item[plain] 不调整默认字号和行距，不会汉化文档中的标题名字，也不会将章节
 %       标题风格修改为中文样式，同时不会调整 \tn{pagestyle}，并禁用 \opt{autoindent}
-%       选项。事实上，此时的 \CTeX\ 宏集只提供了中文支持功能，而不对文章版式进行任何修改。
+%       选项。事实上，此时的 \CTeX{} 宏集只提供了中文支持功能，而不对文章版式进行任何修改。
 %   \end{optdesc}
 %
 % \begin{function}[updated=2014-04-11]{punct}
@@ -1327,14 +1327,14 @@ Copyright and Licence
 %   \begin{syntax}
 %     space = <\TF|(auto)>
 %   \end{syntax}
-%   是否在生成的 PDF 中保留汉字后面的空格。该选项仅在使用 \XeLaTeX/(pdf)\LaTeX\ 编译时有效。
+%   是否在生成的 PDF 中保留汉字后面的空格。该选项仅在使用 \XeLaTeX{}/(pdf)\LaTeX{} 编译时有效。
 % \end{function}
 %
 % \begin{optdesc}
 %   \item[true] 总是保留汉字后的空格。此时，用户需要自行在行尾加上~|%|~处理换行产生
-%     的空格\footnote{\LaTeX\ 将单个换行视作一个空格。}。
-%   \item[false] 使用 (pdf)\LaTeX\ 编译时：总是忽略掉汉字后面的空格，不论汉字后是什么；
-%     使用 \XeLaTeX\ 编译时，等同于 \opt{auto} 的效果。不建议使用该选项。
+%     的空格\footnote{\LaTeX{} 将单个换行视作一个空格。}。
+%   \item[false] 使用 (pdf)\LaTeX{} 编译时：总是忽略掉汉字后面的空格，不论汉字后是什么；
+%     使用 \XeLaTeX{} 编译时，等同于 \opt{auto} 的效果。不建议使用该选项。
 %   \item[auto] 根据空格后面的情况决定是否保留：如果空格后面是汉字，则忽略该
 %   空格，否则保留。
 % \end{optdesc}
@@ -1353,7 +1353,7 @@ Copyright and Licence
 %   \end{ctexexam}
 %   则会得到“{\ctexset{space=auto}汉字 分词 技术 English}”。
 %
-% \emph{使用 \textup{\LuaLaTeX\ 及 \upLaTeX} 编译的时候，该选项无效：汉字间的
+% \emph{使用 \textup{\LuaLaTeX{} 及 \upLaTeX} 编译的时候，该选项无效：汉字间的
 % 空格以及汉字与西文字符之间的空格总是有效，不会被忽略，但可以自动忽略掉由换行
 % 产生的空格。}
 %
@@ -1368,7 +1368,7 @@ Copyright and Licence
 %   时，相邻两行的基线（\tn{baselineskip}）距离为 $1.3\times 1.2=1.56$ 倍字体
 %   高度。对 \cls{beamer} 不改变行距，即使用默认的单倍行距。
 %
-%   \item[scheme = plain] \CTeX\ 宏集默认不调整行距倍数，文档中的行距由所选文档类和
+%   \item[scheme = plain] \CTeX{} 宏集默认不调整行距倍数，文档中的行距由所选文档类和
 %   其他宏包或用户设置决定。
 % \end{optdesc}
 %
@@ -1420,21 +1420,21 @@ Copyright and Licence
 %     experiment/CJKecglue = \Arg{弹性长度}
 %   \end{syntax}
 %   设置 CJK 文字与西文之间的间距（汉英文间胶）。这是一个实验性选项，
-%   目前仅在 \XeLaTeX、\LuaLaTeX\ 和 \upLaTeX\ 下有效，
-%   使用 \pdfLaTeX\ 编译时会产生警告。
+%   目前仅在 \XeLaTeX{}、\LuaLaTeX{} 和 \upLaTeX{} 下有效，
+%   使用 \pdfLaTeX{} 编译时会产生警告。
 % \end{function}
 %
-%   在 \XeLaTeX\ 下，此选项等价于设置
+%   在 \XeLaTeX{} 下，此选项等价于设置
 %   |\xeCJKsetup{CJKecglue={\hskip ...}}|；
-%   在 \LuaLaTeX\ 和 \upLaTeX\ 下，此选项设置 |xkanjiskip|。
+%   在 \LuaLaTeX{} 和 \upLaTeX{} 下，此选项设置 |xkanjiskip|。
 %   例如：
 %   \begin{ctexexam}
 %   \ctexset{experiment/CJKecglue = 0.25em plus 0.15em minus 0.05em}
 %   \end{ctexexam}
 %
-%   请注意，由于 \pdfLaTeX\ 下的 \pkg{CJK} 宏包没有独立的汉英文间胶概念，
+%   请注意，由于 \pdfLaTeX{} 下的 \pkg{CJK} 宏包没有独立的汉英文间胶概念，
 %   此选项无法在所有引擎下提供一致的行为。因此，\emph{除非确定文档仅会在
-%   \XeLaTeX\ 或 \LuaLaTeX\ 下编译}，否则不建议使用此选项。
+%   \XeLaTeX{} 或 \LuaLaTeX{} 下编译}，否则不建议使用此选项。
 %
 % \section{文档汉化}
 % \label{sec:chinese-localization}
@@ -1544,7 +1544,7 @@ Copyright and Licence
 %
 % 在标准文档类中 \cls{article} 的参考文献名使用宏 \tn{refname}，而
 % \cls{book} 和 \cls{report} 使用宏 \tn{bibname}。本选项会根据标准文档类的不同，自动
-% 设定 \tn{refname} 或是 \tn{bibname}。因此，对于标准文档类及对应的 \CTeX\ 文档类
+% 设定 \tn{refname} 或是 \tn{bibname}。因此，对于标准文档类及对应的 \CTeX{} 文档类
 % 可以统一地使用 \opt{bibname} 选项来控制参考文献标题名。
 %
 % 对于 \cls{beamer} 及对应的 \cls{ctexbeamer} 来说，它们同时具有宏 \tn{bibname} 和
@@ -1569,9 +1569,9 @@ Copyright and Licence
 %   \end{syntax}
 % 设置参考文献标题名 \tn{refname}。中文默认为“\refname”。
 %
-% 注意，三个标准文档类（及相应的 \CTeX\ 文档类）的参考文献标题名由 \opt{bibname} 选项
+% 注意，三个标准文档类（及相应的 \CTeX{} 文档类）的参考文献标题名由 \opt{bibname} 选项
 % 统一设置，本选项仅适用于 \cls{beamer} 及其对应的 \cls{ctexbeamer}。
-% 在三个标准文档类（及相应的 \CTeX\ 文档类）中使用 \opt{refname} 选项会报错。
+% 在三个标准文档类（及相应的 \CTeX{} 文档类）中使用 \opt{refname} 选项会报错。
 % \end{function}
 %
 % \begin{function}[EXP]{algorithmname}
@@ -1595,7 +1595,7 @@ Copyright and Licence
 % \label{subs:pagestyle}
 %
 % 页面格式设置与汉化的功能（及章节标题样式设置功能，见第 \ref{sec:secstyle}~节）^^A
-% 由 \pkg{ctexheading} 宏包完成。加载该宏包时，或者使用 \CTeX\ 文档类时，^^A
+% 由 \pkg{ctexheading} 宏包完成。加载该宏包时，或者使用 \CTeX{} 文档类时，^^A
 % 或者是使用 \pkg{ctex} 宏包并设定选项 \opt{heading = true} 时，相关功能被激活。
 % 此时，整个文档的页面格式（page style）被设定为 |headings|，即相当于设置了
 % \begin{frameverb}
@@ -1692,10 +1692,10 @@ Copyright and Licence
 % \section{章节标题样式设置}
 % \label{sec:secstyle}
 %
-% \CTeX\ 宏集对 \LaTeX\ 的标准文档类（\cls{article}、\cls{report}、
+% \CTeX{} 宏集对 \LaTeX{} 的标准文档类（\cls{article}、\cls{report}、
 % \cls{book}）和 \cls{beamer} 进行了章节标题样式设置功能的扩充。
 % 章节标题样式设置功能（及页面格式设置与汉化功能，见第 \ref{subs:pagestyle}~节）^^A
-% 由 \pkg{ctexheading} 宏包完成。加载该宏包时，或者使用 \CTeX\ 文档类时，^^A
+% 由 \pkg{ctexheading} 宏包完成。加载该宏包时，或者使用 \CTeX{} 文档类时，^^A
 % 或者是使用 \pkg{ctex} 宏包并设定选项 \opt{heading = true} 时，相关功能被激活。
 % 其中，独立使用 \pkg{ctexheading} 宏包时，本节介绍各选项的默认值与指定
 % \opt{scheme = plain} 时相同。
@@ -1761,7 +1761,7 @@ Copyright and Licence
 %   控制是否对\emph{不带星号}的章节标题进行编号。
 %   各级标题的默认值均为 \opt{true}。
 %
-%   \LaTeX\ 标准的章节标题命令（如 \tn{section}）大体上完成四项工作：
+%   \LaTeX{} 标准的章节标题命令（如 \tn{section}）大体上完成四项工作：
 %   输出标题内容、对标题编号（计数器增加 1）、将标题列入目录（若调用了
 %   \pkg{hyperref} 宏包还会添加 PDF 书签）、更新页眉页脚标记。带星号的
 %   章节标题命令（如 \tn{section*}）只简单地输出章节标题内容，但不对标题编号，
@@ -1782,7 +1782,7 @@ Copyright and Licence
 %   三章的标题分别为“第一章\quad A”、“B”和“C”，但在目录中则只出现
 %   “第一章\quad A”和“C”。
 %
-%   注意，章节标题是否编号还要受到 \LaTeX\ 计数器 |secnumdepth| 的控制^^A
+%   注意，章节标题是否编号还要受到 \LaTeX{} 计数器 |secnumdepth| 的控制^^A
 %   （可通过以下介绍的 \opt{secnumdepth} 选项设置）。
 %   例如，对于 |section| 而言，其深度为 1。因此，|section| 会被编号，当且仅当
 %   |secnumdepth| 不小于 1，并且 \opt{section/numbering} 为 \opt{true}，
@@ -1896,7 +1896,7 @@ Copyright and Licence
 %   将会使 \tn{section} 的编号变为大写罗马数字（如 I、II 等）。
 %
 %   \opt{number} 选项定义的同时将控制对章节计数器的交叉引用。在引用计数器时，
-%   记录在 \LaTeX\ 辅助文件中的是 \opt{number} 选项的定义。
+%   记录在 \LaTeX{} 辅助文件中的是 \opt{number} 选项的定义。
 %
 %   但是，\opt{number} 选项不会影响计数器本身的输出。即设置 |section/number|
 %   不会影响 \tn{thesection} 的定义（但该选项会影响 \tn{CTEXthesection} 的定
@@ -1935,7 +1935,7 @@ Copyright and Licence
 % \subsection{格式相关}
 % \label{subsec:sec-format}
 %
-% \CTeX\ 宏集提供了 \opt{numberformat}, \opt{nameformat}, \opt{titleformat},
+% \CTeX{} 宏集提供了 \opt{numberformat}, \opt{nameformat}, \opt{titleformat},
 % \opt{format} 这几个选项用来控制章节标题的格式。
 % 它们的作用范围如图~\ref{fig:heading-format} 所示。具体用法见下文。
 %
@@ -2008,7 +2008,7 @@ Copyright and Licence
 %     \bottomrule
 %     \end{tabular}
 %     \begin{tablenotes}
-%       \item[*] 为了与 \LaTeXe\ 的默认效果保持一致，在 \opt{scheme = plain}
+%       \item[*] 为了与 \LaTeXe{} 的默认效果保持一致，在 \opt{scheme = plain}
 %           时，part 和 chapter 的 \opt{nameformat} 和 \opt{titleformat}
 %           并不一样，因此没有使用 \opt{format} 选项统一设置名字和标题的格式。
 %     \end{tablenotes}
@@ -2295,7 +2295,7 @@ Copyright and Licence
 %   和 \opt{indent} 选项设置的宽度之和）。
 %
 %   注意，当 \opt{hang = true} 时，不恰当地设置选项 \opt{aftername} 的值，可能会引发
-%   错误。这是因为当 \opt{hang = true} 时，\LaTeX\ 内部会构造一个 \tn{hbox} 而
+%   错误。这是因为当 \opt{hang = true} 时，\LaTeX{} 内部会构造一个 \tn{hbox} 而
 %   进入受限水平模式（restricted horizontal mode）。若在 \opt{aftername} 中加入
 %   包含 \tn{vskip} 等会导致从受限水平模式切出的垂直命令（vertical command）时，就会报错。
 %   特别地，\opt{aftername} 的默认值也可能导致这种情形（见表~\ref{tab:aftername-default}）。
@@ -2682,7 +2682,7 @@ Copyright and Licence
 % \subsection{辅助命令}
 % \label{subsec:sec-commands}
 %
-% \CTeX\ 宏集还提供了一些辅助命令（宏），用于存储章节标题格式，或进行一些条件判断。
+% \CTeX{} 宏集还提供了一些辅助命令（宏），用于存储章节标题格式，或进行一些条件判断。
 %
 % \begin{function}{\CTEXthepart, \CTEXthechapter, \CTEXthesection,
 %   \CTEXthesubsection, \CTEXthesubsubsection, \CTEXtheparagraph,
@@ -2701,8 +2701,8 @@ Copyright and Licence
 %   \end{syntax}
 %   \tn{CTEXifname} 会根据当前章节有无名字展开得到不同内容（通常是格式命令）。
 %   由于章节名字总是与编号一起出现，章节有无名字通常也表达为“章节是否编号”。
-%   在 \LaTeX\ 中，后者取决于以下几个方面：章节深度是否不大于计数器
-%   |secnumdepth| 的值，章节标题是否使用不带星号的命令。在 \CTeX\ 宏集中，
+%   在 \LaTeX{} 中，后者取决于以下几个方面：章节深度是否不大于计数器
+%   |secnumdepth| 的值，章节标题是否使用不带星号的命令。在 \CTeX{} 宏集中，
 %   后者还取决于 \opt{.../numbering} 是否为 \opt{true}。
 %
 %   \tn{CTEXifname} 可用于 \opt{format}, \opt{titleformat}, \opt{aftertitle},
@@ -2812,7 +2812,7 @@ Copyright and Licence
 %
 % \subsection{中文数字转换}
 %
-% \CTeX\ 宏集的中文数字转换功能实际上是调用 \pkg{zhnumber} 宏包来完成。下面只
+% \CTeX{} 宏集的中文数字转换功能实际上是调用 \pkg{zhnumber} 宏包来完成。下面只
 % 介绍一些基本的用法，更高级的用法可以查阅 \pkg{zhnumber} 宏包的文档。
 %
 % \begin{function}[updated=2016-05-01]{\chinese}
@@ -2820,7 +2820,7 @@ Copyright and Licence
 %     \tn{chinese} \Arg{counter}
 %     \tn{pagenumbering} \{chinese\}
 %   \end{syntax}
-%   \tn{chinese} 命令与 \tn{roman} 等命令的用法类似，作用在一个 \LaTeX\
+%   \tn{chinese} 命令与 \tn{roman} 等命令的用法类似，作用在一个 \LaTeX{}
 %   计数器上，将计数器的值以中文数字的形式输出。
 % \end{function}
 %
@@ -2842,7 +2842,7 @@ Copyright and Licence
 %   \begin{syntax}
 %     \tn{CTEXnumber} "\"<macro> \Arg{number}
 %   \end{syntax}
-%   |\|<macro> 必须是一个 \TeX\ 宏，不需预先定义。\tn{CTEXnumber} 通过
+%   |\|<macro> 必须是一个 \TeX{} 宏，不需预先定义。\tn{CTEXnumber} 通过
 %   \tn{zhnumber} 将 \meta{number} 转为中文数字，最后将结果存储在 |\|<macro>
 %   里。对 |\|<macro> 的定义是局部的，将它展开一次就可以得到转换结果。
 % \end{function}
@@ -2866,19 +2866,19 @@ Copyright and Licence
 % 用于显示 \CTeX 标志。
 % \end{function}
 %
-% \section{\LuaLaTeX\ 下的中文支持方式}
+% \section{\LuaLaTeX{} 下的中文支持方式}
 % \label{sec:lualatex-chinese}
 %
-% 在 \LuaLaTeX\ 下，\CTeX\ 宏集依赖 \pkg{LuaTeX-ja} 宏包来完成中文支持。
-% 该宏包是日本 \TeX\ 社区的北川弘典、前田一贵、八登崇之等人开发的，设计目的主要
-% 是在 \LuaTeX\ 引擎下实现日本 p\TeX\ 引擎的（大部分）功能。它为了兼容 p\LaTeX
+% 在 \LuaLaTeX{} 下，\CTeX{} 宏集依赖 \pkg{LuaTeX-ja} 宏包来完成中文支持。
+% 该宏包是日本 \TeX{} 社区的北川弘典、前田一贵、八登崇之等人开发的，设计目的主要
+% 是在 \LuaTeX{} 引擎下实现日本 p\TeX{} 引擎的（大部分）功能。它为了兼容 p\LaTeX
 % 的使用习惯，对 \LaTeXe 的 \pkg{NFSS} 作了不少修改和扩充。这对于简体中文用户来说
-% 不是必要的，因而 \CTeX\ 禁用了它在 \LaTeX\ 格式下的大部分设置，只保留了必要的
+% 不是必要的，因而 \CTeX{} 禁用了它在 \LaTeX{} 格式下的大部分设置，只保留了必要的
 % 部分。同时修改了它的字体设置方式，使得相关命令与 \pkg{xeCJK} 宏包大致相同。
 %
-% 20150420 版以后的 \pkg{LuaTeX-ja} 宏包开始支持竖排，但 \CTeX\ 暂不支持竖排。
+% 20150420 版以后的 \pkg{LuaTeX-ja} 宏包开始支持竖排，但 \CTeX{} 暂不支持竖排。
 %
-% \subsection{\LuaLaTeX\ 下替代字体的设置}
+% \subsection{\LuaLaTeX{} 下替代字体的设置}
 %
 % \begin{function}[updated=2020-04-30]{AlternateFont}
 %   \begin{syntax}
@@ -2959,39 +2959,39 @@ Copyright and Licence
 %   当前 CJK 字体族。清除与重置操作总是全局的。
 % \end{function}
 %
-% \section{\CTeX\ 宏集的配置文件}
+% \section{\CTeX{} 宏集的配置文件}
 %
-% \CTeX\ 宏集提供了不同的配置文件，可以通过修改配置文件来改变 \CTeX\ 宏集的
+% \CTeX{} 宏集提供了不同的配置文件，可以通过修改配置文件来改变 \CTeX{} 宏集的
 % 默认行为。
 %
-% 在多数情况下，并不需要修改配置文件，\CTeX\ 宏集的默认设置已经能满足大多数用
-% 户的需要。不恰当地修改 \CTeX\ 宏集的默认行为也可能导致同一文件在别处无法正
+% 在多数情况下，并不需要修改配置文件，\CTeX{} 宏集的默认设置已经能满足大多数用
+% 户的需要。不恰当地修改 \CTeX{} 宏集的默认行为也可能导致同一文件在别处无法正
 % 常编译或排版效果完全不同，因此修改应该慎重。
 %
 % 但在一些情况下，直接修改配置文件仍是必要的，例如：
 % \begin{itemize}
 % \item 系统没有安装默认设置的字体文件，无法编译。
-% \item 需要经常编译来自其他系统的中文 \TeX\ 文件，但对方的操作系统或默认设置
+% \item 需要经常编译来自其他系统的中文 \TeX{} 文件，但对方的操作系统或默认设置
 % 与本机不同。
 % \end{itemize}
 %
-% 与 \CTeX\ 宏集的源代码一样，配置文件采用 \LaTeXiii\ 的语法编写。
+% 与 \CTeX{} 宏集的源代码一样，配置文件采用 \LaTeXiii{} 的语法编写。
 %
-% \CTeX\ 宏集的配置文件随宏包其他文件一起安装在 \TeX\ 系统 TDS 目录树中，文
-% 件后缀是 \file{.cfg}。为了避免本地配置文件内容因 \CTeX\ 宏集的更新而丢失，
+% \CTeX{} 宏集的配置文件随宏包其他文件一起安装在 \TeX{} 系统 TDS 目录树中，文
+% 件后缀是 \file{.cfg}。为了避免本地配置文件内容因 \CTeX{} 宏集的更新而丢失，
 % 不要直接修改系统 TDS 目录树中的配置文件，而应该将系统自带的配置文件复制到本
 % 地的或用户私有的 TDS 目录树中修改，并运行 \bashcmd{texhash} 命令刷新文件名数据库。
 %
-% 例如对于 \TeX\ Live，系统自带的配置文件就在 \TeX\ Live 安装目录下的
+% 例如对于 \TeX{} Live，系统自带的配置文件就在 \TeX{} Live 安装目录下的
 % \path{texmf-dist/tex/latex/ctex/config/} 子目录下，可以修改它的副本，保存在
 % 本地 TDS 树的 \path{texmf-local/tex/latex/ctex/} 目录下，或者用户 TDS 树的
 % \path{~/texmf/tex/latex/ctex/} 目录下，作为本地/用户专有的
 % 配置文件。复制配置文件后需要运行 |texhash| 命令使本地配置文件生效。
 %
-% \MiKTeX\ 的配置文件也保存在类似的目录结构中，\MiKTeX\ 管理的
-% 几个 TDS 根目录可以在 \MiKTeX\ Options 设置项中查看到，这里不再赘述。
+% \MiKTeX{} 的配置文件也保存在类似的目录结构中，\MiKTeX{} 管理的
+% 几个 TDS 根目录可以在 \MiKTeX{} Options 设置项中查看到，这里不再赘述。
 %
-% 除了修改本地 \TeX\ 系统中的配置文件，对于特定文档，也可以将修改过的配置文件
+% 除了修改本地 \TeX{} 系统中的配置文件，对于特定文档，也可以将修改过的配置文件
 % 保存在文档的工作目录下。此时配置文件就只对工作目录下的所有文档生效。
 %
 % \subsection{修改宏包默认选项}
@@ -3005,17 +3005,17 @@ Copyright and Licence
 %   % 该设置可以用在安装了 Windows 字体的非 Windows 系统中。
 %   \ctex_set:nn { option } { fontset = windows }
 % \end{ctexexam}
-% 如上例所示，宏包选项通常使用 \LaTeXiii\ 的 \cs{ctex_set:nn} 命令完成键值设置，
+% 如上例所示，宏包选项通常使用 \LaTeXiii{} 的 \cs{ctex_set:nn} 命令完成键值设置，
 % 第一个参数是固定的子模块 |option|，第二个参数中是用户定义的新的默认宏包选项。
 %
-% \file{ctexopts.cfg} 中的设置将在 \CTeX\ 宏集的开始处，定义过宏包选项之后，
+% \file{ctexopts.cfg} 中的设置将在 \CTeX{} 宏集的开始处，定义过宏包选项之后，
 % \tn{ProcessKeysOptions} 命令之前生效。最好只使用此配置文件修改宏包默认选项。
 %
 % \subsection{宏包载入后的配置}
 %
 % 配置文件 \file{ctex.cfg} 将在宏包的末尾被载入生效。可以用它完成任意的设置，
 % 或是覆盖已有的定义。随系统安装的配置文件除版本信息外没有实际内容，注意配置文
-% 件中也使用 \LaTeXiii\ 语法。
+% 件中也使用 \LaTeXiii{} 语法。
 %
 % \begin{ctexexam}
 %   % 简单的 ctex.cfg 内容示例。
@@ -3039,7 +3039,7 @@ Copyright and Licence
 %
 % \subsection{配置标题中文翻译}
 %
-% 由于 \CTeX\ 宏集需要同时支持 GBK 和 UTF-8 两种编码，因此对标题的中文翻译写
+% 由于 \CTeX{} 宏集需要同时支持 GBK 和 UTF-8 两种编码，因此对标题的中文翻译写
 % 在两个配置文件当中：\file{ctex-name-gbk.cfg} 和 \file{ctex-name-utf8.cfg}。
 % 两个文件的设置相同，只是编码不同。
 %
@@ -3048,15 +3048,15 @@ Copyright and Licence
 % \subsection{自定义字体集}
 %
 % \ref{subs:options-CJK-font}~节介绍的用于 |fontset| 选项的自定义字库文件，
-% 类似于 \CTeX\ 宏集的配置文件，也应该与其他本地配置文件一起保存在本地
+% 类似于 \CTeX{} 宏集的配置文件，也应该与其他本地配置文件一起保存在本地
 % \texttt{TDS} 目录树下，并可以配合 \file{ctexopts.cfg} 等配置文件使用。
 %
 % \section{第三方宏包兼容}
 % \label{sec:third-party}
 %
-% \CTeX\ 宏集为使 \tn{labelformat} 功能与章节标题设置兼容，对 \pkg{cleveref}
+% \CTeX{} 宏集为使 \tn{labelformat} 功能与章节标题设置兼容，对 \pkg{cleveref}
 % 等宏包进行了补丁。由于 \pkg{cleveref} 长期未维护（CTAN 上仍为 0.21.4），与新版
-% \LaTeX\ 内核和 \pkg{hyperref} 存在兼容问题，\CTeX\ 提供了选项以控制补丁行为。
+% \LaTeX{} 内核和 \pkg{hyperref} 存在兼容问题，\CTeX{} 提供了选项以控制补丁行为。
 %
 % \begin{function}[EXP, added = 2026-04-24]{patch/cleveref}
 %   \begin{syntax}
@@ -3066,13 +3066,13 @@ Copyright and Licence
 %   该补丁在 \pkg{cleveref} 的 \tn{refstepcounter} 变体中注入 \tn{expandafter}，
 %   以确保 \tn{labelformat} 格式化后的标签能正确展开。
 %
-%   当该补丁与上游 \LaTeX\ 内核或 \pkg{hyperref} 的更新产生冲突时，
+%   当该补丁与上游 \LaTeX{} 内核或 \pkg{hyperref} 的更新产生冲突时，
 %   可以将此选项设为 |false| 以关闭补丁。
 %
 %   \textbf{注意：}当同时使用 \pkg{hyperref} 和 \pkg{cleveref} 时，|\appendix|
 %   之后的交叉引用类型可能不正确（例如，\texttt{appendix} 退化为
-%   \texttt{chapter}）。这是上游 \LaTeX\ 内核 \texttt{firstaid} 对
-%   \pkg{cleveref} 补丁不完整所致，与 \CTeX\ 无关。
+%   \texttt{chapter}）。这是上游 \LaTeX{} 内核 \texttt{firstaid} 对
+%   \pkg{cleveref} 补丁不完整所致，与 \CTeX{} 无关。
 %   可以使用以下方法规避：
 % \begin{ctexexam}
 %   \AddToHook{cmd/appendix/before}{%
@@ -3095,7 +3095,7 @@ Copyright and Licence
 %
 % \subsection{\CTeX\ 0.9--\CTeX\ 1.0d}
 %
-% 在 2009 年在 ctex-kit 项目成立后，新增了 \XeTeX\ 引擎的支持，并增加了不少控
+% 在 2009 年在 ctex-kit 项目成立后，新增了 \XeTeX{} 引擎的支持，并增加了不少控
 % 制字体的命令和选项。
 %
 % 这里主要介绍新版本 \CTeX 宏包相对 1.02d 版本（2014/06/09）的兼容性。
@@ -3124,7 +3124,7 @@ Copyright and Licence
 % \opt{indent} 和 \opt{noindent} 什么也不做，过时选项。
 %
 % 在中文版式下，\pkg{ctex} 宏包的相关功能在与标准文档类及其衍生文档类联用时
-% 默认打开。\CTeX\ 文档类的相关功能由章节标题的 \opt{afterindent} 选项的值
+% 默认打开。\CTeX{} 文档类的相关功能由章节标题的 \opt{afterindent} 选项的值
 % 来确定。
 % \end{function}
 %
@@ -3185,19 +3185,19 @@ Copyright and Licence
 %
 % \begin{function}{fntef}
 % 旧版本的 \opt{fntef} 选项用于统一 \pkg{CCTfntef} 与 \pkg{CJKfntef} 的界面，
-% 新版本 \CTeX\ 宏集不再支持 \pkg{CCT}，也不再自动载入 \pkg{CJKfntef} 或
+% 新版本 \CTeX{} 宏集不再支持 \pkg{CCT}，也不再自动载入 \pkg{CJKfntef} 或
 % \pkg{xeCJKfntef} 宏包，而仅在其末尾做适当格式调整。
 %
 % \opt{fntef} 选项过时，因兼容性保留，功能是根据引擎载入 \pkg{CJKfntef}
-% (\pdfTeX) 或 \pkg{xeCJKfntef} (\XeTeX) 宏包。
+% (\pdfTeX{}) 或 \pkg{xeCJKfntef} (\XeTeX{}) 宏包。
 % \end{function}
 %
 % \begin{function}{\CTEXunderdot, \CTEXunderline, \CTEXunderdblline,
 %   \CTEXunderwave, \CTEXsout, \CTEXxout, CTEXfilltwosides}
-% 在调用 \opt{fntef} 宏包选项的同时，旧版本 \CTeX\ 宏包由于需要支持 \pkg{CCT}
+% 在调用 \opt{fntef} 宏包选项的同时，旧版本 \CTeX{} 宏包由于需要支持 \pkg{CCT}
 % 系统，会将以 |\CJK| 开头的 \tn{CJKunderline} 等宏换名为以 |\CTEX| 开头的
-% \tn{CTEXunderline} 等宏。此功能在新版本的 \CTeX\ 宏集中已失去意义。此外，
-% 在 \pdfTeX\ 引擎下，用于设置格式的 \tn{CJKunderdotbasesep} 等宏也被更名为
+% \tn{CTEXunderline} 等宏。此功能在新版本的 \CTeX{} 宏集中已失去意义。此外，
+% 在 \pdfTeX{} 引擎下，用于设置格式的 \tn{CJKunderdotbasesep} 等宏也被更名为
 % \tn{CTEXunderdotbasesep} 等宏。
 %
 % 在新版本中，上述由 \opt{fntef} 衍生的相关命令和环境均被移除。
@@ -3299,7 +3299,7 @@ Copyright and Licence
 % \CTeX\ 2.5 有一些比较大的变动。
 %
 % \begin{function}[label =]{UTF8, GBK}
-%   (pdf)\LaTeX\ 格式下，文档编码初始值统一设置成 UTF-8。因此，仍旧使用 GBK
+%   (pdf)\LaTeX{} 格式下，文档编码初始值统一设置成 UTF-8。因此，仍旧使用 GBK
 %   编码的文档，需要在文档类或宏包选项中显式指定 \opt{GBK}。
 % \end{function}
 %
@@ -3332,20 +3332,20 @@ Copyright and Licence
 %   新的语法是将可选项放在字体名之后的花括号之内。
 % \end{function}
 %
-% 除了以上列出的选项以外，当用户使用 \CTeX\ 系列文档类，且使用 \LaTeX 或
+% 除了以上列出的选项以外，当用户使用 \CTeX{} 系列文档类，且使用 \LaTeX 或
 % \upLaTeX 编译时，若用户没有在文档类选项中显式指定 |dvips|/|dvipdfmx|/|dvisvgm|
 % 等驱动选项，则文档类指定默认驱动为 \dvipdfmx。
 %
 % \section{宏集依赖情况与手工安装方法}
 % \label{sec:dep-ins}
 %
-% 本节介绍 \CTeX\ 宏集的依赖情况，并介绍手工编译安装的具体方法。
+% 本节介绍 \CTeX{} 宏集的依赖情况，并介绍手工编译安装的具体方法。
 % 通常用户只需参照第 \ref{subsec:easy-ins}~节介绍的方法，使用发行版自带的包管理器安装
 % 本宏集。
 %
-% \CTeX\ 宏集有两个源文件：\file{ctex.dtx}、\file{ctexpunct.spa}。
-% 使用不同的编译方式时，\CTeX\ 依赖的宏包略有不同。在手工安装 \CTeX\ 宏集之前，请确保
-% 你的 \TeX\ 发行版中已经正确安装了这些宏包。\CTeX\ 依赖宏包的详情叙述如下：
+% \CTeX{} 宏集有两个源文件：\file{ctex.dtx}、\file{ctexpunct.spa}。
+% 使用不同的编译方式时，\CTeX{} 依赖的宏包略有不同。在手工安装 \CTeX{} 宏集之前，请确保
+% 你的 \TeX{} 发行版中已经正确安装了这些宏包。\CTeX{} 依赖宏包的详情叙述如下：
 %
 % \begin{itemize}
 %   \item \pkg{expl3}、\pkg{xparse} 和 \pkg{l3keys2e} 宏包。它们属于 \pkg{l3kernel}
@@ -3365,14 +3365,14 @@ Copyright and Licence
 %     \item \pkg{kvsetkeys} 宏包。
 %     \item \pkg{keyval} 宏包，\pkg{graphics} 宏集。
 %   \end{itemize}
-%   \item[\ding{229}] 以上是使用 \pdfLaTeX\ 或 \LaTeX\ + \dvipdfmx\ 的编译方式所需要
+%   \item[\ding{229}] 以上是使用 \pdfLaTeX{} 或 \LaTeX{} + \dvipdfmx{} 的编译方式所需要
 %   的依赖项，其中 \pkg{zhmCJK} 是可选的。
 %   \item \pkg{xeCJK} 宏集，它还依赖
 %   \begin{itemize}
 %     \item \pkg{xtemplate} 宏包，它属于 \pkg{l3packages} 宏集。
 %     \item \pkg{fontspec} 宏包。
 %   \end{itemize}
-%   \item[\ding{229}] 以上是使用 \XeLaTeX\ 编译时的依赖项。
+%   \item[\ding{229}] 以上是使用 \XeLaTeX{} 编译时的依赖项。
 %   \item \pkg{luatexja} 宏包，它还依赖
 %   \begin{itemize}
 %     \item \pkg{adobemapping} 宏包。
@@ -3388,35 +3388,35 @@ Copyright and Licence
 %     \item \pkg{chinese-jfm} 宏包。
 %   \end{itemize}
 %   \item \pkg{fontspec} 宏包。
-%   \item[\ding{229}] 以上是使用 \LuaLaTeX\ 编译时的依赖项。
+%   \item[\ding{229}] 以上是使用 \LuaLaTeX{} 编译时的依赖项。
 %   \item \pkg{zhmetrics-uptex} 宏包。
-%   \item[\ding{229}] 以上是使用 \upLaTeX\ 编译时的依赖项。
+%   \item[\ding{229}] 以上是使用 \upLaTeX{} 编译时的依赖项。
 % \end{itemize}
 %
-% 出于一些原因，\pkg{zhmCJK} 尚未被收入 \TeXLive\ 和 \MiKTeX。因此，若
-% 你希望使用 \pkg{zhmCJK} 作为 \CTeX\ 宏集的底层中文支持方式，那么你需要自行安装该宏包。
+% 出于一些原因，\pkg{zhmCJK} 尚未被收入 \TeXLive{} 和 \MiKTeX。因此，若
+% 你希望使用 \pkg{zhmCJK} 作为 \CTeX{} 宏集的底层中文支持方式，那么你需要自行安装该宏包。
 % \pkg{zhmCJK} 的安装较为复杂。我们建议你
 % \begin{enumerate}
 %   \item 从 CTAN 下载 \pkg{zhmCJK} 宏包的
 %   \href{http://mirrors.ctan.org/install/language/chinese/zhmcjk.tds.zip}
 %   {TDS 安装包}，
-%   \item 按目录结构将文件复制到 \TeX\ 发行版的本地 TDS 根目录，
-%   \item 最后执行 \bashcmd{texhash} 刷新 \TeX\ 发行版的 ls-R 数据库以完成安装。
+%   \item 按目录结构将文件复制到 \TeX{} 发行版的本地 TDS 根目录，
+%   \item 最后执行 \bashcmd{texhash} 刷新 \TeX{} 发行版的 ls-R 数据库以完成安装。
 % \end{enumerate}
 % 其他细节，可参照其
 % \href{http://mirrors.ctan.org/language/chinese/zhmcjk/zhmCJK.pdf}{宏包手册}
 % 中第 3 节的指导。
 %
-% \emph{\CTeX\ 宏集已被 \TeXLive\ 和 \MiKTeX\ 收录，若无特别理由，
+% \emph{\CTeX{} 宏集已被 \TeXLive{} 和 \MiKTeX{} 收录，若无特别理由，
 % 我们强烈建议用户使用包管理器安装本宏集。}
 %
 % 若要手工安装，请遵循如下步骤：
 % \begin{enumerate}
-%   \item 从 CTAN 下载 \CTeX\ 宏集的
+%   \item 从 CTAN 下载 \CTeX{} 宏集的
 %   \href{http://mirrors.ctan.org/install/language/chinese/ctex.tds.zip}
 %   {TDS 安装包}，
-%   \item 按目录结构将文件复制到 \TeX\ 发行版的本地 TDS 根目录，
-%   \item 最后执行 \bashcmd{texhash} 刷新 \TeX\ 发行版的 ls-R 数据库以完成安装。
+%   \item 按目录结构将文件复制到 \TeX{} 发行版的本地 TDS 根目录，
+%   \item 最后执行 \bashcmd{texhash} 刷新 \TeX{} 发行版的 ls-R 数据库以完成安装。
 % \end{enumerate}
 %
 % \section{开发人员}
@@ -3441,7 +3441,7 @@ Copyright and Licence
 % \begin{thebibliography}{9}
 % \bibitem{knuthtex1986}
 % \textsc{Donald~Ervin Knuth}.
-% \newblock \textit{The {{\TeX book}}}, \textit{Computers \& Typesetting},
+% \newblock \textit{The {{\TeX{}book}}}, \textit{Computers \& Typesetting},
 %   volume~A.
 % \newblock Addison-Wesley, 1986
 %
@@ -3489,12 +3489,12 @@ Copyright and Licence
 %<*class|ctex>
 %    \end{macrocode}
 %
-% \changes{v2.3}{2015/12/20}{与 \LaTeXiii\ (2015/12/20) 同步。}
+% \changes{v2.3}{2015/12/20}{与 \LaTeXiii{} (2015/12/20) 同步。}
 % \changes{v2.4.10}{2017/07/19}{常数 \cs{c_minus_one} 已过时。}
 % \changes{v2.4.10}{2017/07/22}{使用 \texttt{lazy} 函数对 Boolean 表达式
-% 进行最小化运算（\LaTeXiii\ 2017/07/19）。}
-% \changes{v2.6.0}{2024/04/20}{提升 \LaTeXiii\ 版本至 2022/10/09。}
-% \changes{v2.6.0}{2026/05/03}{提升 \LaTeXiii\ 最低版本要求至 2025/10/09。}
+% 进行最小化运算（\LaTeXiii{} 2017/07/19）。}
+% \changes{v2.6.0}{2024/04/20}{提升 \LaTeXiii{} 版本至 2022/10/09。}
+% \changes{v2.6.0}{2026/05/03}{提升 \LaTeXiii{} 最低版本要求至 2025/10/09。}
 %
 % 检查 \pkg{expl3} 的版本。
 %    \begin{macrocode}
@@ -3510,7 +3510,7 @@ Copyright and Licence
 %    \end{macrocode}
 %
 % \begin{variable}{\c_@@_engine_str,\c_@@_engine_file_str}
-% 引擎检查。目前 \LaTeXiii\ 将 \ApTeX\ 识别为 \upTeX。
+% 引擎检查。目前 \LaTeXiii{} 将 \ApTeX{} 识别为 \upTeX。
 %    \begin{macrocode}
 \str_const:Nx \c_@@_engine_str
   { \cs_if_exist:NTF \ngostype { aptex } { \c_sys_engine_str } }
@@ -3663,7 +3663,7 @@ Copyright and Licence
 % \end{macro}
 %
 % \begin{macro}[int]{\ctex_if_preamble:TF}
-% 测试是否在 \LaTeXe\ 的导言区。在宏包内部初始为真，文档最开始位置再设置为假。
+% 测试是否在 \LaTeXe{} 的导言区。在宏包内部初始为真，文档最开始位置再设置为假。
 % 注意，钩子 \cs{ctex_after_end_preamble:n} 在 \tn{AtBeginDocument} 之后执行，
 % 可以与 \tn{@onlypreamble} 的行为一致。
 %    \begin{macrocode}
@@ -4196,7 +4196,7 @@ Copyright and Licence
 %</class|style>
 %    \end{macrocode}
 %
-% \pdfLaTeX\ 下，如果没有显式指定编码为 |UTF8|，则给出警告信息。
+% \pdfLaTeX{} 下，如果没有显式指定编码为 |UTF8|，则给出警告信息。
 %    \begin{macrocode}
 %<*class|ctex>
 \msg_new:nnn { ctex } { pdftex-utf8 }
@@ -4249,14 +4249,14 @@ Copyright and Licence
 %
 % \subsubsection{\pkg{ctexbackend.cfg}}
 %
-% 对于 \XeLaTeX/\pdfLaTeX/\LuaLaTeX\ 等默认直接输出 PDF 的编译方式，用户
-% 无需为涉及驱动的宏包指定驱动选项。对于 \LaTeX 和 \upLaTeX\ 等默认不直接输出 PDF 的编译方式，
+% 对于 \XeLaTeX{}/\pdfLaTeX{}/\LuaLaTeX{} 等默认直接输出 PDF 的编译方式，用户
+% 无需为涉及驱动的宏包指定驱动选项。对于 \LaTeX 和 \upLaTeX{} 等默认不直接输出 PDF 的编译方式，
 % 用户则需要指定驱动选项。
 %
-% 由于历史遗留问题，在使用 \LaTeX\ 或 \upLaTeX\ 等编译时，
+% 由于历史遗留问题，在使用 \LaTeX{} 或 \upLaTeX{} 等编译时，
 % 大多数涉及驱动的宏包选定的默认输出驱动都是 Dvips。
-% 考虑当前实际使用频率，以及考虑到 \CTeX\ 宏集对中文支持的默认方式，
-% 我们在用户使用 \CTeX\ 系列文档类时，将默认的输出驱动改为 \dvipdfmx。
+% 考虑当前实际使用频率，以及考虑到 \CTeX{} 宏集对中文支持的默认方式，
+% 我们在用户使用 \CTeX{} 系列文档类时，将默认的输出驱动改为 \dvipdfmx。
 %
 % 具体来说，如果 |dvips|，|dvipdfmx|，|dvisvgm| 等驱动没有在文档类的全局选项中被明确指定，
 % 我们就在 \tn{@classoptionslist} 开头加入 |dvipdfmx|。
@@ -4291,8 +4291,8 @@ Copyright and Licence
 % \subsubsection{\pkg{ctex-engine-pdftex.def}}
 %
 % \begin{macro}[int]{\ctex_set_zhmap:n}
-% 设置 \upTeX\ 字体映射，同时作用于 \tn{AtBeginDvi} 与
-% \tn{AtBeginShipoutFirst}。该宏对 \pdfTeX\ 和 \upTeX\ 均有用。
+% 设置 \upTeX{} 字体映射，同时作用于 \tn{AtBeginDvi} 与
+% \tn{AtBeginShipoutFirst}。该宏对 \pdfTeX{} 和 \upTeX{} 均有用。
 % \tn{AtBeginDvi} 直接将 \tn{special} 保存到盒子中，
 % \tn{AtBeginShipoutFirst} 是保存到到宏中，并且不展开参数。
 %
@@ -4331,7 +4331,7 @@ Copyright and Licence
 %<*pdftex>
 %    \end{macrocode}
 %
-% \changes{v2.1}{2015/05/18}{给 \pdfLaTeX\ 下的非 UTF-8 编码 CJK 字体族加上 CMap。}
+% \changes{v2.1}{2015/05/18}{给 \pdfLaTeX{} 下的非 UTF-8 编码 CJK 字体族加上 CMap。}
 %
 % \begin{variable}{\c_@@_cmap_encoding_seq}
 % 需要加上 CMap 的 CJK 字体编码。
@@ -4398,7 +4398,7 @@ Copyright and Licence
 % \end{macro}
 %
 % \begin{macro}[int]{\DeclareFontFamily}
-% 只在 \pdfLaTeX\ 下加 CMap。如 \pkg{cmap} 宏包被引入，则不重复设置。
+% 只在 \pdfLaTeX{} 下加 CMap。如 \pkg{cmap} 宏包被引入，则不重复设置。
 %    \begin{macrocode}
 \sys_if_output_pdf:T
   {
@@ -5171,7 +5171,7 @@ Copyright and Licence
 %
 % \changes{v2.3}{2015/09/26}{更新 \pkg{unicode-math} 宏包补丁。}
 %
-% 在 \LaTeX\ 下，\pkg{LuaTeX-ja} 对 \pkg{fontspec}、\pkg{xunicode}、\pkg{unicode-math}
+% 在 \LaTeX{} 下，\pkg{LuaTeX-ja} 对 \pkg{fontspec}、\pkg{xunicode}、\pkg{unicode-math}
 % 和 \pkg{listings} 打了补丁。其中前三个是把 \tn{char} 换成 \tn{ltjalchar}，确保
 % 字符是 ALchar 类。我们这里用 \pkg{xunicode-addon} 来处理 \pkg{xunicode}。
 %    \begin{macrocode}
@@ -5581,7 +5581,7 @@ Copyright and Licence
 % 以下内容来自 \file{lltjfont.sty}，目的是让汉字可以在数学环境中直接使用。
 %
 % \begin{macro}[int]{\ctex_ltj_if_jfont:nTF}
-% 参数 |#1| 是一个 \LaTeXe\ 编码名称或者字体命令。\LaTeXe\ 字体命令的一般形式是：
+% 参数 |#1| 是一个 \LaTeXe{} 编码名称或者字体命令。\LaTeXe{} 字体命令的一般形式是：
 % \begin{quote}\ttfamily\small
 %   \textbackslash\meta{encoding}/\meta{family}/\meta{series}/\meta{shape}
 % \end{quote}
@@ -6659,7 +6659,7 @@ Copyright and Licence
 % \changes{v2.6.0}{2026/04/27}{修复内联 \tn{verb} 前 \opt{xkanjiskip} 丢失的问题
 %   （移植 \pkg{lltjcore} 对 \tn{verb} 和 \tn{do@noligs} 的修复）。}
 %
-% \pkg{LuaTeX-ja} 的 \file{lltjcore.sty} 会将 \LaTeX\ 的 \tn{verb} 中
+% \pkg{LuaTeX-ja} 的 \file{lltjcore.sty} 会将 \LaTeX{} 的 \tn{verb} 中
 % \tn{null}（即 |\hbox{}|）替换为 |\vadjust{}|，因为空 |\hbox{}| 会阻断
 % \opt{xkanjiskip} 的自动插入。由于 \pkg{ctex} 禁用了 \pkg{ltj-latex}，
 % 这里需要自行复制该修复。
@@ -6680,7 +6680,7 @@ Copyright and Licence
 %    \end{macrocode}
 %
 % \begin{macro}{\@@@@italiccorr}
-% \LaTeX\ 的倾斜校正也要重新定义。
+% \LaTeX{} 的倾斜校正也要重新定义。
 %    \begin{macrocode}
 \cs_set_eq:NN \@@@@italiccorr \/
 %    \end{macrocode}
@@ -6733,10 +6733,10 @@ Copyright and Licence
 %    \end{macrocode}
 %
 % \begin{macro}[int]{\em}
-% \changes{v2.4.2}{2016/05/15}{兼容 \upLaTeX\ 2016/05/07u00 的定义。}
-% 取消 \upLaTeX\ 对 \tn{em} 使用 |\mcfamily|、|\gtfamily| 命令的重定义，恢复
-% \LaTeXe\ 对 \tn{em} 的原始定义。如果用户已经重定义了 \tn{em}，则新定义保持
-% 不变。\upLaTeX\ 2016/05/07u00 的定义有所变化，这一行为可以由用户通过 \pkg{platexrelease}
+% \changes{v2.4.2}{2016/05/15}{兼容 \upLaTeX{} 2016/05/07u00 的定义。}
+% 取消 \upLaTeX{} 对 \tn{em} 使用 |\mcfamily|、|\gtfamily| 命令的重定义，恢复
+% \LaTeXe{} 对 \tn{em} 的原始定义。如果用户已经重定义了 \tn{em}，则新定义保持
+% 不变。\upLaTeX{} 2016/05/07u00 的定义有所变化，这一行为可以由用户通过 \pkg{platexrelease}
 % 包改变，需要分支处理。
 %    \begin{macrocode}
 \ctex_patch_cmd_once:NnnnTF \em
@@ -6753,7 +6753,7 @@ Copyright and Licence
 %    \end{macrocode}
 % \end{macro}
 %
-% \changes{v2.4}{2016/04/24}{正确设置 \upTeX\ 下字体命令。}
+% \changes{v2.4}{2016/04/24}{正确设置 \upTeX{} 下字体命令。}
 % \begin{macro}[int]{\ctex_set_upfamily:nnn}
 % 将 NFSS 字体族 |#1| 设置为 JFM 字体名 |#2|，粗体形式字体名 |#3|。其中字体名
 % 形如 |upzhserif|，不包括表示方向的后缀 |-h| 与 |-v|。粗体字体名为空时不设置该
@@ -6777,7 +6777,7 @@ Copyright and Licence
 % \end{macro}
 %
 % \begin{macro}[int]{\ctex_set_upmap:nnn}
-% 设置 \upTeX\ 字体映射。|#1| 是形如 |upserif| 的 PS TFM 字体名，不带表示粗体
+% 设置 \upTeX{} 字体映射。|#1| 是形如 |upserif| 的 PS TFM 字体名，不带表示粗体
 % 的后缀 |b| 与表示排版方向的后缀 |-h| 与 |-v|。|#2| 与 |#3| 是普通与粗体的实际
 % 字体名。
 %    \begin{macrocode}
@@ -6798,7 +6798,7 @@ Copyright and Licence
 % \end{macro}
 %
 % \begin{macro}[int]{\ctex_set_upmap_unicode:nnn}
-% 设置 \upTeX\ 字体映射，使用 |unicode| CMap。参数同上。
+% 设置 \upTeX{} 字体映射，使用 |unicode| CMap。参数同上。
 %    \begin{macrocode}
 \cs_new_protected:Npn \ctex_set_upmap_unicode:nnn #1#2#3
   {
@@ -6817,7 +6817,7 @@ Copyright and Licence
 % \end{macro}
 %
 % \begin{macro}[int]{\ctex_set_upfonts:nnnnnn}
-% 设置 \upTeX\ 基本字体映射，按 \pkg{zhmetrics-uptex} 的定义，依次设置衬线体
+% 设置 \upTeX{} 基本字体映射，按 \pkg{zhmetrics-uptex} 的定义，依次设置衬线体
 % 正、粗、意大利，无衬线体正、粗，等宽体正——共 6 种字体，并分横排及直排。
 %    \begin{macrocode}
 \cs_new_protected:Npn \ctex_set_upfonts:nnnnnn #1#2#3#4#5#6
@@ -6840,7 +6840,7 @@ Copyright and Licence
 %
 % \changes{v2.4.7}{2016/12/27}{依赖 \pkg{pxeverysel} 宏包。}
 %
-% \pkg{everysel} 宏包（2011/10/28）未考虑 \upLaTeX\ 对 \tn{selectfont} 的修
+% \pkg{everysel} 宏包（2011/10/28）未考虑 \upLaTeX{} 对 \tn{selectfont} 的修
 % 改，需要引入 \pkg{pxeverysel} 宏包。
 %    \begin{macrocode}
 \bool_if:NT \c_@@_everysel_loaded_bool
@@ -6933,7 +6933,7 @@ Copyright and Licence
 %    \end{macrocode}
 %
 % \changes{v2.4}{2016/02/15}{正确更新 \pkg{CJK} 包的 \tn{CJKfamilydefault}。}
-% \changes{v2.4.1}{2016/04/26}{正确更新 \upLaTeX\ 的 \tn{CJKfamilydefault}。}
+% \changes{v2.4.1}{2016/04/26}{正确更新 \upLaTeX{} 的 \tn{CJKfamilydefault}。}
 %
 % \begin{macro}[int]{\ctex_update_default_family:}
 % 在导言区结束，如果 \tn{CJKfamilydefault} 没有被更改，则在此时根据西文字体的情况
@@ -6958,8 +6958,8 @@ Copyright and Licence
         \group_end:
       }
 %    \end{macrocode}
-% 使用 \LuaLaTeX\ 时，自动调整得到的 \tn{CJKfamilydefault} 可能没有定义，需要
-% 确认它的存在性。使用 \pkg{CJK} 宏包或 \upLaTeX\
+% 使用 \LuaLaTeX{} 时，自动调整得到的 \tn{CJKfamilydefault} 可能没有定义，需要
+% 确认它的存在性。使用 \pkg{CJK} 宏包或 \upLaTeX{}
 % 时，\texttt{C19rm}、\texttt{JY2rm} 等总是有定义的，不需要确认。
 %    \begin{macrocode}
 %<luatex>    \ctex_ltj_ensure_default_family:
@@ -7018,7 +7018,7 @@ Copyright and Licence
 %
 % \changes{v2.5.7}{2021/06/06}{禁用 \dvipdfmx\ 驱动的 \opt{unicode} 书签设置。}
 %
-% 在 \pdfTeX\ 下使用 \texttt{GBK} 编码，\dvipdfmx\ 驱动可以直接用它的
+% 在 \pdfTeX{} 下使用 \texttt{GBK} 编码，\dvipdfmx{} 驱动可以直接用它的
 % \tn{special} 命令，其他模式用 \pkg{xCJK2uni} 宏包处理。使用 \texttt{UTF-8} 编
 % 码时，\pkg{CJKutf8} 已经处理了书签问题，但仍需要设置 \opt{pdfencoding} 为
 % \opt{unicode}，目的是在书签的开头写入 BOM (|\376\377|)，提示这是
@@ -7065,8 +7065,8 @@ Copyright and Licence
 %</xetex|luatex>
 %    \end{macrocode}
 %
-% 我们假定 \upTeX\ 使用 \dvipdfmx\ 驱动输出，于是使用与 \pdfTeX\ 类似的设
-% 置。注意 \upTeX\ 需要使用 UTF8-UTF16 的编码转换。
+% 我们假定 \upTeX{} 使用 \dvipdfmx{} 驱动输出，于是使用与 \pdfTeX{} 类似的设
+% 置。注意 \upTeX{} 需要使用 UTF8-UTF16 的编码转换。
 %    \begin{macrocode}
 %<*uptex|aptex>
 \@ifpackageloaded { hyperref }
@@ -7102,7 +7102,7 @@ Copyright and Licence
 % \tn{CTEXunderdblline}、\tn{CTEXunderwave}、\tn{CTEXsout}、\tn{CTEXxout}、
 % \env{CTEXfilltwosides} 等命令和环境。}
 %
-% 对 \pdfTeX\ 与 \XeTeX\ 引擎，分别在 \pkg{CJKfntef}、\pkg{xeCJKfntef} 宏包
+% 对 \pdfTeX{} 与 \XeTeX{} 引擎，分别在 \pkg{CJKfntef}、\pkg{xeCJKfntef} 宏包
 % 的末尾关闭彩色显式等多余格式。
 %
 %    \begin{macrocode}
@@ -7137,7 +7137,7 @@ Copyright and Licence
 % \subsubsection{\tn{ccwd} 的更新}
 %
 % \begin{macro}[int]{\ctex_update_ccwd:,\ccwd}
-% \changes{v2.4.1}{2016/04/29}{正确设置 \upTeX\ 下的 \tn{ccwd}。}
+% \changes{v2.4.1}{2016/04/29}{正确设置 \upTeX{} 下的 \tn{ccwd}。}
 %    \begin{macrocode}
 \cs_new_protected:Npn \ctex_update_ccwd:
 %<*pdftex|xetex>
@@ -7214,12 +7214,12 @@ Copyright and Licence
 % \begin{macro}[int]{\ctex_update_em_unit:}
 % 将当前汉字的宽度保存到 \tn{ccwd} 中备用。不采用 \texttt{1em}，因为这时的
 % \texttt{1em} 实际上来自西文字体的信息，未必等于汉字的宽度，这似乎在传统的
-% \file{.tfm} 字体上表现更明显。在 \pdfTeX\ 和 \XeTeX\ 下，直接使用 |\f@size\p@|
+% \file{.tfm} 字体上表现更明显。在 \pdfTeX{} 和 \XeTeX{} 下，直接使用 |\f@size\p@|
 % 作为汉字的宽度，这应该对大多数汉字字体都成立，但不适用于诸如“方正兰亭黑长”之类
-% 的特殊字体。在 \XeTeX\ 可以用 \tn{fontcharwd} 来改进。而在 \pdfTeX\ 下，若使用
+% 的特殊字体。在 \XeTeX{} 可以用 \tn{fontcharwd} 来改进。而在 \pdfTeX{} 下，若使用
 % \pkg{zhmetrics} 技术，所有的汉字共享同一个 \file{.tfm}，\tn{fontcharwd} 也就没有
-% 意义。在 \LuaTeX\ 下，\pkg{LuaTeX-ja} 总是按照 JFM 中的设置输出汉字的宽度，可以
-% 直接用 \tn{zw} 作为汉字宽度。\upTeX\ 可以直接使用原生的长度单位 |zw|。
+% 意义。在 \LuaTeX{} 下，\pkg{LuaTeX-ja} 总是按照 JFM 中的设置输出汉字的宽度，可以
+% 直接用 \tn{zw} 作为汉字宽度。\upTeX{} 可以直接使用原生的长度单位 |zw|。
 %    \begin{macrocode}
 \cs_new_protected:Npn \ctex_update_em_unit:
 %<pdftex|xetex>  { \dim_set:Nn \ccwd { \f@size \p@ } }
@@ -7334,13 +7334,13 @@ Copyright and Licence
 %</luatex>
 %    \end{macrocode}
 %
-% \changes{v2.4.1}{2016/05/01}{随字体更新 \upTeX\ 的 \tn{xkanjiskip}。}
+% \changes{v2.4.1}{2016/05/01}{随字体更新 \upTeX{} 的 \tn{xkanjiskip}。}
 %
 % \begin{macro}[int]{\ctex_update_xkanjiskip:}
 % \begin{variable}{\l_@@_xkanjiskip_skip}
-% \upTeX\ 和 \pkg{LuaTeX-ja} 对 \tn{xkanjiskip} 都是即时赋值。单位 \opt{zw} 与字体相关，因此
+% \upTeX{} 和 \pkg{LuaTeX-ja} 对 \tn{xkanjiskip} 都是即时赋值。单位 \opt{zw} 与字体相关，因此
 % 需要每次 \tn{selectfont} 的时候更新一次 \tn{xkanjiskip}。如果用户设置过
-% \tn{xkanjiskip}，就不更新。注意，同 \TeX\ 的 \tn{baselineskip} 一样，如果在
+% \tn{xkanjiskip}，就不更新。注意，同 \TeX{} 的 \tn{baselineskip} 一样，如果在
 % 一个段落内多次设置了 \tn{kanjiskip} 或 \tn{xkanjiskip}，只有最后的设置会影响
 % 全段。
 %    \begin{macrocode}
@@ -7407,7 +7407,7 @@ Copyright and Licence
 %
 % \begin{macro}{space}
 % 在导言区或正文中设置忽略空格方式。
-% \pdfTeX\ 和 \XeTeX\ 下初始设置为 \opt{auto}，\LuaTeX、\upTeX\ 下是无效
+% \pdfTeX{} 和 \XeTeX{} 下初始设置为 \opt{auto}，\LuaTeX{}、\upTeX{} 下是无效
 % 选项。
 %    \begin{macrocode}
 \ctex_define:n
@@ -7436,7 +7436,7 @@ Copyright and Licence
 %
 % \begin{macro}{punct}
 % 在导言区或正文中设置标点符号输出格式。\pkg{LuaTeX-ja} 设置的是字体的默认 \texttt{JFM}，
-% 只会影响到之后设置的字体。\upTeX\ 暂时无效。
+% 只会影响到之后设置的字体。\upTeX{} 暂时无效。
 %    \begin{macrocode}
 \ctex_define:n
   {
@@ -7457,8 +7457,8 @@ Copyright and Licence
 %
 % \begin{macro}{experiment,experiment/CJKecglue}
 % 实验性选项。\opt{experiment/CJKecglue} 用于统一设置 CJK 文字与西文之间的间距。
-% \XeTeX\ 下转发给 \pkg{xeCJK}，\LuaTeX\ 和 \upTeX\ 下设置 |xkanjiskip|，
-% \pdfTeX\ 下不支持。
+% \XeTeX{} 下转发给 \pkg{xeCJK}，\LuaTeX{} 和 \upTeX{} 下设置 |xkanjiskip|，
+% \pdfTeX{} 下不支持。
 %    \begin{macrocode}
 \ctex_define:n
   { experiment .meta:nn = { ctex / experiment } {#1} }
@@ -7710,7 +7710,7 @@ Copyright and Licence
     \dim_compare:nNnTF \ccwd > \c_zero_dim
 %    \end{macrocode}
 % 伸展量保证行内的剩余空白能够被均匀地填充到汉字之间，收缩的最大限度是让当前行
-% 还能够再挤下一个汉字并且不会出现负间距。由 \TeX\ 决定伸展还是收缩。
+% 还能够再挤下一个汉字并且不会出现负间距。由 \TeX{} 决定伸展还是收缩。
 %    \begin{macrocode}
       {
         \dim_set:Nn \l_@@_tmp_dim
@@ -7739,7 +7739,7 @@ Copyright and Licence
     \ctex_update_ccglue:
 %    \end{macrocode}
 % 字距设置得比较大时，为了尽量保证段首缩进能够与下一行对齐，应该需要相应地加上
-% 或者减去伸缩值。但是这里并不清楚 \TeX\ 是伸展还是收缩，之前以“当前行是否还
+% 或者减去伸缩值。但是这里并不清楚 \TeX{} 是伸展还是收缩，之前以“当前行是否还
 % 放得下一个汉字”为标准加上或减去伸缩值的做法也未必与实际结果一致，所以只好还
 % 是设置为 |2\ccwd|。
 %    \begin{macrocode}
@@ -7920,7 +7920,7 @@ Copyright and Licence
 %
 % \subsection{中文化的标题结构}
 %
-% 本节内容在 \CTeX\ 文档类或打开 \opt{heading} 选项下生效。
+% 本节内容在 \CTeX{} 文档类或打开 \opt{heading} 选项下生效。
 %    \begin{macrocode}
 %<*class|heading>
 %    \end{macrocode}
@@ -8056,7 +8056,7 @@ Copyright and Licence
 %
 % \begin{macro}[int]{\ctex_assign_heading_name:nn}
 % \begin{macro}{\@@_assign_heading_name:nnn}
-% \opt{name} 的值是一个至多两个元素的逗号分隔列表。由于 \LaTeXiii\ 的
+% \opt{name} 的值是一个至多两个元素的逗号分隔列表。由于 \LaTeXiii{} 的
 % \texttt{clist} 总是会自动忽略空元素，所以设置 |name={,章}| 后，第一个元素将会
 % 是“章”，必须用空的分组保护空元素：|name={{},章}|，这在使用中有些许不便。我们
 % 可以改用 \texttt{seq} 或者手写函数解析参数来加以改进。为实现的简单起见，这里用
@@ -8174,7 +8174,7 @@ Copyright and Licence
 % \begin{macro}[int]{\CTEX@fixheadingskip}
 % 抑制行间粘连，修正标题前后的多余间距。事实上，减掉 \tn{parskip}，有一定的风险。
 % 如果接下来的内容不会进入水平模式（例如在 \opt{format} 选项中使用 \tn{hrule} 或者 \tn{hbox}），
-% \TeX\ 就不会加上 \tn{parskip}。这时候就需要用户把 \tn{parskip} 加到 \opt{beforeskip}
+% \TeX{} 就不会加上 \tn{parskip}。这时候就需要用户把 \tn{parskip} 加到 \opt{beforeskip}
 % 或者 \opt{afterskip} 作为修正。
 %    \begin{macrocode}
 \cs_new_protected:Npn \CTEX@fixheadingskip
@@ -8944,7 +8944,7 @@ Copyright and Licence
 % \end{macro}
 %
 % \begin{variable}{\c_@@_headings_cs_seq}
-% 保存内部标题命令的 \CTeX\ 定义，用于随后比较。
+% 保存内部标题命令的 \CTeX{} 定义，用于随后比较。
 %    \begin{macrocode}
 \seq_const_from_clist:Nn \c_@@_headings_cs_seq
 %<article>  { part , spart , sect , ssect }
@@ -8960,7 +8960,7 @@ Copyright and Licence
 % \begin{macro}[int]{\CTEX@hyperheadinghook}
 % \pkg{hyperref} 会重定义内部标题命令，目的在于为没有编号的标题设置锚点（这一功能受他的
 % \opt{implicit} 选项的控制）。我们在上面对标题命令的修改已经包含这一功能，如果这些标题命令在
-% \pkg{hyperref} 载入之前没有被修改过，则恢复 \CTeX\ 的定义。
+% \pkg{hyperref} 载入之前没有被修改过，则恢复 \CTeX{} 的定义。
 %    \begin{macrocode}
 \cs_new_protected:Npn \CTEX@hyperheadinghook
   {
@@ -9043,9 +9043,9 @@ Copyright and Licence
 %   \Arg{left}\Arg{right}\Arg{before}\Arg{after}\Arg{afterindent}
 % \end{quote}
 % 其中 \meta{afterindent} 为 |1| 或 |0|，分别对应是否保留段首缩进。
-% 我们需要根据 \CTeX\ 的 \opt{runin} 和 \opt{afterindent} 选项调整
+% 我们需要根据 \CTeX{} 的 \opt{runin} 和 \opt{afterindent} 选项调整
 % |\ttlh@|\meta{shape} 和 \meta{afterindent}。注意，由 \tn{ttl@extract} 得的
-% \meta{before} 和 \meta{after} 的值总是非负的，而 \CTeX\ 的 \opt{beforeskip}
+% \meta{before} 和 \meta{after} 的值总是非负的，而 \CTeX{} 的 \opt{beforeskip}
 % 和 \opt{afterskip} 是可以取负值的，但我们不打算调整它们了。
 % 如果使用了 \pkg{titlesec} 的 \opt{indentafter} 等选项，也不需要调整
 % |\ttls@|\meta{section}。
@@ -9123,7 +9123,7 @@ Copyright and Licence
   }
 %    \end{macrocode}
 %
-% \changes{v2.4.4}{2016/09/13}{使用 \pkg{titlesec} 时，章节目录也使用 \CTeX\ 的编号。}
+% \changes{v2.4.4}{2016/09/13}{使用 \pkg{titlesec} 时，章节目录也使用 \CTeX{} 的编号。}
 % 让编译时终端显示  \tn{CTEXthechapter}，目录使用 |\CTEXtheXXX| 编号。
 %    \begin{macrocode}
 \ctex_at_end_package:nn { titlesec }
@@ -9601,7 +9601,7 @@ Copyright and Licence
 % 关于标签引用的宏包可能会修改 \tn{refstepcounter}。其中 \pkg{cleveref} 和
 % \pkg{hyperref} 宏包都会保存之前的定义，并且它们都要求尽可能晚的被载入，所以
 % 对我们上述的修改影响不大。需要注意的是 \pkg{varioref} 宏包，如果它在
-% \CTeX\ 之后被载入，我们之前的修改将会被覆盖。
+% \CTeX{} 之后被载入，我们之前的修改将会被覆盖。
 % 较新版 \LaTeX \ 内核已经包含 \tn{labelformat}，可以直接使用。
 %    \begin{macrocode}
 \cs_new_protected:Npn \ctex_varioref_hook:
@@ -9615,7 +9615,7 @@ Copyright and Licence
 %
 % \begin{macro}{\ctex_fix_varioref_label:n}
 % \pkg{varioref} 宏包的 \tn{labelformat} 实际上是定义一个以 |\the<#1>| 为参数的宏
-% |\p@<#1>|。\LaTeX\ 在定义计数器 |<#1>| 时，都会将 |\p@<#1>| 初始化为 \tn{@empty}。
+% |\p@<#1>|。\LaTeX{} 在定义计数器 |<#1>| 时，都会将 |\p@<#1>| 初始化为 \tn{@empty}。
 % 如果这个宏非空，说明用户自定义了标签格式，我们就不再修改。这里不能使用
 % \cs{exp_args:Nnc}，因为 \texttt{c} 这种展开格式不会将参数放在花括号内。而
 % \tn{labelformat} 的定义是
@@ -9637,14 +9637,14 @@ Copyright and Licence
 % \changes{v2.5.7}{2021/06/04}{同时兼容 \pkg{cleveref} 和 \cls{beamer}。}
 %
 % \begin{macro}{patch/cleveref}
-% \pkg{cleveref} 宏包长期未维护，与较新的 \LaTeX\ 内核和 \pkg{hyperref}
-% 存在兼容问题。\CTeX\ 提供了对 \pkg{cleveref} 的补丁，但用户也可以选择
+% \pkg{cleveref} 宏包长期未维护，与较新的 \LaTeX{} 内核和 \pkg{hyperref}
+% 存在兼容问题。\CTeX{} 提供了对 \pkg{cleveref} 的补丁，但用户也可以选择
 % 关闭它。
 %
 % 当同时使用 \pkg{hyperref} 和 \pkg{cleveref} 时，|\appendix| 之后的交叉引用
 % 类型可能不正确（例如，\texttt{appendix} 退化为 \texttt{chapter}）。
-% 这是上游 \LaTeX\ 内核 \texttt{firstaid} 对 \pkg{cleveref} 补丁不完整所致，
-% 与 \CTeX\ 无关。可以使用以下方法规避：
+% 这是上游 \LaTeX{} 内核 \texttt{firstaid} 对 \pkg{cleveref} 补丁不完整所致，
+% 与 \CTeX{} 无关。可以使用以下方法规避：
 % \begin{verbatim}
 %   \AddToHook{cmd/appendix/before}{%
 %     \crefalias{chapter}{appendix}%
@@ -10565,7 +10565,7 @@ Copyright and Licence
 %   \DeclareRobustCommand\CTeX{$\mathbb{C}$\kern-.05em\TeX}
 % \end{verbatim}
 % 然而 \tn{mathbb} 未必有定义，这里就不采用它了，只定义最简单的形式。
-% \CTeX\ 可以直接用在 PDF 书签中。
+% \CTeX{} 可以直接用在 PDF 书签中。
 %    \begin{macrocode}
 \NewDocumentCommand \CTeX { }
   { C \TeX }
@@ -10816,8 +10816,8 @@ Copyright and Licence
 %<tt&c70>\DeclareFontFamily{C70}{tt}{\hyphenchar\font\m@ne}
 %    \end{macrocode}
 %
-% \changes{v2.4}{2016/04/25}{提供 \upLaTeX\ 的 NFSS 字体定义。}
-% \upLaTeX\ 使用的字体族。\upLaTeX 在 NFSS 下使用字体编码 |JY2| 和 |JT2| 来分别
+% \changes{v2.4}{2016/04/25}{提供 \upLaTeX{} 的 NFSS 字体定义。}
+% \upLaTeX{} 使用的字体族。\upLaTeX 在 NFSS 下使用字体编码 |JY2| 和 |JT2| 来分别
 % 表示横排与直排的日文。
 %    \begin{macrocode}
 %<rm&jy2>\DeclareKanjiFamily{JY2}{zhrm}{}
@@ -11312,7 +11312,7 @@ Copyright and Licence
 %
 % \changes{v2.4.14}{2018/05/01}{配置 \opt{macnew} 的默认字体设置。}
 % \changes{v2.5}{2019/11/05}{为 \opt{macnew} 增加粗楷体、隶书和圆体的定义。}
-% \changes{v2.5}{2019/11/07}{允许 \opt{macnew} 在 \LaTeX\ 和 \upLaTeX\ 下使用。}
+% \changes{v2.5}{2019/11/07}{允许 \opt{macnew} 在 \LaTeX{} 和 \upLaTeX{} 下使用。}
 %
 % |macold| 的设置参考了
 % \href{https://github.com/CTeX-org/ctex-kit/wiki/OS-X-Mavericks-(10.9)-预装的主要简体中文字体}^^A
@@ -11565,7 +11565,7 @@ Copyright and Licence
 % \paragraph{\opt{ubuntu}}
 %
 % \changes{v2.5}{2019/11/07}{\opt{ubuntu} 改用思源（Noto CJK）和文鼎字库，不再
-% 支持使用 \pdfLaTeX\ 编译。}
+% 支持使用 \pdfLaTeX{} 编译。}
 %
 %    \begin{macrocode}
 %<*ubuntu>
@@ -11726,7 +11726,7 @@ Copyright and Licence
 % \changes{v2.4.14}{2018/05/01}{为 \opt{macnew} 配置字体命令。}
 %
 % \begin{macro}{\songti,\heiti,\fangsong,\kaishu,\lishu,\youyuan,\yahei,\pingfang}
-% 使用 \upLaTeX\ 编译时，\opt{macnew} 字库中由于传统黑体（黑体-简）无法使用，
+% 使用 \upLaTeX{} 编译时，\opt{macnew} 字库中由于传统黑体（黑体-简）无法使用，
 % 我们用苹方来代替。同时 \tn{yahei}、\tn{pingfang} 命令被设置为与 \tn{heiti} 相同。
 %    \begin{macrocode}
 %<*!mac>
@@ -11824,7 +11824,7 @@ Copyright and Licence
 % \end{macro}
 %
 % \begin{macro}[int]{\ProvidesFile}
-% 提供非 \LaTeX\ 格式下的 \tn{ProvidesFile}。
+% 提供非 \LaTeX{} 格式下的 \tn{ProvidesFile}。
 %    \begin{macrocode}
 \begingroup
 \expandafter\ifx\csname ProvidesFile\endcsname\relax
@@ -12163,7 +12163,7 @@ Copyright and Licence
 % \changes{v2.5.2}{2020/05/05}{\file{ctexspamacro.tex} 更名为 \file{ctex-spa-macro.tex}。}
 % \changes{v2.6.0}{2026/04/30}{修复了 \TeX\ tree 字体无法制作 \file{.spa} 文件的问题。}
 %
-% 我们通过 \XeTeX\ 的 \tn{XeTeXglyphbounds} 取得字体中标点符号的边界信息，为
+% 我们通过 \XeTeX{} 的 \tn{XeTeXglyphbounds} 取得字体中标点符号的边界信息，为
 % \pkg{CJKpunct} 宏包制作 \file{spa}。
 %
 %    \begin{macrocode}
@@ -12312,7 +12312,7 @@ Copyright and Licence
 %</macro>
 %    \end{macrocode}
 %
-% 下面是 \CTeX\ 定义的一些字体。
+% 下面是 \CTeX{} 定义的一些字体。
 %    \begin{macrocode}
 %<*make>
 \input ctex-spa-macro %
@@ -12799,7 +12799,7 @@ Copyright and Licence
 % \end{macro}
 %
 % \begin{macro}[int]{\ctex_patch_cmd:Nnn}
-% 快捷方式，在补丁的时候关闭 \LaTeXiii\ 语法和设置 |@| 为字母类，补丁失败时给出警告。
+% 快捷方式，在补丁的时候关闭 \LaTeXiii{} 语法和设置 |@| 为字母类，补丁失败时给出警告。
 %    \begin{macrocode}
 \cs_new_protected:Npn \ctex_patch_cmd:Nnn #1
   {


### PR DESCRIPTION
The latter one is better.

> **Note:** I've carefully using regrex to replace _only_ the hologos `\rexpstar{}`, and \expstar{}, not other commands which will eat arguments.