### PR TITLE
chore(zhlineskip): 添加到 `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,11 +181,20 @@ zhmetrics/zhmCJK-test.pdf
 zhmetrics/zhmCJK-test.tex
 
 # zhmetrics-uptex
+
 zhmetrics-uptex/*.tfm
 zhmetrics-uptex/*.vf
 zhmetrics-uptex/*.pdf
 zhmetrics-uptex/ctan/*
 zhmetrics-uptex/tds/*
+
+# zhlineskip
+
+zhlineskip/build/**/*.*
+!zhlineskip/build/**/*.diff
+!zhlineskip/build/**/*.fc
+zhlineskip/zhlineskip-test.pdf
+zhlineskip/zhlineskip.pdf
 
 # zhnumber
 


### PR DESCRIPTION
否则一 l3build unpack 后 `./build/unpacked` 里的全出来了.