### PR TITLE
test(ctex): 更新 thuthesis/pkuthss 回归测试参考文件

### DIFF
--- a/ctex/test/testfiles-contrib/pkuthss.tlg
+++ b/ctex/test/testfiles-contrib/pkuthss.tlg
@@ -2084,9 +2084,10 @@ Completed box being shipped out [3]
 ...........\rule(14.06366+6.02736)x0.0
 ........\penalty 10000
 ........\hbox(0.0+0.0)x0.0
-.........\hbox(0.0+0.0)x0.0, shifted -23.09103
+.........\hbox(0.0+0.0)x0.0, shifted -20.09103
 ..........\special{pdf:dest (equation.2.1) [@thispage /XYZ @xpos @ypos null]}
 ..........\penalty 10000
+........\kern 0.0
 ........\hbox(8.14243+2.13194)x23.07822
 .........\TU/XITS(0)/m/n/12.045 (2.1
 .........\kern -0.0002
@@ -2152,9 +2153,10 @@ Completed box being shipped out [3]
 ...........\rule(14.06366+6.02736)x0.0
 ........\penalty 10000
 ........\hbox(0.0+0.0)x0.0
-.........\hbox(0.0+0.0)x0.0, shifted -23.09103
+.........\hbox(0.0+0.0)x0.0, shifted -20.09103
 ..........\special{pdf:dest (equation.2.2) [@thispage /XYZ @xpos @ypos null]}
 ..........\penalty 10000
+........\kern 0.0
 ........\hbox(8.14243+2.13194)x23.07822
 .........\TU/XITS(0)/m/n/12.045 (2.2
 .........\kern -0.0002
@@ -2216,9 +2218,10 @@ Completed box being shipped out [3]
 ...........\rule(14.06366+6.02736)x0.0
 ........\penalty 10000
 ........\hbox(0.0+0.0)x0.0
-.........\hbox(0.0+0.0)x0.0, shifted -23.09103
+.........\hbox(0.0+0.0)x0.0, shifted -20.09103
 ..........\special{pdf:dest (equation.2.3) [@thispage /XYZ @xpos @ypos null]}
 ..........\penalty 10000
+........\kern 0.0
 ........\hbox(8.14243+2.13194)x23.07822
 .........\TU/XITS(0)/m/n/12.045 (2.3
 .........\kern -0.0002

--- a/ctex/test/testfiles-contrib/pkuthss.tlg
+++ b/ctex/test/testfiles-contrib/pkuthss.tlg
@@ -2084,10 +2084,9 @@ Completed box being shipped out [3]
 ...........\rule(14.06366+6.02736)x0.0
 ........\penalty 10000
 ........\hbox(0.0+0.0)x0.0
-.........\hbox(0.0+0.0)x0.0, shifted -20.09103
+.........\hbox(0.0+0.0)x0.0, shifted -23.09103
 ..........\special{pdf:dest (equation.2.1) [@thispage /XYZ @xpos @ypos null]}
 ..........\penalty 10000
-........\kern 0.0
 ........\hbox(8.14243+2.13194)x23.07822
 .........\TU/XITS(0)/m/n/12.045 (2.1
 .........\kern -0.0002
@@ -2153,10 +2152,9 @@ Completed box being shipped out [3]
 ...........\rule(14.06366+6.02736)x0.0
 ........\penalty 10000
 ........\hbox(0.0+0.0)x0.0
-.........\hbox(0.0+0.0)x0.0, shifted -20.09103
+.........\hbox(0.0+0.0)x0.0, shifted -23.09103
 ..........\special{pdf:dest (equation.2.2) [@thispage /XYZ @xpos @ypos null]}
 ..........\penalty 10000
-........\kern 0.0
 ........\hbox(8.14243+2.13194)x23.07822
 .........\TU/XITS(0)/m/n/12.045 (2.2
 .........\kern -0.0002
@@ -2218,10 +2216,9 @@ Completed box being shipped out [3]
 ...........\rule(14.06366+6.02736)x0.0
 ........\penalty 10000
 ........\hbox(0.0+0.0)x0.0
-.........\hbox(0.0+0.0)x0.0, shifted -20.09103
+.........\hbox(0.0+0.0)x0.0, shifted -23.09103
 ..........\special{pdf:dest (equation.2.3) [@thispage /XYZ @xpos @ypos null]}
 ..........\penalty 10000
-........\kern 0.0
 ........\hbox(8.14243+2.13194)x23.07822
 .........\TU/XITS(0)/m/n/12.045 (2.3
 .........\kern -0.0002

--- a/ctex/test/testfiles-contrib/thuthesis.tlg
+++ b/ctex/test/testfiles-contrib/thuthesis.tlg
@@ -1831,16 +1831,17 @@ Completed box being shipped out [2]
 ....\hbox(14.05243+6.02255)x0.00002
 .....\kern -160.2767
 .....\kern 160.27672
-.....\hbox(14.05243+6.02255)x0.0, glue set - 31.5097fil
+.....\hbox(14.05243+6.02255)x0.0, glue set - 39.14624fil
 ......\glue 0.0 plus 1.0fil minus 1.0fil
-......\hbox(14.05243+6.02255)x31.5097
+......\hbox(14.05243+6.02255)x39.14624
 .......\hbox(14.05243+6.02255)x0.0
 ........\vbox(14.05243+6.02255)x0.0
 .........\kern 0.0
 .........\hbox(14.05243+6.02255)x0.0
 ..........\rule(14.05243+6.02255)x0.0
-.......\hbox(9.636+2.40898)x31.5097
-........\glue 0.0
+.......\hbox(9.636+2.40898)x39.14624
+........\kern 0.0
+........\glue 7.63654 minus 6.0225
 ........\rule(0.0+0.0)x-7.63654
 ........\TU/FandolSong(0)/m/n/12.045 （
 ........\kern 0.00009
@@ -1908,16 +1909,17 @@ Completed box being shipped out [2]
 ....\hbox(14.05243+6.02255)x0.00002
 .....\kern -160.2767
 .....\kern 160.27672
-.....\hbox(14.05243+6.02255)x0.0, glue set - 31.5097fil
+.....\hbox(14.05243+6.02255)x0.0, glue set - 39.14624fil
 ......\glue 0.0 plus 1.0fil minus 1.0fil
-......\hbox(14.05243+6.02255)x31.5097
+......\hbox(14.05243+6.02255)x39.14624
 .......\hbox(14.05243+6.02255)x0.0
 ........\vbox(14.05243+6.02255)x0.0
 .........\kern 0.0
 .........\hbox(14.05243+6.02255)x0.0
 ..........\rule(14.05243+6.02255)x0.0
-.......\hbox(9.636+2.40898)x31.5097
-........\glue 0.0
+.......\hbox(9.636+2.40898)x39.14624
+........\kern 0.0
+........\glue 7.63654 minus 6.0225
 ........\rule(0.0+0.0)x-7.63654
 ........\TU/FandolSong(0)/m/n/12.045 （
 ........\kern 0.00009
@@ -1981,16 +1983,17 @@ Completed box being shipped out [2]
 ....\hbox(14.05243+6.02255)x0.00002
 .....\kern -160.2767
 .....\kern 160.27672
-.....\hbox(14.05243+6.02255)x0.0, glue set - 31.5097fil
+.....\hbox(14.05243+6.02255)x0.0, glue set - 39.14624fil
 ......\glue 0.0 plus 1.0fil minus 1.0fil
-......\hbox(14.05243+6.02255)x31.5097
+......\hbox(14.05243+6.02255)x39.14624
 .......\hbox(14.05243+6.02255)x0.0
 ........\vbox(14.05243+6.02255)x0.0
 .........\kern 0.0
 .........\hbox(14.05243+6.02255)x0.0
 ..........\rule(14.05243+6.02255)x0.0
-.......\hbox(9.636+2.40898)x31.5097
-........\glue 0.0
+.......\hbox(9.636+2.40898)x39.14624
+........\kern 0.0
+........\glue 7.63654 minus 6.0225
 ........\rule(0.0+0.0)x-7.63654
 ........\TU/FandolSong(0)/m/n/12.045 （
 ........\kern 0.00009
@@ -2081,7 +2084,7 @@ Completed box being shipped out [2]
 No file bu.aux.
 No file bu.aux.
 Completed box being shipped out [3]
-\vbox(710.18088+0.0)x439.87962
+\vbox(710.18088+4.1104)x439.87962
 .\hbox(0.0+0.0)x0.0
 ..\kern -72.26999
 ..\vbox(0.0+0.0)x0.0, glue set 72.26999fil
@@ -2093,16 +2096,57 @@ Completed box being shipped out [3]
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\glue 0.0 plus 1.0fil minus 1.0fil
 .\glue -72.26997
-.\vbox(782.45085+0.0)x426.79135, shifted 13.08827
-..\vbox(76.82234+0.0)x426.79135, glue set 76.82234fil
+.\vbox(782.45085+4.1104)x426.79135, shifted 13.08827
+..\vbox(76.82234+0.0)x426.79135, glue set 63.12115fil
 ...\glue 0.0 plus 1.0fil
-...\hbox(0.0+0.0)x426.79135
+...\hbox(13.70119+0.0)x426.79135
 ....\special{color push gray 0}
-....\hbox(0.0+0.0)x426.79135
+....\hbox(13.70119+0.0)x426.79135
+.....\hbox(13.70119+0.0)x426.79135
+......\vbox(13.70119+0.0)x426.79135
+.......\hbox(9.59079+4.1104)x426.79135
+........\hbox(0.0+0.0)x0.0, glue set - 426.79135fil
+.........\vbox(0.0+0.0)x426.79135
+..........\hbox(0.0+0.0)x426.79135, glue set 213.39568fil
+...........\hbox(0.0+0.0)x0.0
+...........\penalty 10000
+...........\glue(\parfillskip) 0.0 plus 1.0fil
+...........\glue(\rightskip) 0.0 plus 1.0fil
+.........\glue 0.0 plus 1.0fil minus 1.0fil
+........\glue 0.0 plus 1.0fill
+........\vbox(9.59079+4.1104)x426.79135
+.........\hbox(9.59079+4.1104)x426.79135, glue set 197.58662fil
+..........\glue(\leftskip) 0.0 plus 1.0fil
+..........\hbox(0.0+0.0)x0.0
+..........\TU/FandolSong(0)/m/n/10.53937 声
+..........\kern -0.00017
+..........\kern 0.00017
+..........\glue 10.53937
+..........\TU/FandolSong(0)/m/n/10.53937 明
+..........\kern -0.00017
+..........\kern 0.00017
+..........\rule(9.59079+4.1104)x0.0
+..........\penalty 10000
+..........\glue(\parfillskip) 0.0
+..........\glue(\rightskip) 0.0 plus 1.0fil
+........\glue 0.0 plus 1.0fill
+........\hbox(0.0+0.0)x0.0, glue set - 426.79135fil
+.........\glue 0.0 plus 1.0fil minus 1.0fil
+.........\vbox(0.0+0.0)x426.79135
+..........\hbox(0.0+0.0)x426.79135, glue set 426.79135fil
+...........\glue(\leftskip) 0.0 plus 1.0fil
+...........\hbox(0.0+0.0)x0.0
+...........\penalty 10000
+...........\glue(\parfillskip) 0.0
+...........\glue(\rightskip) 0.0
+.......\glue 0.0
+.......\rule(0.7528+0.0)x426.79135
+.......\glue -0.7528
+.....\glue 0.0 plus 1.0fil minus 1.0fil
 ....\special{color pop}
 ..\glue 8.5359
 ..\glue(\lineskip) 0.0
-..\vbox(674.33032+0.0)x426.79135, glue set 422.64514fil
+..\vbox(674.33032+0.0)x426.79135, glue set 422.14334fil
 ...\write-{}
 ...\write1{\ttl@writefile{toc}{\protect \setcounter {tocdepth}{0}}}
 ...\write-{}
@@ -2135,308 +2179,308 @@ Completed box being shipped out [3]
 ...\penalty 10000
 ...\marks3{\__mark_value:nn {16}{声\protect \hspace  {1em}明}}
 ...\penalty 10000
-...\glue 12.045
+...\glue 13.04874
 ...\glue 0.0
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
-...\hbox(9.45532+2.32468)x426.79135, glue set 0.34389
+...\hbox(9.45532+2.32468)x426.79135, glue set 0.29224
 ....\hbox(0.0+0.0)x24.09
 ....\TU/FandolSong(0)/m/n/12.045 本
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 人
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 郑
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 重
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 声
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 明
 ....\penalty 10000
 ....\TU/FandolSong(0)/m/n/12.045 ：
 ....\rule(0.0+0.0)x-8.39537
 ....\glue 8.39537 minus 6.0225
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 所
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 呈
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 交
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 的
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 学
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 位
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 论
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 文
 ....\penalty 10000
 ....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 是
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 本
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 人
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 在
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 导
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 师
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 指
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 导
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 下
 ....\penalty 10000
 ....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 独
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 立
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 进
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 行
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 研
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 究
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 工
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 9.2867
-...\hbox(9.46736+2.32468)x426.79135, glue set 0.3217
+...\hbox(9.46736+2.32468)x426.79135, glue set 0.17662
 ....\TU/FandolSong(0)/m/n/12.045 作
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 所
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 取
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 得
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 的
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 成
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 果
 ....\penalty 10000
 ....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 不
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 包
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 含
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 涉
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 及
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 国
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 家
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 秘
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 密
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 的
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 内
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 容
 ....\penalty 10000
 ....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 尽
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 我
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 所
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 知
 ....\penalty 10000
 ....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 除
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 文
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 中
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 已
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 经
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 注
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 明
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 引
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 9.34691
-...\hbox(9.40715+2.32468)x426.79135, glue set 0.31165
+...\hbox(9.40715+2.32468)x426.79135, glue set 0.12424
 ....\TU/FandolSong(0)/m/n/12.045 的
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 内
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 容
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 外
 ....\penalty 10000
 ....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 本
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 学
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 位
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 论
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 文
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 的
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 研
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 究
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 成
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 果
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 不
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 包
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 含
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 任
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 何
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 他
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 人
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 享
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 有
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 著
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 作
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 权
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 的
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 内
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 容
 ....\penalty 10000
 ....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 对
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 本
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 论
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 文
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 9.35896
-...\hbox(9.3951+2.32468)x426.79135, glue set 25.01839fil
+...\hbox(9.3951+2.32468)x426.79135, glue set 20.35155fil
 ....\TU/FandolSong(0)/m/n/12.045 所
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 涉
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 及
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 的
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 研
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 究
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 工
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 作
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 做
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 出
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 贡
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 献
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 的
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 其
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 他
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 个
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 人
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 和
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 集
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 体
 ....\penalty 10000
 ....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 均
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 已
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 在
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 文
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 中
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 以
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 明
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 确
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 方
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 式
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 标
-....\glue 0.0 plus 0.52307
+....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 明
 ....\penalty 10000
 ....\TU/FandolSong(0)/m/n/12.045 。
@@ -2448,13 +2492,13 @@ Completed box being shipped out [3]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\glue 79.29625
+...\glue 78.79437
 ...\glue 0.0
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 5.6431
-...\hbox(10.09972+4.30565)x426.79135, glue set 24.67003fil
-....\glue 153.6447
+...\hbox(10.09972+4.30565)x426.79135, glue set 24.80835fil
+....\glue 154.07562
 ....\TU/FandolSong(0)/m/n/13.04874 签
 ....\kern -0.00017
 ....\kern 0.00017
@@ -2470,16 +2514,16 @@ Completed box being shipped out [3]
 ....\glue 9.09497 minus 6.52437
 ....\glue 1.0
 ....\mathon
-....\vbox(0.0+4.30565)x79.6678
-.....\hbox(0.0+0.0)x79.6678
-......\hbox(0.0+0.0)x79.6678, glue set 39.83391fil
+....\vbox(0.0+4.30565)x76.28499
+.....\hbox(0.0+0.0)x76.28499
+......\hbox(0.0+0.0)x76.28499, glue set 38.1425fil
 .......\glue 0.0 plus 1.0fil minus 1.0fil
 .......\glue 0.0 plus 1.0fil minus 1.0fil
 .....\kern2.58339
 .....\rule(0.86113+0.0)x*
 ....\mathoff
 ....\glue 3.0
-....\glue -6.02249
+....\glue -3.01125
 ....\TU/FandolSong(0)/m/n/13.04874 日
 ....\kern -0.00017
 ....\kern 0.00017
@@ -2495,9 +2539,9 @@ Completed box being shipped out [3]
 ....\glue 9.09497 minus 6.52437
 ....\glue 1.0
 ....\mathon
-....\vbox(0.0+4.30565)x65.44142
-.....\hbox(0.0+0.0)x65.44142
-......\hbox(0.0+0.0)x65.44142, glue set 32.72072fil
+....\vbox(0.0+4.30565)x65.24374
+.....\hbox(0.0+0.0)x65.24374
+......\hbox(0.0+0.0)x65.24374, glue set 32.62187fil
 .......\glue 0.0 plus 1.0fil minus 1.0fil
 .......\glue 0.0 plus 1.0fil minus 1.0fil
 .....\kern2.58339
@@ -2518,12 +2562,48 @@ Completed box being shipped out [3]
 ...\glue 0.0 plus 1.0fil
 ...\glue 0.0
 ...\glue 0.0 plus 0.0001fil
-..\glue(\baselineskip) 22.76228
-..\hbox(0.0+0.0)x426.79135
+..\glue(\baselineskip) 7.14894
+..\hbox(15.61334+4.1104)x426.79135
 ...\special{color push gray 0}
-...\hbox(0.0+0.0)x426.79135
+...\hbox(15.61334+4.1104)x426.79135
+....\hbox(15.61334+4.1104)x426.79135
+.....\vbox(15.61334+4.1104)x426.79135
+......\rule(0.0+0.0)x426.79135
+......\glue 6.02255
+......\hbox(9.59079+4.1104)x426.79135
+.......\hbox(0.0+0.0)x0.0, glue set - 426.79135fil
+........\vbox(0.0+0.0)x426.79135
+.........\hbox(0.0+0.0)x426.79135, glue set 213.39568fil
+..........\hbox(0.0+0.0)x0.0
+..........\penalty 10000
+..........\glue(\parfillskip) 0.0 plus 1.0fil
+..........\glue(\rightskip) 0.0 plus 1.0fil
+........\glue 0.0 plus 1.0fil minus 1.0fil
+.......\glue 0.0 plus 1.0fill
+.......\vbox(9.59079+4.1104)x426.79135
+........\hbox(9.59079+4.1104)x426.79135, glue set 210.76083fil
+.........\glue(\leftskip) 0.0 plus 1.0fil
+.........\hbox(0.0+0.0)x0.0
+.........\TU/texgyretermes(0)/m/n/10.53937 3
+.........\kern -0.0002
+.........\kern 0.0002
+.........\rule(9.59079+4.1104)x0.0
+.........\penalty 10000
+.........\glue(\parfillskip) 0.0
+.........\glue(\rightskip) 0.0 plus 1.0fil
+.......\glue 0.0 plus 1.0fill
+.......\hbox(0.0+0.0)x0.0, glue set - 426.79135fil
+........\glue 0.0 plus 1.0fil minus 1.0fil
+........\vbox(0.0+0.0)x426.79135
+.........\hbox(0.0+0.0)x426.79135, glue set 426.79135fil
+..........\glue(\leftskip) 0.0 plus 1.0fil
+..........\hbox(0.0+0.0)x0.0
+..........\penalty 10000
+..........\glue(\parfillskip) 0.0
+..........\glue(\rightskip) 0.0
+....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{color pop}
-.\kern -710.18088
+.\kern -714.29128
 .\hbox(0.0+0.0)x0.0
 ..\kern -72.26999
 ..\vbox(0.0+0.0)x0.0, glue set 72.26999fil
@@ -2534,7 +2614,7 @@ Completed box being shipped out [3]
 .....\glue 0.0 plus 1.0fil minus 1.0fil
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\glue 0.0 plus 1.0fil minus 1.0fil
-.\kern 710.18088
+.\kern 714.29128
 .\kern 0.0
 附录 A
 Completed box being shipped out [4]


### PR DESCRIPTION
## Summary

- thuthesis v7.7.0 (2026-05-10 CTAN) 更新了 `\statement` 页面的页眉行为（空页眉 → 显示「声明」），导致 `thuthesis.tlg` 不匹配
- 同时更新 `pkuthss.tlg` 以匹配上游公式编号位移变化（`shifted -20.09103` → `-23.09103`，`\kern 0.0` 移除）
- 两者均为上游包更新导致的参考文件过期，ctex-kit 代码无变化

## Test plan

- [x] `l3build check -c test/config-contrib` 本地通过
- [x] `l3build check -c test/config-ctxdoc` 本地通过
- [x] `l3build check -c test/config-cmap` 本地通过
- [ ] CI 三平台通过