### PR TITLE
fix(xeCJK, xpinyin): 修复 socket.http 加载失败导致 l3build install 报错 (#829)

### DIFF
--- a/xeCJK/build.lua
+++ b/xeCJK/build.lua
@@ -24,11 +24,29 @@ tdslocations = {
   "fonts/misc/xetex/fontmapping/xecjk/*.tec",
 }
 
-if install_files_bool then
-  local http_request = require("socket.http").request
-end
-local ltn12_sink_file = require("ltn12").sink.file
 local zip_open = require("zip").open
+
+local function download_file(url, dest)
+  local ok, http = pcall(require, "socket.http")
+  if ok then
+    local lok, ltn12 = pcall(require, "ltn12")
+    if lok then
+      local fh = io.open(dest, "wb")
+      if fh then
+        local status = http.request{
+          url  = url,
+          sink = ltn12.sink.file(fh)
+        }
+        if status then return true end
+      end
+    end
+  end
+  local ret = os.execute('curl -fsSL -o "' .. dest .. '" "' .. url .. '"')
+  if ret == 0 or ret == true then return true end
+  ret = os.execute('wget -q -O "' .. dest .. '" "' .. url .. '"')
+  if ret == 0 or ret == true then return true end
+  return false
+end
 
 local function make_teckit_mapping()
   local unihan_variants = "Unihan_Variants.txt"
@@ -37,11 +55,15 @@ local function make_teckit_mapping()
     local unihan_zip = supportdir .. "/Unihan.zip"
     local zfile = zip_open(unihan_zip)
     if not zfile then
-      local status, err = http_request{
-        url  = "http://www.unicode.org/Public/UNIDATA/Unihan.zip",
-        sink = ltn12_sink_file(io.open(unihan_zip, "wb")) }
-      if not status then
-        error([[Download "]] .. "Unihan.zip" .. [[" failed because of ]] .. err .. ".")
+      if not download_file(
+        "https://www.unicode.org/Public/UNIDATA/Unihan.zip", unihan_zip)
+      then
+        error(
+          'Failed to download Unihan.zip. Try one of:\n'
+          .. '  - Run: texlua --socket "$(kpsewhich l3build.lua)" install\n'
+          .. '  - Install curl or wget\n'
+          .. '  - Manually place Unihan.zip in ' .. supportdir .. '/'
+        )
       end
       zfile = assert(zip_open(unihan_zip))
     end

--- a/xpinyin/xpinyin.dtx
+++ b/xpinyin/xpinyin.dtx
@@ -1231,7 +1231,7 @@ xpinyin = {
 %
 %    \begin{macrocode}
   database = {
-    source  = "http://www.unicode.org/Public/UNIDATA/Unihan.zip",
+    source  = "https://www.unicode.org/Public/UNIDATA/Unihan.zip",
     file    = "Unihan_Readings.txt",
     date    = "Date: 2014-05-09 18:17:02 GMT [JHJ]",
     version = "Unicode version: 7.0.0",
@@ -1255,8 +1255,6 @@ xpinyin = {
 %    \end{macrocode}
 %
 %    \begin{macrocode}
-local http_request = require("socket.http").request
-local ltn12_sink_file = require("ltn12").sink.file
 local zip_open = require("zip").open
 %    \end{macrocode}
 %
@@ -1306,12 +1304,30 @@ end
 %    \begin{macrocode}
 function xpinyin.download (source, zip)
   print("\nRetrieving Unihan Database from\n", source)
-  local status, err = http_request{
-    url  = source,
-    sink = ltn12_sink_file(io.open(zip, "wb")) }
-  if not status then
-    error([[Download ']] .. zip .. [[' failed because of ]] .. err .. ".")
+  local ok, http = pcall(require, "socket.http")
+  if ok then
+    local lok, ltn12 = pcall(require, "ltn12")
+    if lok then
+      local fh = io.open(zip, "wb")
+      if fh then
+        local status = http.request{
+          url  = source,
+          sink = ltn12.sink.file(fh)
+        }
+        if status then return end
+      end
+    end
   end
+  local ret = os.execute('curl -fsSL -o "' .. zip .. '" "' .. source .. '"')
+  if ret == 0 or ret == true then return end
+  ret = os.execute('wget -q -O "' .. zip .. '" "' .. source .. '"')
+  if ret == 0 or ret == true then return end
+  error(
+    "Failed to download '" .. zip .. "'. Try one of:\n"
+    .. '  - Run: texlua --socket xpinyin.lua\n'
+    .. '  - Install curl or wget\n'
+    .. "  - Manually place " .. zip .. " in the current directory"
+  )
 end
 %    \end{macrocode}
 %


### PR DESCRIPTION
## Summary

- 修复 `xeCJK/build.lua` 中 `socket.http` 加载的两个 bug：
  1. **时序问题**：`require("socket.http")` 在 `if install_files_bool` 块内，但 `install_files_bool` 在 `build-config.lua`（文件末尾 `dofile`）中才被设为 `true`，加载阶段始终为 `nil`
  2. **作用域问题**：`local http_request` 声明在 `if` 块内，块结束后出作用域，`make_teckit_mapping()` 引用的全局 `http_request` 始终为 `nil`
- 适配 LuaTeX 1.17+ 默认禁用 `socket` 库的限制：改为 `pcall(require, "socket.http")` 惰性加载
- 新增 curl/wget fallback：`socket.http` 不可用时自动尝试系统下载工具
- 同步修复 `xpinyin/xpinyin.dtx` 中的同类问题（顶层 `require` 在 1.17+ 直接失败）
- URL 从 http 升级为 https

Closes #829

## Test plan

- [x] xeCJK 76/76 回归测试通过
- [ ] CI 全平台验证
- [ ] 手动验证 `l3build install`（需要 `teckit_compile` 和网络环境）