### PR TITLE
doc(ctex, jiazhu, xCJK2uni, xeCJK, zhnumber): 规范 `\cs` 与 `\tn` 的用法

### DIFF
--- a/ctex/ctex.dtx
+++ b/ctex/ctex.dtx
@@ -2359,7 +2359,7 @@ Copyright and Licence
 %   \opt{indent} 选项用于设置章节标题本身的首行缩进。
 %   该选项的默认设置见表~\ref{tab:indent-default}。
 %
-%   如果 \opt{indent} 的值是以 \texttt{em}、\texttt{ex} 或 \cs{ccwd} 为单位，
+%   如果 \opt{indent} 的值是以 \texttt{em}、\texttt{ex} 或 \tn{ccwd} 为单位，
 %   那么缩进间距的大小是相对于 \opt{format} 中指定的字号大小。
 %   例如，设置 \tn{part} 标题缩进三个字、\tn{section} 标题缩进 \SI{20}{pt}：
 %   \begin{ctexexam}

--- a/jiazhu/jiazhu.dtx
+++ b/jiazhu/jiazhu.dtx
@@ -171,14 +171,14 @@ Copyright and Licence
 %
 % \begin{function}{\jiazhu}
 %   \begin{syntax}
-%     \cs{jiazhu} \oarg{键值选项} \Arg{夹注内容}
+%     \tn{jiazhu} \oarg{键值选项} \Arg{夹注内容}
 %   \end{syntax}
 %   主要用户函数，提供全部功能。
 % \end{function}
 %
 % \begin{function}{\jiazhuset}
 %   \begin{syntax}
-%     \cs{jiazhuset} \Arg{键值选项}
+%     \tn{jiazhuset} \Arg{键值选项}
 %   \end{syntax}
 %   用于统一设置 \pkg{jiazhu} 的选项，选项将在下面说明。
 % \end{function}
@@ -216,7 +216,7 @@ Copyright and Licence
 %   指定汉字的字框高与其字号的比值，是实数
 %   （也接受 \opt{ideohtratio=8/10} 这种分数写法）。
 %   默认值是~0.5。
-%   这篇用户手册在导言区通过 \cs{jiazhuset} 声明了 \opt{ideohtratio=0.8}。
+%   这篇用户手册在导言区通过 \tn{jiazhuset} 声明了 \opt{ideohtratio=0.8}。
 %   \begin{center}
 %   \footnotesize
 %   \def\textbox{\fbox{\rule[-2.4pt]{0pt}{20pt}\rule{20pt}{0pt}}}
@@ -237,7 +237,7 @@ Copyright and Licence
 %   \copy0 \copy0 \kern15pt
 %   \lower\ht4\rlap{$\leftarrow$ 横排基线，字框高 88\%}
 %   \end{center}
-%   如果你在横排文档中未经设置就直接输入 \cs{jiazhu}\marg{夹注内容}，那么
+%   如果你在横排文档中未经设置就直接输入 \tn{jiazhu}\marg{夹注内容}，那么
 %   你会惊讶\jiazhu{惊讶【形容词】，感到意外、奇怪。}地发现夹注的位置偏下。
 %   这是因为 \opt{ideohtratio=0.5} 的默认值是根据直排文档设定的值。
 %   在横排文档中，\opt{ideohtratio} 的值视具体的字体而定，

--- a/xCJK2uni/xCJK2uni.dtx
+++ b/xCJK2uni/xCJK2uni.dtx
@@ -252,7 +252,7 @@ Copyright and Licence
 %
 % \begin{function}{\useCJKencmap}
 %   \begin{syntax}
-%     \cs{useCJKencmap} \Arg{Bg5|Bg5+|GB|GBK|JIS|KS}
+%     \tn{useCJKencmap} \Arg{Bg5|Bg5+|GB|GBK|JIS|KS}
 %   \end{syntax}
 %   设置当前的编码环境。以上是 \pkg{xCJK2uni} 支持的文字编码，缺省使用 GBK。
 %   \pkg{xCJK2uni} 会在 \env{CJK} 环境内自动更新支持的编码。
@@ -260,14 +260,14 @@ Copyright and Licence
 %
 % \begin{function}[EXP]{\CJKchartouni}
 %   \begin{syntax}
-%     \cs{CJKchartouni} \Arg{单个CJK文字}
+%     \tn{CJKchartouni} \Arg{单个CJK文字}
 %   \end{syntax}
 %   将文字转换成 Unicode。例如 |\CJKchartouni{一}| 将得到 \texttt{\number\string"4E00 }。
 % \end{function}
 %
 % \begin{function}[EXP]{\CJKsfdtouni}
 %   \begin{syntax}
-%     \cs{CJKsfdtouni} \Arg{plane} \Arg{slot}
+%     \tn{CJKsfdtouni} \Arg{plane} \Arg{slot}
 %   \end{syntax}
 %   \meta{plane} 表示由 \file{.sfd} 文件定义的子字体的编号，\meta{slot} 表示在
 %   子字体中的位置，这个命令将得到该坐标位置的 Unicode。

--- a/xeCJK/xeCJK.dtx
+++ b/xeCJK/xeCJK.dtx
@@ -3321,7 +3321,7 @@ Copyright and Licence
 % \changes{v3.10.0}{2026/04/30}{移除通用 whatsit 恢复，避免
 %   \pkg{hyperref} 链接注释等 whatsit 节点导致 \texttt{CJKecglue}
 %   在错误位置插入（\#803）。配合 \cs{set@color} 定点补丁保持
-%   \cs{textcolor} 场景的正确性（\#315）。}
+%   \tn{textcolor} 场景的正确性（\#315）。}
 %    \begin{macrocode}
 \cs_new_protected:Npn \xeCJK_Boundary_and_Default:
   { \xeCJK_check_for_ecglue: }
@@ -3543,9 +3543,9 @@ Copyright and Licence
 %
 % \changes{v3.9.1}{2022/08/02}{简化部分内部实现。}
 % \changes{v3.10.0}{2022/08/31}{修复 \opt{xCJKecglue} 错误。}
-% \changes{v3.10.0}{2024/05/03}{修复 \cs{xeCJKnobreak} 错误。}
-% \changes{v3.10.0}{2026/04/27}{修复 \cs{textcolor} 等 whatsit 节点导致 \texttt{CJKecglue} 丢失的问题。}
-% \changes{v3.10.0}{2026/04/27}{修复字体切换组（如 \cs{texttt}、\cs{zihao}）导致 \texttt{CJKecglue} 使用错误字体度量的问题。}
+% \changes{v3.10.0}{2024/05/03}{修复 \tn{xeCJKnobreak} 错误。}
+% \changes{v3.10.0}{2026/04/27}{修复 \tn{textcolor} 等 whatsit 节点导致 \texttt{CJKecglue} 丢失的问题。}
+% \changes{v3.10.0}{2026/04/27}{修复字体切换组（如 \tn{texttt}、\tn{zihao}）导致 \texttt{CJKecglue} 使用错误字体度量的问题。}
 %
 % \begin{macro}[TF]{
 %   \@@_if_last_none:,
@@ -9294,7 +9294,7 @@ Copyright and Licence
 % \changes{v3.10.0}{2026/04/29}{为 \pkg{mtpro2} 提供兼容补丁，
 %   使大花括号内部的 \tn{char} 不被 interchar 拦截（\#407）。}
 %
-% \pkg{mtpro2} 的 \cs{overcbrace} 和 \cs{undercbrace} 通过
+% \pkg{mtpro2} 的 \tn{overcbrace} 和 \tn{undercbrace} 通过
 % |\char| 访问 |mt2exe| 等字体的特殊位置，其中部分位置
 % （如 183\,=\,|U+00B7|）与 \pkg{xeCJK} 的 interchar 字符分类冲突。
 % 由于这两个命令只用在数学模式中，参数不含 CJK 字符，可以在入口处
@@ -9394,7 +9394,7 @@ Copyright and Licence
 % \changes{v3.10.0}{2026/05/03}{通过在 \cs{Hy@BeginAnnot} 中保存并
 %   选择性恢复 xeCJK 节点标记，同时清除旧标记，
 %   解决目录中链接注释起始处的虚假 \texttt{ecglue}（\#810），
-%   并为 \cs{ref} 提供前侧 \texttt{ecglue}（\#809）。}
+%   并为 \tn{ref} 提供前侧 \texttt{ecglue}（\#809）。}
 %    \begin{macrocode}
 \tl_new:N \g_@@_hyper_saved_node_tl
 \cs_new_protected:Npn \@@_patch_hyperref_annot:
@@ -9430,15 +9430,15 @@ Copyright and Licence
 %    \end{macrocode}
 %
 % \changes{v3.10.0}{2026/04/30}{为 \pkg{color}/\pkg{xcolor} 添加兼容补丁，
-%   在颜色切换 whatsit 后重放 xeCJK 节点标记，修复 \cs{textcolor}
+%   在颜色切换 whatsit 后重放 xeCJK 节点标记，修复 \tn{textcolor}
 %   后 \texttt{CJKecglue} 丢失的问题（\#315, \#803）。}
 % \changes{v3.10.0}{2026/05/01}{修复 \cs{set@color} 补丁在无真实节点标记时
-%   未清除全局状态，导致首次 \cs{textcolor} 在标点或段首后插入虚假
+%   未清除全局状态，导致首次 \tn{textcolor} 在标点或段首后插入虚假
 %   \texttt{ecglue} 的问题（\#807）。}
 % \changes{v3.10.0}{2026/05/02}{使用 \cs{l_keys_key_str} 和
 %   \cs{l_keys_choice_str} 替代已废弃的 \texttt{\_tl} 版本（\#806）。}
 %
-% \pkg{color}/\pkg{xcolor} 的颜色切换通过 \cs{set@color} 插入 \cs{special}
+% \pkg{color}/\pkg{xcolor} 的颜色切换通过 \cs{set@color} 插入 \tn{special}
 % 节点（whatsit），会遮蔽 xeCJK 的标记 kern，导致后续的 \texttt{CJKecglue}
 % 检测失败。此处在 \cs{set@color} 之后重新放置 xeCJK 节点标记。
 %    \begin{macrocode}
@@ -11361,7 +11361,7 @@ Copyright and Licence
 % 活动字符。
 %
 % 当 \tn{lstinline} 出现在宏参数中时，\TeX{} 参数传递将 |#| 双写为 |##|
-% （catcode 6 parameter token）。\cs{tl_set_rescan:Nnn} 底层的 \cs{scantokens}
+% （catcode 6 parameter token）。\cs{tl_set_rescan:Nnn} 底层的 \tn{scantokens}
 % 在字符串化阶段会再次将 catcode~6 的 |#| 双写，导致输出中 |#| 数量翻倍。
 % 修复方法是在 rescan 前用 \cs{regex_replace_all:nnN} 将 catcode~6 的 |#|
 % 替换为 active |#|（catcode 13），这是 \pkg{listings} 期望的字符类型。

--- a/zhnumber/zhnumber.dtx
+++ b/zhnumber/zhnumber.dtx
@@ -1467,7 +1467,7 @@ Copyright and Licence
     }
 %    \end{macrocode}
 % \pkg{expl3} 2023-12-14 起，\cs{tl_build_get:NN} 是废弃命令。当 \pkg{l3debug}
-% 的 \texttt{deprecation} 开启，废弃命令被重定义为 \cs{outer} 的，无法在其他命令
+% 的 \texttt{deprecation} 开启，废弃命令被重定义为 \tn{outer} 的，无法在其他命令
 % 的参数中使用，所以这里用 \cs{use:c} 绕过。
 %    \begin{macrocode}
   \cs_if_exist:NTF \tl_build_get_intermediate:NN


### PR DESCRIPTION
In p.5 of [l3doc.pdf](https://mirrors.ctan.org/macros/latex/required/l3kernel/l3doc.pdf#page5):

> Analogous to `\cs` but intended for "traditional" TeX or LaTeX2e commands; _they are indexed accordingly_. This is in fact equivalent to `\cs [module=TeX, replace=false, ⟨options⟩] {⟨csname⟩}`.

此准则对 "套用" `l3doc` 的 `ctxdoc` 同样生效.

对 L2e 命令使用 `\cs` 可能导致它们被归类到不正确的索引等规范问题, 如在 `ctex.dtx` 里面有 1 处 `\cs{ttwd}` 和 18 处 `\tn{ccwd}`.