### PR TITLE
refactor(xeCJK, zhnumber, ctex): 使用 e-type variant 代替 x-type (#679)

### DIFF
--- a/ctex/ctex.dtx
+++ b/ctex/ctex.dtx
@@ -589,7 +589,7 @@ Copyright and Licence
 % \changes{v2.4.15}{2019/03/23}{同步 \LaTeXiii{} 2019/03/05。}
 % \changes{v2.5.1}{2020/05/02}{\pkg{zhconv} 更名为 \pkg{ctex-zhconv}。}
 %
-% \CheckSum{6926}
+% \CheckSum{6924}
 %
 % \CharacterTable
 %  {Upper-case    \A\B\C\D\E\F\G\H\I\J\K\L\M\N\O\P\Q\R\S\T\U\V\W\X\Y\Z
@@ -3513,17 +3513,17 @@ Copyright and Licence
 % \begin{variable}{\c_@@_engine_str,\c_@@_engine_file_str}
 % 引擎检查。目前 \LaTeXiii{} 将 \ApTeX{} 识别为 \upTeX。
 %    \begin{macrocode}
-\str_const:Nx \c_@@_engine_str
+\str_const:Ne \c_@@_engine_str
   { \cs_if_exist:NTF \ngostype { aptex } { \c_sys_engine_str } }
 \msg_new:nnnn { ctex } { engine-not-supported }
   { Engine~`#1'~is~not~yet~supported,~ctex~will~abort! }
   { You~can~switch~to~xelatex,~lualatex,~pdflatex,~uplatex,~or~aplatex. }
 \file_if_exist:nTF { ctex-engine- \c_@@_engine_str .def }
   {
-    \str_const:Nx \c_@@_engine_file_str
+    \str_const:Ne \c_@@_engine_file_str
       { ctex-engine- \c_@@_engine_str .def }
   }
-  { \msg_critical:nnx { ctex } { engine-not-supported } { \c_@@_engine_str } }
+  { \msg_critical:nne { ctex } { engine-not-supported } { \c_@@_engine_str } }
 %    \end{macrocode}
 % \end{variable}
 %
@@ -3681,7 +3681,7 @@ Copyright and Licence
 % 若参数 |#2| 带长度单位，则设置它为 |tl| 变量 |#1| 的值，否则以 \tn{ccwd} 为单位。
 %    \begin{macrocode}
 \cs_new_protected:Npn \ctex_set_default_ccwd:Nn #1#2
-  { \tl_set:Nx #1 { \@@_default_ccwd_aux:n {#2} } }
+  { \tl_set:Ne #1 { \@@_default_ccwd_aux:n {#2} } }
 \cs_new:Npn \@@_default_ccwd_aux:n #1
   {
     \exp_not:n {#1}
@@ -3780,7 +3780,7 @@ Copyright and Licence
   }
 \cs_new_protected:Npn \ctex_deprecated_command:Nn #1#2
   {
-    \msg_warning:nnxx { ctex } { deprecated-command }
+    \msg_warning:nnee { ctex } { deprecated-command }
       { \token_to_str:N #1 } { \exp_not:n {#2} }
   }
 \msg_new:nnn { ctex } { deprecated-option }
@@ -4301,7 +4301,7 @@ Copyright and Licence
 %     \begin{macrocode}
 %<*pdftex|uptex|aptex>
 \cs_new_protected:Npn \ctex_set_zhmap:n
-  { \tl_gput_right:Nx \g_@@_zhmap_tl }
+  { \tl_gput_right:Ne \g_@@_zhmap_tl }
 \cs_new_protected:Npn \ctex_use_zhmap:
   { \tl_use:N \g_@@_zhmap_tl }
 \cs_if_exist:NTF \ctex_gadd_ltxhook:nn
@@ -4382,7 +4382,7 @@ Copyright and Licence
     \exp_args:Ne \file_get_full_name:nNTF
       { \str_lowercase:n {#2} .cmap } \l_@@_cmap_file_tl
       {
-        \pdf_object_unnamed_write:nx
+        \pdf_object_unnamed_write:ne
           { fstream }
           { { } { \l_@@_cmap_file_tl } }
         \cs_new_protected:Npx #1
@@ -4500,10 +4500,10 @@ Copyright and Licence
         \int_set:Nn \l_@@_tmp_int
           { \exp_args:Ne \int_from_hex:n {#2} }
         \int_compare:nNnTF \l_@@_tmp_int < { 256 }
-          { \tl_gset:Nx #1 { \int_to_Hex:n { \l_@@_tmp_int } } }
+          { \tl_gset:Ne #1 { \int_to_Hex:n { \l_@@_tmp_int } } }
           {
             \int_sub:Nn \l_@@_tmp_int { 256 }
-            \tl_gset:Nx #1
+            \tl_gset:Ne #1
               {
                 \int_to_Hex:n
                   { \int_div_truncate:nn { \l_@@_tmp_int } { 4 } + "D800 }
@@ -4971,7 +4971,7 @@ Copyright and Licence
     Loading~file~`#1'~will~abort!
   }
 \@ifpackageloaded { luatexja }
-  { \msg_critical:nnx { ctex } { luatexja-loaded } { \g_file_curr_name_str } }
+  { \msg_critical:nne { ctex } { luatexja-loaded } { \g_file_curr_name_str } }
   {
     \ctex_at_begin_package:nn { luatexja }
       { \msg_redirect_name:nnn { ctexhook } { disable-package } { info } }
@@ -5393,7 +5393,7 @@ Copyright and Licence
 \cs_new_protected:Npn \@@_push_fontname:n #1
   {
     \seq_gpush:No \g_@@_fontname_seq { \font@name }
-    \tl_gset:Nx \font@name { \exp_not:c {#1} }
+    \tl_gset:Ne \font@name { \exp_not:c {#1} }
   }
 \cs_new_protected:Npn \@@_pop_fontname:
   {
@@ -5455,7 +5455,7 @@ Copyright and Licence
     \get@external@font
     \ctex_ltj_if_alternate_shape_exist:nT { \curr@fontshape }
       {
-        \tl_set:Nx \external@font
+        \tl_set:Ne \external@font
           { \exp_after:wN \@@_patch_external_font:w \external@font }
       }
     \exp_after:wN \globaljfont \font@name \external@font \scan_stop:
@@ -5637,13 +5637,13 @@ Copyright and Licence
 \cs_set_eq:NN \getanddefine@fonts \ctex_ltj_get_and_define_fonts:nN
 \cs_new_protected:Npn \ctex_ltj_get_and_define_fonts_ja:nN #1#2
   {
-    \tl_gset:Nx \font@name { \use:c { \token_to_str:N #2 / \tf@size } }
+    \tl_gset:Ne \font@name { \use:c { \token_to_str:N #2 / \tf@size } }
     \ctex_ltj_pickup_font: \tl_set_eq:NN \textfont@name \font@name
-    \tl_gset:Nx \font@name { \use:c { \token_to_str:N #2 / \sf@size } }
+    \tl_gset:Ne \font@name { \use:c { \token_to_str:N #2 / \sf@size } }
     \ctex_ltj_pickup_font: \tl_set_eq:NN \scriptfont@name \font@name
-    \tl_gset:Nx \font@name { \use:c { \token_to_str:N #2 / \ssf@size } }
+    \tl_gset:Ne \font@name { \use:c { \token_to_str:N #2 / \ssf@size } }
     \ctex_ltj_pickup_font:
-    \tl_put_right:Nx \math@fonts
+    \tl_put_right:Ne \math@fonts
       {
         \ltj@setpar@global
         \ltj@@@@set@stackfont #1 , \textfont@name   \c_colon_str { MJT }
@@ -5822,7 +5822,7 @@ Copyright and Licence
 \cs_new_protected:Npn \@@_use_global_options:N #1
   {
     \clist_concat:NNN #1 \g_@@_default_features_clist #1
-    \clist_put_left:Nx #1
+    \clist_put_left:Ne #1
       { NFSSEncoding = \CJK@encoding , JFM = \l_@@_jfm_tl }
   }
 %    \end{macrocode}
@@ -5854,7 +5854,7 @@ Copyright and Licence
             \cs_undefine:c { \@@_alternate_cs:n { reset / #1 } }
             \prop_gremove:Nn \g_@@_reset_alternate_prop {#1}
           }
-        \msg_warning:nnxx { ctex } { redefine-family } {#1} { \l_@@_tmp_tl }
+        \msg_warning:nnee { ctex } { redefine-family } {#1} { \l_@@_tmp_tl }
       }
   }
 \tl_new:N \l_@@_tmp_tl
@@ -5899,7 +5899,7 @@ Copyright and Licence
 % 切换字体。
 %    \begin{macrocode}
 \NewDocumentCommand \CJKfamily { m }
-  { \ctex_ltj_switch_family:x {#1} \tex_ignorespaces:D }
+  { \ctex_ltj_switch_family:e {#1} \tex_ignorespaces:D }
 \cs_new_protected:Npn \ctex_ltj_switch_family:n #1
   {
     \ctex_ltj_family_if_exist:nNTF {#1} \CJK@family
@@ -5910,7 +5910,7 @@ Copyright and Licence
       { \@@_family_unknown_warning:n {#1} }
   }
 \tl_new:N \l_ctex_ltj_family_tl
-\cs_generate_variant:Nn \ctex_ltj_switch_family:n { x }
+\cs_generate_variant:Nn \ctex_ltj_switch_family:n { e }
 %    \end{macrocode}
 % \end{macro}
 %
@@ -5930,7 +5930,7 @@ Copyright and Licence
           { \prg_return_false: }
       }
   }
-\prg_generate_conditional_variant:Nnn \ctex_ltj_family_if_exist:nN { x } { T , F , TF }
+\prg_generate_conditional_variant:Nnn \ctex_ltj_family_if_exist:nN { e } { T , F , TF }
 %    \end{macrocode}
 % \end{macro}
 %
@@ -5983,7 +5983,7 @@ Copyright and Licence
   {
     \prop_get:NnNTF \g_@@_fontspec_prop
       { CJKfontspec/#1/#2/id } \l_ctex_ltj_family_tl
-      { \ctex_ltj_switch_family:x { \l_ctex_ltj_family_tl } }
+      { \ctex_ltj_switch_family:e { \l_ctex_ltj_family_tl } }
       {
         \int_gincr:N \g_@@_family_int
         \@@_fontspec:enn
@@ -6022,7 +6022,7 @@ Copyright and Licence
 % {\ctex_ltj_add_font_features:n,\ctex_ltj_add_font_features:nn}
 %    \begin{macrocode}
 \cs_new_protected:Npn \ctex_ltj_add_font_features:n #1
-  { \ctex_ltj_add_font_features:xn { \l_ctex_ltj_family_tl } {#1} }
+  { \ctex_ltj_add_font_features:en { \l_ctex_ltj_family_tl } {#1} }
 \cs_new_protected:Npn \ctex_ltj_add_font_features:nn #1#2
   {
     \prop_get:NnNTF \g_@@_family_font_name_prop
@@ -6039,8 +6039,8 @@ Copyright and Licence
       { \msg_warning:nn { ctex } { addCJKfontfeature-ignored } }
   }
 \bool_new:N \l_@@_add_alternate_bool
-\cs_generate_variant:Nn \ctex_ltj_add_font_features:n  { x }
-\cs_generate_variant:Nn \ctex_ltj_add_font_features:nn { x }
+\cs_generate_variant:Nn \ctex_ltj_add_font_features:n  { e }
+\cs_generate_variant:Nn \ctex_ltj_add_font_features:nn { e }
 \msg_new:nnn { ctex } { addCJKfontfeature-ignored }
   {
     \token_to_str:N \addCJKfontfeature (s)~ignored.\\
@@ -6088,10 +6088,10 @@ Copyright and Licence
   { Control~sequence~#1~is~already~defined. }
 \NewDocumentCommand \newCJKfontfamily { o m o m }
   {
-    \tl_set:Nx \l_@@_tmp_tl
+    \tl_set:Ne \l_@@_tmp_tl
       { \tl_if_novalue:nTF {#1} { \cs_to_str:N #2 } {#1} }
     \cs_if_exist:NTF #2
-      { \msg_error:nnx { ctex } { command-already-defined }
+      { \msg_error:nne { ctex } { command-already-defined }
           { \token_to_str:N #2 } }
       {
         \cs_set_protected:Npx #2
@@ -6109,7 +6109,7 @@ Copyright and Licence
   }
 \NewDocumentCommand \addCJKfontfeatures { m }
   {
-    \ctex_ltj_add_font_features:x {#1}
+    \ctex_ltj_add_font_features:e {#1}
     \tex_ignorespaces:D
   }
 \cs_new_eq:NN \addCJKfontfeature \addCJKfontfeatures
@@ -6167,12 +6167,12 @@ Copyright and Licence
   {
     \prop_if_empty:NF \g_@@_family_font_name_prop
       {
-        \ctex_ltj_family_if_exist:xNF { \CJKfamilydefault } \l_@@_tmp_tl
+        \ctex_ltj_family_if_exist:eNF { \CJKfamilydefault } \l_@@_tmp_tl
           {
             \str_if_eq:eeTF { \CJKfamilydefault } { \CJKrmdefault }
               { \use:n }
               {
-                \ctex_ltj_family_if_exist:xNTF { \CJKrmdefault } \l_@@_tmp_tl
+                \ctex_ltj_family_if_exist:eNTF { \CJKrmdefault } \l_@@_tmp_tl
                   { \tl_gset:Nn \CJKfamilydefault { \CJKrmdefault } \use_none:n }
                   { \use:n }
               }
@@ -6196,16 +6196,16 @@ Copyright and Licence
 %    \begin{macrocode}
 \cs_new_protected:Npn \ctex_ltj_update_mathfont:
   {
-    \ctex_ltj_family_if_exist:xNTF { \c_@@_math_tl } \l_@@_tmp_tl
+    \ctex_ltj_family_if_exist:eNTF { \c_@@_math_tl } \l_@@_tmp_tl
       { \ctex_ltj_update_mathfont:n { \l_@@_tmp_tl } }
       {
-        \ctex_ltj_family_if_exist:xNT { \CJKfamilydefault } \l_@@_tmp_tl
+        \ctex_ltj_family_if_exist:eNT { \CJKfamilydefault } \l_@@_tmp_tl
           { \ctex_ltj_update_mathfont:n { \l_@@_tmp_tl } }
       }
   }
 \cs_new_protected:Npn \ctex_ltj_update_mathfont:n #1
   {
-    \tl_const:Nx \c_@@_math_family_tl {#1}
+    \tl_const:Ne \c_@@_math_family_tl {#1}
     \DeclareSymbolFont { \c_@@_math_tl } { \CJK@encoding }
       { \c_@@_math_family_tl } { \mddefault } { \shapedefault }
     \cs_if_free:cTF
@@ -6246,7 +6246,7 @@ Copyright and Licence
   { \clist_map_function:nN {#1} \@@_push_alternate_prop:n }
 \cs_new_protected:Npn \@@_push_alternate_prop:n #1
   {
-    \clist_set:Nx \l_@@_tmp_clist { \tl_head:n {#1} }
+    \clist_set:Ne \l_@@_tmp_clist { \tl_head:n {#1} }
     \tl_remove_all:Nn \l_@@_tmp_clist { ~ }
     \exp_args:No \@@_push_alternate_prop:nn
       { \l_@@_tmp_clist } {#1}
@@ -6304,7 +6304,7 @@ Copyright and Licence
     \tl_if_blank:nTF {#2}
       { \tl_set:Nn \l_@@_tmp_tl {#6} }
       {
-        \tl_set:Nx \l_@@_tmp_tl { \tl_trim_spaces:n {#2} }
+        \tl_set:Ne \l_@@_tmp_tl { \tl_trim_spaces:n {#2} }
         \tl_replace_all:Nnn \l_@@_tmp_tl { * } {#6}
       }
     \use:e
@@ -6395,7 +6395,7 @@ Copyright and Licence
 \cs_new_protected:Npn \@@_update_family_uid:N #1
   {
     \int_gincr:N \g_@@_family_int
-    \clist_put_right:Nx #1 { LTJFONTUID = \int_use:N \g_@@_family_int }
+    \clist_put_right:Ne #1 { LTJFONTUID = \int_use:N \g_@@_family_int }
   }
 \int_new:N \g_@@_family_int
 %    \end{macrocode}
@@ -6517,7 +6517,7 @@ Copyright and Licence
 \cs_new_protected:Npn \ctex_ltj_clear_alternate_font:n #1
   {
     \group_begin:
-      \ctex_ltj_family_if_exist:xNTF {#1} \l_@@_base_family_tl
+      \ctex_ltj_family_if_exist:eNTF {#1} \l_@@_base_family_tl
         {
           \cs_if_exist_use:cT
             { \@@_alternate_cs:n { clear / #1 } }
@@ -6589,7 +6589,7 @@ Copyright and Licence
   { \ctex_ltj_save_char_range:nn #1 }
 \cs_new_protected:Npn \ctex_ltj_save_char_range:nn #1#2
   {
-    \tl_put_right:Nx \l_@@_char_range_tl
+    \tl_put_right:Ne \l_@@_char_range_tl
       { { \@@_range_normalization:nn {#1} {#2} } }
   }
 \cs_new:Npn \@@_range_normalization:nn #1#2
@@ -6891,7 +6891,7 @@ Copyright and Licence
 \cs_new_protected:Npn \@@_provide_font_hook_aux:NNNN #1#2#3#4
   {
     \tl_new:N #1
-    \exp_args:Nx \ctex_gadd_ltxhook:nn { \cs_to_str:N #2 } {#1}
+    \exp_args:Ne \ctex_gadd_ltxhook:nn { \cs_to_str:N #2 } {#1}
   }
 \ctex_provide_font_hook:NNN \rmfamily \@rmfamilyhook \selectfont
 \ctex_provide_font_hook:NNN \sffamily \@sffamilyhook \selectfont
@@ -6955,7 +6955,7 @@ Copyright and Licence
       {
         \group_begin:
           \cs_set_eq:NN \@@_family_default_wrap:n \exp_not:n
-          \tl_gset:Nx \CJKfamilydefault
+          \tl_gset:Ne \CJKfamilydefault
             {
               \str_case:onF { \familydefault }
                 {
@@ -6982,7 +6982,7 @@ Copyright and Licence
 %    \begin{macrocode}
 \tl_new:N \l_@@_family_default_init_tl
 \cs_new_eq:NN \@@_family_default_wrap:n \use:n
-\tl_set:Nx \l_@@_family_default_init_tl
+\tl_set:Ne \l_@@_family_default_init_tl
   {
     \exp_not:N \@@_family_default_wrap:n
       { \exp_not:o { \CJKfamilydefault } }
@@ -7452,7 +7452,7 @@ Copyright and Licence
   {
     punct .code:n =
       {
-        \tl_set:Nx \l_@@_punct_tl {#1}
+        \tl_set:Ne \l_@@_punct_tl {#1}
 %<pdftex>        \punctstyle { \l_@@_punct_tl }
 %<xetex>        \xeCJKsetup { PunctStyle = \l_@@_punct_tl }
 %<luatex>        \ctex_set_jfm:o { \l_@@_punct_tl }
@@ -7595,7 +7595,7 @@ Copyright and Licence
       }
       { \ctex_update_ziju: }
   }
-\tl_const:Nx \c_@@_zero_tl { \fp_use:N \c_zero_fp }
+\tl_const:Ne \c_@@_zero_tl { \fp_use:N \c_zero_fp }
 \tl_new:N \l_@@_ziju_tl
 \tl_set_eq:NN \l_@@_ziju_tl \c_@@_zero_tl
 %    \end{macrocode}
@@ -7699,10 +7699,10 @@ Copyright and Licence
 % 若参数为 $0$，则恢复正常间距。
 %    \begin{macrocode}
 \NewDocumentCommand \ziju { m }
-  { \exp_args:Nx \ctex_ziju:n {#1} \tex_ignorespaces:D }
+  { \exp_args:Ne \ctex_ziju:n {#1} \tex_ignorespaces:D }
 \cs_new_protected:Npn \ctex_ziju:n #1
   {
-    \tl_set:Nx \l_@@_ziju_tl { \fp_eval:n {#1} }
+    \tl_set:Ne \l_@@_ziju_tl { \fp_eval:n {#1} }
     \ctex_select_size:
   }
 %    \end{macrocode}
@@ -7845,7 +7845,7 @@ Copyright and Licence
         \zhnumsetup { time = Chinese }
       } ,
     today / unknown .code:n =
-      { \msg_error:nnx { ctex } { today-undef } {#1} }
+      { \msg_error:nne { ctex } { today-undef } {#1} }
   }
 \msg_new:nnnn { ctex } { today-undef }
   { Today~format~`#1'~is~undefined. }
@@ -7971,13 +7971,13 @@ Copyright and Licence
   {
     \tl_new:c { CTEX@pre#1 }
     \tl_new:c { CTEX@post#1 }
-    \tl_const:cx { CTEXthe#1 }
+    \tl_const:ce { CTEXthe#1 }
       {
         \exp_not:c { CTEX@pre#1 }
         \exp_not:c { CTEX@the#1 }
         \exp_not:c { CTEX@post#1 }
       }
-    \tl_const:cx { CTEX@#1name }
+    \tl_const:ce { CTEX@#1name }
       {
         \group_begin:
           \exp_not:c { CTEX@#1@nameformat }
@@ -9092,7 +9092,7 @@ Copyright and Licence
   }
 \cs_new_protected:Npn \@@_titlesec_format:Nn #1#2
   {
-    \tl_set:Nx #1
+    \tl_set:Ne #1
       {
         \bool_if:cTF { CTEX@#2@runin }
           { \exp_not:N \ttlh@runin }
@@ -9111,7 +9111,7 @@ Copyright and Licence
       }
   }
 \cs_new_protected:Npn \@@_titlesec_spacing:Nn #1#2
-  { \tl_set:Nx #1 { \exp_after:wN \@@_titlesec_spacing:nnnnnn #1 {#2} } }
+  { \tl_set:Ne #1 { \exp_after:wN \@@_titlesec_spacing:nnnnnn #1 {#2} } }
 \cs_new:Npn \@@_titlesec_spacing:nnnnnn #1#2#3#4#5#6
   {
     \exp_not:n { {#1} {#2} {#3} {#4} }
@@ -9637,7 +9637,7 @@ Copyright and Licence
 \cs_new_protected:Npn \ctex_fix_varioref_label:n #1
   {
     \tl_if_empty:cT { p@#1 }
-      { \exp_args:Nnx \labelformat {#1} { \exp_not:c { CTEX@the#1 } } }
+      { \exp_args:Nne \labelformat {#1} { \exp_not:c { CTEX@the#1 } } }
   }
 %    \end{macrocode}
 % \end{macro}
@@ -10071,7 +10071,7 @@ Copyright and Licence
             \tl_const:Nn \c_@@_class_tl { book }
           }
           { \tl_const:Nn \c_@@_class_tl { article } }
-        \msg_warning:nnx { ctex } { not-standard-class } { \c_@@_class_tl }
+        \msg_warning:nne { ctex } { not-standard-class } { \c_@@_class_tl }
       }
     \ctex_file_input:n { ctex-heading- \c_@@_class_tl .def }
   }
@@ -10231,7 +10231,7 @@ Copyright and Licence
 % \begin{macro}{\zihao}
 %    \begin{macrocode}
 \NewDocumentCommand \zihao { m }
-  { \exp_args:Nx \ctex_zihao:n {#1} \tex_ignorespaces:D }
+  { \exp_args:Ne \ctex_zihao:n {#1} \tex_ignorespaces:D }
 %    \end{macrocode}
 % \end{macro}
 %
@@ -10393,8 +10393,8 @@ Copyright and Licence
     \tl_map_inline:nn {#2}
       {
         \prop_get:NnNTF \c_@@_font_size_prop {##1} \l_@@_tmp_tl
-          { \tl_put_right:Nx #1 { { \tl_head:N \l_@@_tmp_tl } } }
-          { \tl_put_right:Nx #1 { { \dim_to_decimal:n { ##1 } } } }
+          { \tl_put_right:Ne #1 { { \tl_head:N \l_@@_tmp_tl } } }
+          { \tl_put_right:Ne #1 { { \dim_to_decimal:n { ##1 } } } }
       }
   }
 %    \end{macrocode}
@@ -10545,7 +10545,7 @@ Copyright and Licence
 %    \begin{macrocode}
 \fp_if_nan:nF { \l_@@_line_spread_fp }
   {
-    \exp_args:Nx \linespread { \fp_use:N \l_@@_line_spread_fp }
+    \exp_args:Ne \linespread { \fp_use:N \l_@@_line_spread_fp }
 %    \end{macrocode}
 %
 % \changes{v2.0}{2014/04/23}{调整 \tn{footnotesep} 的大小，以适合行距的变化。}
@@ -10700,7 +10700,7 @@ Copyright and Licence
           { \str_if_eq_p:on { \g_@@_fontset_tl } { windowsnew } }
           { \str_if_eq_p:on { \g_@@_fontset_tl } { windowsold } }
           {
-            \msg_warning:nnxx { ctex } { deprecated-fontset }
+            \msg_warning:nnee { ctex } { deprecated-fontset }
               { \g_@@_fontset_tl } { windows }
             \tl_gset:Nn \g_@@_fontset_tl { windows }
           }
@@ -10710,7 +10710,7 @@ Copyright and Licence
                 \use:e
                   {
                     \ctex_detect_platform:
-                    \msg_error:nnxx { ctex } { fontset-not-found }
+                    \msg_error:nnee { ctex } { fontset-not-found }
                       { \g_@@_fontset_tl } { \exp_not:N \g_@@_fontset_tl }
                   }
               }
@@ -10741,11 +10741,11 @@ Copyright and Licence
               {
                 \str_if_eq:onTF { \g_@@_fontset_tl } { none }
                   {
-                    \tl_gset:Nx \g_@@_fontset_tl {#1}
+                    \tl_gset:Ne \g_@@_fontset_tl {#1}
                     \ctex_load_fontset:
                   }
                   {
-                    \msg_error:nnxx { ctex } { fontset-loaded }
+                    \msg_error:nnee { ctex } { fontset-loaded }
                       { \g_@@_fontset_tl } {#1}
                   }
               }
@@ -12235,7 +12235,7 @@ Copyright and Licence
           \exp_args:No \@@_save_bounds:n
             { \int_use:N \tex_XeTeXcharglyph:D ##1 }
         }
-      \iow_now:Nx \g_@@_spa_iow
+      \iow_now:Ne \g_@@_spa_iow
         {
           \token_to_str:N \ctexspadef {#1}
 %    \end{macrocode}
@@ -12295,7 +12295,7 @@ Copyright and Licence
 %    \begin{macrocode}
 \cs_new_protected:Npn \@@_save_bounds:n #1
   {
-    \clist_put_right:Nx \l_@@_punct_bounds_clist
+    \clist_put_right:Ne \l_@@_punct_bounds_clist
       {
         \@@_calc_bounds:nn { 1 } {#1} ,
         \@@_calc_bounds:nn { 3 } {#1}
@@ -12499,7 +12499,7 @@ Copyright and Licence
 % \pkg{ctexcap} 是过时宏包。
 %    \begin{macrocode}
 \clist_new:N \l_@@_ctexcap_options_clist
-\clist_set:Nx \l_@@_ctexcap_options_clist
+\clist_set:Ne \l_@@_ctexcap_options_clist
   { \exp_not:v { opt@ \@currname . \@currext } , heading }
 \msg_new:nnn { ctexcap } { deprecated }
   {
@@ -12507,7 +12507,7 @@ Copyright and Licence
     Please~use~package~`ctex'~with~option~`#1'~instead: \\\\
     \iow_indent:n { \token_to_str:N \usepackage [#1] \{ ctex \} } \\
   }
-\msg_warning:nnx { ctexcap } { deprecated }
+\msg_warning:nne { ctexcap } { deprecated }
   { \clist_use:Nn \l_@@_ctexcap_options_clist { , ~ } }
 %    \end{macrocode}
 %
@@ -12596,18 +12596,18 @@ Copyright and Licence
 \cs_new_protected:Npn \ctex_disable_package:n #1
   {
     \@ifpackageloaded {#1}
-      { \msg_error:nnxx }
+      { \msg_error:nnee }
       { \@@_disable_package_aux:nnnn }
       { ctexhook } { disable-package } {#1} { \@currname }
   }
-\cs_new_protected:Npx \@@_disable_package_aux:nnnn #1#2#3#4
+\cs_new_protected:Npn \@@_disable_package_aux:nnnn #1#2#3#4
   {
     \cs_if_exist:NTF \disable@package@load
       {
-        \exp_args:Nnx \exp_not:N \disable@package@load {#3}
+        \exp_args:Nne \disable@package@load {#3}
           { \msg_warning:nnnn {#1} {#2} {#3} {#4} }
       }
-      { \tl_const:cn { ver@ #3 . \exp_not:N \@pkgextension } { 9999/99/99 } }
+      { \tl_const:cn { ver@ #3 . \@pkgextension } { 9999/99/99 } }
   }
 \msg_new:nnn { ctexhook } { disable-package }
   { Package~`#1'~can~not~be~loaded~with~`#2'. }
@@ -12649,7 +12649,7 @@ Copyright and Licence
       { \ctex_gadd_package_hook:nnn { before } {#1} }
   }
 \cs_new_protected:Npn \@@_package_loaded_warning:nn #1#2
-  { \msg_warning:nnx { ctexhook } { invalid-hook } {#1} }
+  { \msg_warning:nne { ctexhook } { invalid-hook } {#1} }
 \msg_new:nnn { ctexhook } { invalid-hook }
   {
     Package~`#1'~is~loaded. \\
@@ -12823,7 +12823,7 @@ Copyright and Licence
       { \ctex_patch_failure:N #1 }
   }
 \cs_new_protected:Npn \ctex_patch_failure:N #1
-  { \msg_warning:nnx { ctexpatch } { patch-failure } { \token_to_str:N #1 } }
+  { \msg_warning:nne { ctexpatch } { patch-failure } { \token_to_str:N #1 } }
 \msg_new:nnn { ctexpatch } { patch-failure }
   { Oops!~Command~`#1'~is~NOT~patchable.\\ }
 %    \end{macrocode}
@@ -12890,7 +12890,7 @@ Copyright and Licence
 % 类似的工作。
 %    \begin{macrocode}
 \cs_new_protected:Npn \ctex_parse_name:NN #1#2
-  { \ctex_parse_name:NNx #1#2 { \cs_to_str:N #2 } }
+  { \ctex_parse_name:NNe #1#2 { \cs_to_str:N #2 } }
 \group_begin:
 \cs_set_protected:Npn \@@_tmp:w #1#2#3
   {
@@ -12951,7 +12951,7 @@ Copyright and Licence
       { \tl_to_str:n { testopt } }
   }
 \group_end:
-\cs_generate_variant:Nn \ctex_parse_name:NNn { NNx }
+\cs_generate_variant:Nn \ctex_parse_name:NNn { NNe }
 %    \end{macrocode}
 % \end{macro}
 %

--- a/xeCJK/xeCJK.dtx
+++ b/xeCJK/xeCJK.dtx
@@ -245,12 +245,12 @@ Copyright and Licence
     \CJKfontspec[Language=Chinese ~ Simplified]{Noto ~ Serif ~ CJK ~ SC}
     \tl_clear:N \l_tmpa_tl
     \int_zero:N \l_tmpa_int
-    \tl_set:Nx \l_tmpb_tl { \tl_to_str:n { c__xeCJK_#2_chars_clist } }
+    \tl_set:Ne \l_tmpb_tl { \tl_to_str:n { c__xeCJK_#2_chars_clist } }
     \int_set:Nn \l_tmpb_int { \clist_count:c { \l_tmpb_tl } }
     \clist_map_inline:cn { \l_tmpb_tl }
       {
         \int_incr:N \l_tmpa_int
-        \tl_put_right:Nx \l_tmpa_tl
+        \tl_put_right:Ne \l_tmpa_tl
           {
             \use_none:n ##1 & \tex_char:D ##1 \scan_stop:
             \int_compare:nNnF \l_tmpa_int = \l_tmpb_int
@@ -1770,7 +1770,7 @@ Copyright and Licence
     \tl_if_exist:cTF { ver@ #1 . \c_@@_package_ext_tl }
       { \prg_return_true: } { \prg_return_false: }
   }
-\tl_const:Nx \c_@@_package_ext_tl { \@pkgextension }
+\tl_const:Ne \c_@@_package_ext_tl { \@pkgextension }
 %    \end{macrocode}
 % \end{macro}
 %
@@ -1825,18 +1825,18 @@ Copyright and Licence
 %    \end{macrocode}
 %
 % \begin{macro}
-%  {\@@_msg_new:nn ,\@@_error:n,\@@_error:nx,\@@_warning:nx,\@@_info:nxx}
+%  {\@@_msg_new:nn ,\@@_error:n,\@@_error:ne,\@@_warning:ne,\@@_info:nee}
 % 各种信息函数的缩略形式。
 %    \begin{macrocode}
 \cs_new_protected:Npn \@@_msg_new:nn   { \msg_new:nnn       { xeCJK } }
 \cs_new_protected:Npn \@@_msg_new:nnn  { \msg_new:nnnn      { xeCJK } }
 \cs_new_protected:Npn \@@_error:n      { \msg_error:nn      { xeCJK } }
-\cs_new_protected:Npn \@@_error:nx     { \msg_error:nnx     { xeCJK } }
+\cs_new_protected:Npn \@@_error:ne     { \msg_error:nne     { xeCJK } }
 \cs_new_protected:Npn \@@_warning:n    { \msg_warning:nn    { xeCJK } }
-\cs_new_protected:Npn \@@_warning:nx   { \msg_warning:nnx   { xeCJK } }
-\cs_new_protected:Npn \@@_warning:nxx  { \msg_warning:nnxx  { xeCJK } }
-\cs_new_protected:Npn \@@_warning:nxxx { \msg_warning:nnxxx { xeCJK } }
-\cs_new_protected:Npn \@@_info:nxx     { \msg_info:nnxx     { xeCJK } }
+\cs_new_protected:Npn \@@_warning:ne   { \msg_warning:nne   { xeCJK } }
+\cs_new_protected:Npn \@@_warning:nee  { \msg_warning:nnee  { xeCJK } }
+\cs_new_protected:Npn \@@_warning:neee { \msg_warning:nneee { xeCJK } }
+\cs_new_protected:Npn \@@_info:nee     { \msg_info:nnee     { xeCJK } }
 %    \end{macrocode}
 % \end{macro}
 %
@@ -2122,9 +2122,9 @@ Copyright and Licence
 \cs_new_protected:Npn \xeCJK_peek_catcode_ignore_spaces:NTF #1#2#3
   {
     \cs_set_eq:NN \l_@@_peek_search_token #1 \scan_stop:
-    \cs_set_protected:Npx \@@_peek_catcode_true:w
+    \cs_set_protected:Npe \@@_peek_catcode_true:w
       { \exp_not:N \group_align_safe_end: \exp_not:n {#2} }
-    \cs_set_protected:Npx \@@_peek_catcode_false:w
+    \cs_set_protected:Npe \@@_peek_catcode_false:w
       { \exp_not:N \group_align_safe_end: \exp_not:n {#3} }
     \bool_set_false:N \l_@@_peek_ignore_spaces_bool
     \group_align_safe_begin:
@@ -2297,7 +2297,7 @@ Copyright and Licence
 \cs_new_protected:Npn \xeCJK_new_class:n #1
   {
     \int_if_exist:cTF { \@@_class_csname:n {#1} }
-      { \@@_error:nx { class-already-defined } {#1} }
+      { \@@_error:ne { class-already-defined } {#1} }
       {
         \exp_args:Nc \newXeTeXintercharclass
           { \@@_class_csname:n {#1} }
@@ -2318,7 +2318,7 @@ Copyright and Licence
 \cs_new_protected:Npn \xeCJK_save_class:nn #1#2
   {
     \int_if_exist:cTF { \@@_class_csname:n {#1} }
-      { \@@_error:nx { class-already-defined } {#1} }
+      { \@@_error:ne { class-already-defined } {#1} }
       {
         \int_const:cn { \@@_class_csname:n {#1} } {#2}
         \clist_new:c { g_@@_#1_range_clist }
@@ -2377,7 +2377,7 @@ Copyright and Licence
 % \XeTeX{} 0.99994 将字符类总数扩大到 $4096$^^A
 % \footnote{\url{http://tug.org/pipermail/xetex/2016-February/026363.html}}。
 %    \begin{macrocode}
-\str_const:Nx \c_@@_xetex_version_str
+\str_const:Ne \c_@@_xetex_version_str
   { \int_use:N \tex_XeTeXversion:D \tex_XeTeXrevision:D }
 \fp_compare:nNnTF { \c_@@_xetex_version_str } > { 0.99993 }
   { \xeCJK_save_class:nn { Boundary } { 4095 } }
@@ -2900,7 +2900,7 @@ Copyright and Licence
 %    \begin{macrocode}
 \cs_new_protected:Npn \xeCJK_declare_char_class:nn #1#2
   {
-    \clist_set:Nx \l_@@_tmp_clist {#2}
+    \clist_set:Ne \l_@@_tmp_clist {#2}
     \xeCJK_declare_char_class:nN {#1} \l_@@_tmp_clist
   }
 \cs_new_protected:Npn \xeCJK_declare_char_class:nN #1#2
@@ -3114,11 +3114,11 @@ Copyright and Licence
 %    \begin{macrocode}
 \cs_new_protected:Npn \xeCJK_copy_inter_class_toks:nnnn #1#2#3#4
   {
-    \tl_set:Nx \l_@@_tmp_tl
+    \tl_set:Ne \l_@@_tmp_tl
       { \xeCJK_get_inter_class_toks:nn {#3} {#4} }
     \tl_if_empty:NTF \l_@@_tmp_tl
       {
-        \tl_set:Nx \l_@@_tmp_tl
+        \tl_set:Ne \l_@@_tmp_tl
           { \xeCJK_get_inter_class_toks:nn {#1} {#2} }
         \tl_if_empty:NF \l_@@_tmp_tl
           { \xeCJK_clear_inter_class_toks:nn {#1} {#2} }
@@ -3133,7 +3133,7 @@ Copyright and Licence
 %    \begin{macrocode}
 \cs_new_protected:Npn \xeCJK_replace_inter_class_toks:nnnn #1#2#3#4
   {
-    \tl_set:Nx \l_@@_tmp_tl
+    \tl_set:Ne \l_@@_tmp_tl
       { \xeCJK_get_inter_class_toks:nn {#1} {#2} }
     \tl_if_empty:NF \l_@@_tmp_tl
       {
@@ -3153,7 +3153,7 @@ Copyright and Licence
   { }
 \cs_new_protected:Npn \@@_update_clear_toks:n #1
   {
-    \cs_gset_protected:Npx \xeCJK_clear_Boundary_and_CJK_toks:
+    \cs_gset_protected:Npe \xeCJK_clear_Boundary_and_CJK_toks:
       {
         \exp_not:o { \xeCJK_clear_Boundary_and_CJK_toks: }
         \tex_XeTeXinterchartoks:D
@@ -3879,7 +3879,7 @@ Copyright and Licence
 % 需要使用 |glue| 来标记，使用 |kern| 会影响 character protrusion 功能。
 %    \begin{macrocode}
 \cs_new_eq:NN \xeCJK_make_space_node: \prg_do_nothing:
-\cs_new_protected:Npx \@@_make_space_node:
+\cs_new_protected:Npe \@@_make_space_node:
   {
     \tex_hskip:D - \@@_glue_node:n { default-space }
     \tex_hskip:D   \@@_glue_node:n { default-space }
@@ -4916,7 +4916,7 @@ Copyright and Licence
     \dim_set_eq:NN \l_@@_tmp_dim \l_@@_last_kern_dim
     \xeCJK_if_last_node:TF
       {
-        \tl_gset:Nx \g_@@_last_punct_tl
+        \tl_gset:Ne \g_@@_last_punct_tl
           { \tex_Uchar:D \l_@@_tmp_dim }
         \dim_set_eq:NN \l_@@_last_bound_dim \l_@@_last_kern_dim
         \use_i:nn
@@ -5591,7 +5591,7 @@ Copyright and Licence
               { CJK \bool_if:NF \l_@@_sub_cancel_bool { /##1 } }
               { \use:c { g_@@_CJK/##1_range_clist } }
           }
-          { \@@_error:nx { SubBlock-undefined } {##1} }
+          { \@@_error:ne { SubBlock-undefined } {##1} }
       }
   }
 \cs_generate_variant:Nn \@@_sub_restore_or_cancel:n { e }
@@ -5685,7 +5685,7 @@ Copyright and Licence
         \keys_define:nn { xeCJK / options }
           {
             PunctStyle .code:n =
-              { \@@_error:nx { punct-style-unknown } {#1} }
+              { \@@_error:ne { punct-style-unknown } {#1} }
           }
         \seq_gclear:N \g_@@_punct_style_seq
         \@@_set_punct_style:n { plain }
@@ -6574,7 +6574,7 @@ Copyright and Licence
 % \begin{macro}{PunctStyle}
 %    \begin{macrocode}
 \keys_define:nn { xeCJK / options }
-  { PunctStyle .code:n = \exp_args:Nx \@@_set_punct_style:n {#1} }
+  { PunctStyle .code:n = \exp_args:Ne \@@_set_punct_style:n {#1} }
 \cs_new_protected:Npn \@@_set_punct_style:n #1
   {
     \IfInstanceExistTF { xeCJK / punctuation } {#1}
@@ -6582,7 +6582,7 @@ Copyright and Licence
       {
         \prop_get:NnNF \c_@@_punct_style_alias_prop
           {#1} \l_xeCJK_punct_style_tl
-          { \@@_error:nx { punct-style-unknown } {#1} }
+          { \@@_error:ne { punct-style-unknown } {#1} }
       }
   }
 \prop_const_from_keyval:Nn \c_@@_punct_style_alias_prop
@@ -6610,7 +6610,7 @@ Copyright and Licence
 %    \begin{macrocode}
 \cs_new_protected:Npn \@@_trim_spaces:n #1
   {
-    \tl_set:Nx \ProcessedArgument
+    \tl_set:Ne \ProcessedArgument
       { \exp_args:Ne \tl_trim_spaces:n {#1} }
   }
 %    \end{macrocode}
@@ -6623,7 +6623,7 @@ Copyright and Licence
   { > { \@@_trim_spaces:n } m m }
   {
     \IfInstanceExistTF { xeCJK / punctuation } {#1}
-      { \@@_warning:nx { punct-style-already-defined } {#1} }
+      { \@@_warning:ne { punct-style-already-defined } {#1} }
       { \seq_gput_right:Nn \g_@@_punct_style_seq {#1} }
     \DeclareInstance { xeCJK / punctuation } {#1} { basic } {#2}
   }
@@ -6645,7 +6645,7 @@ Copyright and Licence
   {
     \IfInstanceExistTF { xeCJK / punctuation } {#1}
       { \EditInstance { xeCJK / punctuation } {#1} {#2} }
-      { \@@_error:nx { punct-style-unknown } {#1} }
+      { \@@_error:ne { punct-style-unknown } {#1} }
   }
 \@onlypreamble \xeCJKEditPunctStyle
 %    \end{macrocode}
@@ -6755,7 +6755,7 @@ Copyright and Licence
   }
 \cs_new_protected:Npn \@@_fallback_symbol_aux:nnNN
   {
-    \cs_set_protected:Npx \xeCJK_reset_fallback_font:
+    \cs_set_protected:Npe \xeCJK_reset_fallback_font:
       {
         \tex_the:D \tex_font:D
         \xeCJK_clear_fallback_font:
@@ -6800,7 +6800,7 @@ Copyright and Licence
   }
 \cs_new_protected:Npn \@@_fallback_missing_glyph:nnnNN #1#2#3#4#5
   {
-    \@@_warning:nxxx { missing-glyph } {#1} {#2} {#5}
+    \@@_warning:neee { missing-glyph } {#1} {#2} {#5}
     #4#5
   }
 \cs_new_protected:Npn \xeCJK_select_fallback_font:nnn #1#2
@@ -6962,7 +6962,7 @@ Copyright and Licence
             \tl_if_blank:nTF {##1}
               {
                 \prop_clear:N \l_@@_sub_key_prop
-                \tl_set:Nx \l_@@_sub_family_name_tl
+                \tl_set:Ne \l_@@_sub_family_name_tl
                   { \l_@@_family_name_tl /#1 }
                 \clist_remove_all:Nn \l_@@_font_options_clist {#1}
               }
@@ -6986,7 +6986,7 @@ Copyright and Licence
 %    \begin{macrocode}
 \cs_new_protected:Npn \@@_get_sub_features:nn #1#2
   {
-    \tl_set:Nx \l_@@_tmp_tl { \xeCJK_tl_remove_outer_braces:n {#2} }
+    \tl_set:Ne \l_@@_tmp_tl { \xeCJK_tl_remove_outer_braces:n {#2} }
     \clist_clear:N \l_@@_sub_font_options_clist
     \exp_after:wN \@@_get_sub_features:w \l_@@_tmp_tl
       \q_mark [ \q_nil ] \q_mark \q_stop
@@ -7004,7 +7004,7 @@ Copyright and Licence
     \quark_if_nil:nTF {#2}
       { \tl_set_eq:NN \l_@@_sub_font_name_tl \l_@@_tmp_tl }
       {
-        \tl_set:Nx \l_@@_sub_font_name_tl
+        \tl_set:Ne \l_@@_sub_font_name_tl
           { \xeCJK_tl_remove_outer_braces:n {#3} }
         \tl_if_empty:NTF \l_@@_sub_font_name_tl
           { \tl_set_eq:NN \l_@@_sub_font_name_tl \l_@@_tmp_tl }
@@ -7145,7 +7145,7 @@ Copyright and Licence
 %    \begin{macrocode}
 \cs_new_protected:Npn \@@_gset_family_cs:n #1
   {
-    \cs_gset_protected:cpx { \@@_family_csname:n {#1} }
+    \cs_gset_protected:cpe { \@@_family_csname:n {#1} }
       {
         \group_begin:
         \exp_not:n { \cs_set_eq:NN \xeCJK@fontfamily \use_none:n }
@@ -7175,7 +7175,7 @@ Copyright and Licence
             \cs_undefine:c { \@@_family_csname:n {#1} }
             \cs_undefine:c { \@@_family_nfss_csname:n {#1} }
           }
-        \@@_warning:nxx { CJKfamily-redef } {#1} { \l_@@_tmp_tl }
+        \@@_warning:nee { CJKfamily-redef } {#1} { \l_@@_tmp_tl }
       }
   }
 \cs_generate_variant:Nn \@@_check_family:n { o }
@@ -7192,24 +7192,24 @@ Copyright and Licence
       {
         \bool_if:NT \l_@@_auto_fake_bold_bool
           {
-            \clist_put_right:Nx \l_@@_fontspec_options_clist
+            \clist_put_right:Ne \l_@@_fontspec_options_clist
               { AutoFakeBold = { \fp_use:N \l_@@_embolden_factor_fp } }
           }
       }
       {
-        \clist_put_right:Nx \l_@@_fontspec_options_clist
+        \clist_put_right:Ne \l_@@_fontspec_options_clist
           { BoldFont = { \exp_not:o \l_@@_font_name_bf_tl } }
       }
     \tl_if_blank:oTF \l_@@_font_name_it_tl
       {
         \bool_if:NT \l_@@_auto_fake_slant_bool
           {
-            \clist_put_right:Nx \l_@@_fontspec_options_clist
+            \clist_put_right:Ne \l_@@_fontspec_options_clist
               { AutoFakeSlant = { \fp_use:N \l_@@_slant_factor_fp } }
           }
       }
       {
-        \clist_put_right:Nx \l_@@_fontspec_options_clist
+        \clist_put_right:Ne \l_@@_fontspec_options_clist
           { ItalicFont = { \exp_not:o \l_@@_font_name_it_tl } }
       }
   }
@@ -7255,7 +7255,7 @@ Copyright and Licence
   }
 \cs_new_protected:Npn \@@_set_sub_block_family:nn #1#2
   {
-    \tl_set:Nx \l_@@_sub_family_name_tl { \l_@@_family_name_tl/#1 }
+    \tl_set:Ne \l_@@_sub_family_name_tl { \l_@@_family_name_tl/#1 }
     \quark_if_no_value:nTF {#2}
       { \@@_copy_sub_family:n {#1} }
       { \xeCJK_set_family:onn \l_@@_sub_family_name_tl #2 }
@@ -7276,7 +7276,7 @@ Copyright and Licence
         \prop_gput:Noo \g_@@_family_font_options_prop
           \l_@@_sub_family_name_tl \l_@@_sub_font_options_clist
       }
-    \cs_gset_protected:cpx
+    \cs_gset_protected:cpe
       { \@@_family_csname:n { \l_@@_sub_family_name_tl } }
       {
         \xeCJK_family_if_exist:eT { \l_@@_family_name_tl }
@@ -7400,7 +7400,7 @@ Copyright and Licence
   {
     \str_if_eq:nnF {#1} {#2}
       {
-        \@@_info:nxx { CJK-block } {#1} {#2}
+        \@@_info:nee { CJK-block } {#1} {#2}
         \str_if_eq:nnTF {#2} { CJK }
           { \xeCJK_select_font: }
           { \xeCJK_select_font:n {#2} }
@@ -7465,7 +7465,7 @@ Copyright and Licence
 \cs_new_protected:Npn \@@_gset_family_nfss_cs:nn #1#2
   {
     \prop_gput:Nnn \g_@@_family_name_prop {#1} {#2}
-    \cs_gset_protected:cpx
+    \cs_gset_protected:cpe
       { \@@_family_nfss_csname:n {#1} }
       { \@@_nfss_family:nn { \c_@@_encoding_tl } {#2} }
   }
@@ -7654,7 +7654,7 @@ Copyright and Licence
         \seq_if_in:NnF \g_@@_unknown_family_seq {#1}
           {
             \seq_gput_right:Nn \g_@@_unknown_family_seq {#1}
-            \@@_warning:nx { CJKfamily-Unknown } {#1}
+            \@@_warning:ne { CJKfamily-Unknown } {#1}
           }
       }
   }
@@ -7772,12 +7772,12 @@ Copyright and Licence
   { Control~sequence~#1~is~already~defined. }
 \NewDocumentCommand \newCJKfontfamily { o m o m }
   {
-    \tl_set:Nx \l_@@_tmp_tl
+    \tl_set:Ne \l_@@_tmp_tl
       { \tl_if_novalue:nTF {#1} { \cs_to_str:N #2 } {#1} }
     \cs_if_exist:NTF #2
-      { \@@_error:nx { command-already-defined } { \token_to_str:N #2 } }
+      { \@@_error:ne { command-already-defined } { \token_to_str:N #2 } }
       {
-        \cs_set_protected:Npx #2
+        \cs_set_protected:Npe #2
           { \xeCJK_switch_family:n { \l_@@_tmp_tl } }
       }
     \@@_pass_args:nnnn
@@ -7879,7 +7879,7 @@ Copyright and Licence
         \seq_put_right:Nn \l_@@_sub_key_seq {#1}
         \@@_add_sub_class_features:n {#1}
       }
-      { \@@_warning:nx { SubBlock-undefined } {#1} }
+      { \@@_warning:ne { SubBlock-undefined } {#1} }
   }
 \clist_new:N \l_@@_add_font_features_clist
 \clist_new:N \l_@@_add_block_features_clist
@@ -7917,7 +7917,7 @@ Copyright and Licence
       }
     \clist_concat:NNN \l_@@_sub_font_options_clist
       \l_@@_sub_font_options_clist \l_@@_add_font_features_clist
-    \clist_put_right:Nx \l_@@_add_block_features_clist
+    \clist_put_right:Ne \l_@@_add_block_features_clist
       {
         #1 =
           {
@@ -7965,7 +7965,7 @@ Copyright and Licence
       {
         \group_begin:
         \cs_set_eq:NN \@@_family_default_wrap:n \exp_not:n
-        \tl_gset:Nx \CJKfamilydefault
+        \tl_gset:Ne \CJKfamilydefault
           {
             \str_case:onF { \familydefault }
               {
@@ -7985,7 +7985,7 @@ Copyright and Licence
             \@@_load_fandol:
             \xeCJK_ensure_default_family:
           }
-          { \@@_warning:nx { no-CJKfamily } { \CJKfamilydefault } }
+          { \@@_warning:ne { no-CJKfamily } { \CJKfamilydefault } }
       }
       { \xeCJK_ensure_default_family: }
   }
@@ -8007,7 +8007,7 @@ Copyright and Licence
                   { \tl_gset_rescan:Nnn \CJKfamilydefault { } { ##1 } }
               }
           }
-        \@@_warning:nxx { CJKfamilydefault-undefined }
+        \@@_warning:nee { CJKfamilydefault-undefined }
           { \l_@@_tmp_tl } { \CJKfamilydefault }
       }
     \xeCJK_switch_family:e { \CJKfamilydefault }
@@ -8079,7 +8079,7 @@ Copyright and Licence
   }
 \cs_new_protected:Npn \@@_set_mathfont_aux:
   {
-    \tl_const:Nx \c_@@_math_family_tl
+    \tl_const:Ne \c_@@_math_family_tl
       { \l_@@_fontspec_family_tl }
     \xeCJK_declare_mathfont:ee
       { \c_@@_math_tl }
@@ -8190,7 +8190,7 @@ Copyright and Licence
       {
         \int_set_eq:NN \allocationnumber \g_@@_fam_allocation_int
         \int_const:Nn #1 { \allocationnumber }
-        \iow_log:x
+        \iow_log:e
           {
             \token_to_str:N #1 =
             \token_to_str:N \mathgroup \int_use:N \allocationnumber
@@ -8292,7 +8292,7 @@ Copyright and Licence
   }
 \@@_after_preamble:n
   {
-    \cs_set_protected:Npx \verbatim@font
+    \cs_set_protected:Npe \verbatim@font
       { \exp_not:o { \verbatim@font } \@@_verb_font_hook: }
   }
 %    \end{macrocode}
@@ -8348,7 +8348,7 @@ Copyright and Licence
     \cs_set_eq:NN \@@_shipout_punct_hskip:n \@@_punct_hskip:n
     \cs_set_eq:NN
       \@@_shipout_punct_breakable_kern:n \@@_punct_breakable_kern:n
-    \tl_set:Nx \l_@@_off_verb_addon_tl
+    \tl_set:Ne \l_@@_off_verb_addon_tl
       {
         \bool_if:NTF \l_@@_xecglue_bool
           { \keys_set:nn { xeCJK / options } { xCJKecglue = true } }
@@ -8438,7 +8438,7 @@ Copyright and Licence
     \cs_set_eq:NN \@@_shipout_CJKecglue: \CJKecglue
     \cs_set_eq:NN \@@_shipout_check_for_glue: \xeCJK_check_for_glue:
     \cs_set_eq:NN \@@_shipout_boundary:w \xeCJK_CJK_and_Boundary:w
-    \cs_set_protected:Npx \xeCJKOffVerbAddon
+    \cs_set_protected:Npe \xeCJKOffVerbAddon
       {
         \@@_reset_char_class:n { FullLeft }
         \@@_reset_char_class:n { FullRight }
@@ -8486,7 +8486,7 @@ Copyright and Licence
           { \use:c { xeCJK/verb/\CJK@family/\curr@fontshape/\f@size } }
       }
       {
-        \tl_set:Nx \l_@@_current_coor_tl { \CJK@family/\curr@fontshape }
+        \tl_set:Ne \l_@@_current_coor_tl { \CJK@family/\curr@fontshape }
         \prop_get:NoNTF \g_@@_scale_family_prop
           \l_@@_current_coor_tl \l_xeCJK_family_tl
           {
@@ -8519,7 +8519,7 @@ Copyright and Licence
           { \dim_to_fp:n {#1} }
       }
       {
-        \tl_const:cx { xeCJK/verb/\CJK@family/\curr@fontshape/\f@size }
+        \tl_const:ce { xeCJK/verb/\CJK@family/\curr@fontshape/\f@size }
           { \skip_use:N \l_@@_verb_exspace_skip }
       }
   }
@@ -8532,7 +8532,7 @@ Copyright and Licence
 \cs_new_protected:Npn \@@_set_verb_scale:nn #1#2
   {
     \fp_set:Nn \l_@@_scale_factor_fp { #1 / #2 }
-    \@@_warning:nxx { scale-factor }
+    \@@_warning:nee { scale-factor }
       { \fp_eval:n { trunc ( \l_@@_scale_factor_fp , 4 ) } }
       { \fp_eval:n {  ceil ( #2 / #1 , 4 ) } }
     \xeCJK_add_font_features:Nne \c_true_bool
@@ -8569,7 +8569,7 @@ Copyright and Licence
       {
         \int_compare:nNnTF { \tex_XeTeXfonttype:D \tex_font:D } = \c_zero_int
           {
-            \tl_set:Nx \l_@@_visible_space_tl
+            \tl_set:Ne \l_@@_visible_space_tl
               {
                 \str_if_eq:eeTF { \f@family } { \ttdefault }
                     { \c_catcode_other_space_tl }
@@ -8614,7 +8614,7 @@ Copyright and Licence
     \group_begin:
       \exp_args:No \@@_set_visible_space_size:n
         { \dim_use:N \tex_fontdimen:D 2 ~ \tex_font:D }
-      \cs_new_protected:Npx #1
+      \cs_new_protected:Npe #1
         { \group_begin: \tex_the:D \tex_font:D ^^^^2423 \group_end: }
     \group_end:
   }
@@ -8659,7 +8659,7 @@ Copyright and Licence
     LocalConfig / unknown .code:n =
       {
         \bool_gset_true:N \g_@@_config_bool
-        \tl_gset:Nx \g_@@_config_name_tl { xeCJK - \l_keys_value_tl }
+        \tl_gset:Ne \g_@@_config_name_tl { xeCJK - \l_keys_value_tl }
       } ,
     LocalConfig        .default:n = { true }
   }
@@ -8675,11 +8675,11 @@ Copyright and Licence
 \keys_define:nn { xeCJK / options }
   {
     CJKnumber         .code:n =
-      { \@@_warning:nxx { option-deprecated } { \l_keys_key_str } { CJKnumb } } ,
+      { \@@_warning:nee { option-deprecated } { \l_keys_key_str } { CJKnumb } } ,
     indentfirst       .code:n =
-      { \@@_warning:nxx { option-deprecated } { \l_keys_key_str } { indentfirst } } ,
+      { \@@_warning:nee { option-deprecated } { \l_keys_key_str } { indentfirst } } ,
     normalindentfirst .code:n =
-      { \@@_warning:nxx { option-deprecated } { \l_keys_key_str } { } }
+      { \@@_warning:nee { option-deprecated } { \l_keys_key_str } { } }
   }
 \@@_msg_new:nn { option-deprecated }
   {
@@ -8713,7 +8713,7 @@ Copyright and Licence
     unknown .code:n =
       {
         \xeCJK_if_package_loaded:nTF { fontspec }
-          { \@@_error:nx { key-unknown } { \l_keys_key_str } }
+          { \@@_error:ne { key-unknown } { \l_keys_key_str } }
           { \PassOptionsToPackage { \l_keys_key_str } { fontspec } }
       }
   }
@@ -8790,7 +8790,7 @@ Copyright and Licence
 % \begin{variable}{\c_@@_encoding_tl}
 % 保存 \pkg{fontspec} 声明字体时使用的字体编码。
 %    \begin{macrocode}
-\tl_const:Nx \c_@@_encoding_tl { \g_fontspec_encoding_tl }
+\tl_const:Ne \c_@@_encoding_tl { \g_fontspec_encoding_tl }
 %    \end{macrocode}
 % \end{variable}
 %
@@ -8801,7 +8801,7 @@ Copyright and Licence
 \keys_define:nn { xeCJK / options }
   {
     LocalConfig .code:n =
-      { \@@_warning:nx { option-invalid } { \l_keys_key_str } }
+      { \@@_warning:ne { option-invalid } { \l_keys_key_str } }
   }
 \@@_msg_new:nn { option-invalid }
   {
@@ -8821,7 +8821,7 @@ Copyright and Licence
   { \tl_new:N \CJKttdefault \tl_gset:Nn \CJKttdefault { tt } }
 \tl_new:N \l_@@_family_default_init_tl
 \cs_new_eq:NN \@@_family_default_wrap:n \use:n
-\tl_set:Nx \l_@@_family_default_init_tl
+\tl_set:Ne \l_@@_family_default_init_tl
   {
     \exp_not:N \@@_family_default_wrap:n
       {
@@ -9017,23 +9017,23 @@ Copyright and Licence
       {
         \exp_args:No \tl_if_head_eq_meaning:nNTF {#2} \scan_stop:
           {
-            \cs_gset_protected:Npx #1
+            \cs_gset_protected:Npe #1
               { \tl_tail:N #2 }
           }
           {
             \cs_if_eq:NNTF #1 \ensuremath
               {
-                \cs_gset_protected:Npx #1
+                \cs_gset_protected:Npe #1
                   { \exp_not:o {#2} }
               }
               {
-                \@@_warning:nxx { robust-failure }
+                \@@_warning:nee { robust-failure }
                   { \token_to_str:N #1 } { \token_to_meaning:N #2 }
               }
           }
       }
       {
-        \@@_warning:nxx { robust-failure }
+        \@@_warning:nee { robust-failure }
           { \token_to_str:N #1 } { \token_to_meaning:N #2 }
       }
   }
@@ -9312,7 +9312,7 @@ Copyright and Licence
       { #1 \token_to_str:N #2 }
       { #1 - #2 }
   }
-\cs_new_protected:Npx \@@_patch_ambiguous_char:nNn #1#2#3
+\cs_new_protected:Npe \@@_patch_ambiguous_char:nNn #1#2#3
   {
     \exp_not:N \exp_args:Ne
     \exp_not:N \@@_patch_ambiguous_char:nn
@@ -9334,13 +9334,13 @@ Copyright and Licence
       {
         \prop_gput:Nne \g_@@_ambiguous_slot_prop {#2}
           { \int_eval:n {#1} }
-        \cs_set_protected:Npx #1
+        \cs_set_protected:Npe #1
           { \@@_ambiguous_char:n { \tex_Uchar:D #1 } }
       }
       {
         \prop_gput:Nne \g_@@_ambiguous_slot_prop {#2}
           { \int_eval:n { \exp_after:wN ` #1 } }
-        \cs_set_protected:Npx #1
+        \cs_set_protected:Npe #1
           { \@@_ambiguous_char:n { \exp_not:o {#1} } }
       }
   }
@@ -9545,7 +9545,7 @@ Copyright and Licence
       }
     \cs_new_protected:Npn \@@_save_um_char:
       {
-        \cs_set_protected:Npx \@@_restore_um_char:
+        \cs_set_protected:Npe \@@_restore_um_char:
           {
             \prop_map_function:NN
               \c_@@_um_ambiguous_char_prop
@@ -9956,7 +9956,7 @@ Copyright and Licence
         \dim_compare:nNnTF \tex_lastkern:D = { - \l_@@_tmp_dim }
           {
             \tex_unkern:D
-            \cs_set_protected:Npx \xeCJK_ulem_left_node:
+            \cs_set_protected:Npe \xeCJK_ulem_left_node:
               {
                 \tex_kern:D - \dim_use:N \l_@@_tmp_dim \exp_stop_f:
                 \tex_kern:D   \dim_use:N \l_@@_tmp_dim \exp_stop_f:
@@ -10027,7 +10027,7 @@ Copyright and Licence
             \tex_kern:D - #1 \exp_stop_f:
             \tex_kern:D   #1 \exp_stop_f:
           }
-        \tl_gset:Nx \UL@spfactor { \int_use:N \tex_spacefactor:D }
+        \tl_gset:Ne \UL@spfactor { \int_use:N \tex_spacefactor:D }
       }
       {
         \tex_kern:D #1 \exp_stop_f:
@@ -10302,15 +10302,15 @@ Copyright and Licence
 \tl_new:N \g_@@_ulem_saved_CJK_fam_tl
 \cs_new_protected:Npn \@@_ulem_save_font_state:
   {
-    \tl_gset:Nx \g_@@_ulem_saved_series_tl { \f@series }
-    \tl_gset:Nx \g_@@_ulem_saved_shape_tl  { \f@shape }
+    \tl_gset:Ne \g_@@_ulem_saved_series_tl { \f@series }
+    \tl_gset:Ne \g_@@_ulem_saved_shape_tl  { \f@shape }
     \tl_gset_eq:NN \g_@@_ulem_saved_CJK_family_tl \l_xeCJK_family_tl
     \tl_gset_eq:NN \g_@@_ulem_saved_CJK_fam_tl \CJK@family
   }
 \cs_new_protected:Npn \@@_ulem_restore_font_state:
   {
-    \tl_set:Nx \f@series { \g_@@_ulem_saved_series_tl }
-    \tl_set:Nx \f@shape  { \g_@@_ulem_saved_shape_tl  }
+    \tl_set:Ne \f@series { \g_@@_ulem_saved_series_tl }
+    \tl_set:Ne \f@shape  { \g_@@_ulem_saved_shape_tl  }
     \tl_set_eq:NN \l_xeCJK_family_tl \g_@@_ulem_saved_CJK_family_tl
     \tl_set_eq:NN \CJK@family \g_@@_ulem_saved_CJK_fam_tl
   }
@@ -10644,7 +10644,7 @@ Copyright and Licence
       { \skip_horizontal:n {#1} }
   }
 \cs_new_protected:Npn \xeCJK_make_group_tag:
-  { \tl_set:Nx \l_@@_group_tag_tl { \c_@@_group_tag_tl } }
+  { \tl_set:Ne \l_@@_group_tag_tl { \c_@@_group_tag_tl } }
 \tl_new:N \l_@@_group_tag_tl
 \tl_const:Nn \c_@@_group_tag_tl
   {
@@ -11325,9 +11325,9 @@ Copyright and Licence
 %    \begin{macrocode}
 \cs_new_protected:Npn \@@_backup_inter_class_toks:n #1
   {
-    \tl_set:Nx \l_@@_tmp_tl
+    \tl_set:Ne \l_@@_tmp_tl
       { \xeCJK_get_inter_class_toks:nn { Boundary } {#1} }
-    \tl_put_right:Nx \l_@@_restore_listings_toks_tl
+    \tl_put_right:Ne \l_@@_restore_listings_toks_tl
       {
         \xeCJK_inter_class_toks:nnn { Boundary } {#1}
           {
@@ -11684,7 +11684,7 @@ Copyright and Licence
 % \begin{macro}{\@@_listings_escape_backslash:}
 % \tn{catcode} 为 $12$ 的 |\| 需要双写转义。
 %    \begin{macrocode}
-\cs_new_protected:Npx \@@_listings_escape_backslash:
+\cs_new_protected:Npe \@@_listings_escape_backslash:
   {
     \tl_replace_all:Nnn \exp_not:N \l_@@_tmp_tl
       { \c_backslash_str }
@@ -11742,7 +11742,7 @@ Copyright and Licence
 %    \begin{macrocode}
 \clist_new:N \g_@@_encname_clist
 \tl_if_exist:NT \UTFencname
-  { \clist_gput_right:Nx \g_@@_encname_clist { \UTFencname } }
+  { \clist_gput_right:Ne \g_@@_encname_clist { \UTFencname } }
 \DeclareOption*
   { \clist_gput_right:No \g_@@_encname_clist \CurrentOption }
 \ProcessOptions \scan_stop:
@@ -11760,7 +11760,7 @@ Copyright and Licence
     \clist_get:NNF \g_@@_encname_clist \UTFencname
       {
         \cs_if_exist:NTF \UnicodeEncodingName
-          { \tl_set:Nx \UTFencname { \UnicodeEncodingName } }
+          { \tl_set:Ne \UTFencname { \UnicodeEncodingName } }
           {
             \sys_if_engine_xetex:TF
               { \tl_set:Nn \UTFencname { EU1 } }
@@ -11786,7 +11786,7 @@ Copyright and Licence
 %    \begin{macrocode}
 \RenewDocumentCommand \ReloadXunicode { m }
   {
-    \clist_set:Nx \l_@@_encname_clist {#1}
+    \clist_set:Ne \l_@@_encname_clist {#1}
     \@@_reload:N \l_@@_encname_clist
   }
 \cs_new_protected:Npn \@@_reload:N #1
@@ -11858,16 +11858,16 @@ Copyright and Licence
     \cs_if_exist:cTF {#1}
       {
         \cs_new_eq:cc { keepmathUTF #1 } {#1}
-        \cs_gset_protected:cpx {#1}
+        \cs_gset_protected:cpe {#1}
           {
             \exp_not:N \mode_if_math:TF
               { \exp_not:c { keepmathUTF #1 } }
               { \exp_not:c { text #1 } }
           }
-        \tl_put_right:Nx \l_@@_hyperref_hook_tl
+        \tl_put_right:Ne \l_@@_hyperref_hook_tl
           { \cs_set_eq:NN \exp_not:c {#1} \exp_not:c { text #1 } }
       }
-      { \cs_new:cpx {#1} { \exp_not:c { text #1 } } }
+      { \cs_new:cpe {#1} { \exp_not:c { text #1 } } }
   }
 \tl_new:N \l_@@_hyperref_hook_tl
 \AtBeginDocument
@@ -11919,9 +11919,9 @@ Copyright and Licence
 %
 % \begin{macro}{\@@_composite_cs:Nnn,\@@_composite_cs:nnn}
 %    \begin{macrocode}
-\cs_new:Npx \@@_composite_cs:Nnn #1#2#3
+\cs_new:Npe \@@_composite_cs:Nnn #1#2#3
   { \c_backslash_str #2 \exp_not:N \token_to_str:N #1 - \exp_not:N \tl_to_str:n {#3} }
-\cs_new:Npx \@@_composite_cs:nnn #1#2#3
+\cs_new:Npe \@@_composite_cs:nnn #1#2#3
   { \c_backslash_str #2 #1 - \exp_not:N \tl_to_str:n {#3} }
 %    \end{macrocode}
 % \end{macro}
@@ -12677,7 +12677,7 @@ Copyright and Licence
     \int_compare:nNnTF \l_xunadd_slot_int < \c_zero_int
       { \xunadd@original@is@charx #1 \relax }
       {
-        \cs_set_nopar:Npx \MT@char@ { \int_use:N \l_xunadd_slot_int }
+        \cs_set_nopar:Npe \MT@char@ { \int_use:N \l_xunadd_slot_int }
         \bool_if:NT \l_xunadd_rest_bool { \MT@norestfalse }
       }
   }
@@ -14880,7 +14880,7 @@ int main()
 
 \makeatletter
 \ExplSyntaxOn
-\cs_new_protected:Npx \@@_restore_catcode:
+\cs_new_protected:Npe \@@_restore_catcode:
   { \char_set_catcode:nn { 0 } { \char_value_catcode:n { 0 } } }
 \file_if_exist:nTF { xunicode-commands.tex }
   { \char_set_catcode_comment:n { 0 } }
@@ -14963,12 +14963,12 @@ int main()
 ^^@   {
 ^^@     \prop_get:NnNT \l_@@_command_prop {#1} \l_@@_command_tl
 ^^@       {
-^^@         \iow_now:Nx \g_@@_command_iow
+^^@         \iow_now:Ne \g_@@_command_iow
 ^^@           { \token_to_str:N \UnicodeTextSymbol { "#1 } { \l_@@_command_tl } {#2} }
 ^^@       }
 ^^@     \prop_get:NnNT \l_@@_combine_mark_prop {#1} \l_@@_command_tl
 ^^@       {
-^^@         \iow_now:Nx \g_@@_combine_mark_iow
+^^@         \iow_now:Ne \g_@@_combine_mark_iow
 ^^@           { \token_to_str:N \UnicodeCombineMark { "#1 } { \l_@@_command_tl } {#2} }
 ^^@       }
 ^^@   }
@@ -14976,7 +14976,7 @@ int main()
 ^^@   {
 ^^@     \prop_map_inline:Nn \l_@@_combine_marks_prop
 ^^@       {
-^^@         \iow_now:Nx \g_@@_combine_mark_iow
+^^@         \iow_now:Ne \g_@@_combine_mark_iow
 ^^@           { \token_to_str:N \UnicodeCombineMarks ##1 {##2} }
 ^^@       }
 ^^@   }
@@ -15011,7 +15011,7 @@ int main()
 \DeclareDocumentCommand \UTFTABLE { m m }
   {
     \int_gincr:N \g_@@_table_int
-    \exp_args:Nx \@@_make_table:nnn { UTFTABLE - \int_use:N \g_@@_table_int } {#1} {#2}
+    \exp_args:Ne \@@_make_table:nnn { UTFTABLE - \int_use:N \g_@@_table_int } {#1} {#2}
   }
 \cs_new_protected:Npn \@@_make_table:nnn #1#2#3
   {

--- a/zhnumber/zhnumber.dtx
+++ b/zhnumber/zhnumber.dtx
@@ -1429,7 +1429,7 @@ Copyright and Licence
   \int_step_inline:nn { 10 }
     {
       \tl_new:c { l_@@_ #1 _tl }
-      \tl_build_put_right:Nx \l_@@_kv_tl
+      \tl_build_put_right:Ne \l_@@_kv_tl
         {
             #1 .tl_set:N = \exp_not:c { l_@@_normal_    #1 _tl } ,
            F#1 .tl_set:N = \exp_not:c { l_@@_financial_ #1 _tl } ,
@@ -1440,7 +1440,7 @@ Copyright and Licence
   \clist_map_inline:nn { 0 , 100 , 1000 }
     {
       \tl_new:c { l_@@_ #1 _tl }
-      \tl_build_put_right:Nx \l_@@_kv_tl
+      \tl_build_put_right:Ne \l_@@_kv_tl
         {
            #1 .tl_set:N = \exp_not:c { l_@@_normal_    #1 _tl } ,
           F#1 .tl_set:N = \exp_not:c { l_@@_financial_ #1 _tl } ,
@@ -1452,10 +1452,10 @@ Copyright and Licence
       dot , and , parts , year , month , day , hour , minute
     }
     {
-      \tl_build_put_right:Nx \l_@@_kv_tl
+      \tl_build_put_right:Ne \l_@@_kv_tl
         { #1 .tl_set:N = \exp_not:c { l_@@_ #1 _tl } , }
     }
-  \tl_build_put_right:Nx \l_@@_kv_tl
+  \tl_build_put_right:Ne \l_@@_kv_tl
     {
       -   .tl_set:N = \exp_not:N \l_@@_minus_tl ,
       -0  .tl_set:N = \exp_not:N \l_@@_null_tl ,
@@ -1478,7 +1478,7 @@ Copyright and Licence
     { , #1 .groups:n = { user } }
   \clist_map_inline:Nn \l_@@_tmp_tl
     {
-      \tl_build_put_right:Nx \l_@@_kv_tl
+      \tl_build_put_right:Ne \l_@@_kv_tl
         { \@@_tmp:w #1 \q_stop }
     }
   \tl_build_put_right:Nn \l_@@_kv_tl
@@ -1490,7 +1490,7 @@ Copyright and Licence
   \clist_map_inline:nn
     { mon , tue , wed , thu , fri , sat , sun }
     {
-      \tl_build_put_right:Nx \l_@@_kv_tl
+      \tl_build_put_right:Ne \l_@@_kv_tl
         {
           #1 .tl_set:N = \exp_not:c { l_@@_ #1 _tl } ,
           #1 .groups:n = { user , pos , day } ,
@@ -1498,7 +1498,7 @@ Copyright and Licence
     }
   \int_step_inline:nn { 10 }
     {
-      \tl_build_put_right:Nx \l_@@_kv_tl
+      \tl_build_put_right:Ne \l_@@_kv_tl
         {
           T#1 .tl_set:N = \exp_not:c { l_@@_ganzhi_ #1 _tl } ,
           T#1 .groups:n = { user , pre , tiandi } ,
@@ -1506,7 +1506,7 @@ Copyright and Licence
     }
   \int_step_inline:nn { 12 }
     {
-      \tl_build_put_right:Nx \l_@@_kv_tl
+      \tl_build_put_right:Ne \l_@@_kv_tl
         {
           D#1 .tl_set:N = \exp_not:c { l_@@_dizhi_ #1 _tl } ,
           D#1 .groups:n = { user , pre , tiandi } ,
@@ -1514,7 +1514,7 @@ Copyright and Licence
     }
   \int_step_inline:nn { 60 }
     {
-      \tl_build_put_right:Nx \l_@@_kv_tl
+      \tl_build_put_right:Ne \l_@@_kv_tl
         {
           GZ#1 .tl_set:N = \exp_not:c { l_@@_ganzhi_ #1 _tl } ,
           GZ#1 .groups:n = { user , pos , ganzhi } ,
@@ -1627,7 +1627,7 @@ Copyright and Licence
 \tl_new:N \l_@@_ancient_tl
 \cs_new_protected:Npn \@@_add_reset:nn #1#2
   {
-    \tl_put_right:Nx \l_@@_reset_tl
+    \tl_put_right:Ne \l_@@_reset_tl
       {
         \tl_set:Nn \exp_not:c { l_@@_ #1 _tl }
           { \exp_not:n {#2} }
@@ -1635,12 +1635,12 @@ Copyright and Licence
   }
 \cs_new_protected:Npn \@@_add_reset_simp:nNN #1#2#3
   {
-    \tl_put_right:Nx \l_@@_reset_simp_tl
+    \tl_put_right:Ne \l_@@_reset_simp_tl
       {
         \tl_set:Nn \exp_not:c { l_@@_ #1 _tl }
           { \exp_not:o {#2} }
       }
-    \tl_put_right:Nx \l_@@_reset_trad_tl
+    \tl_put_right:Ne \l_@@_reset_trad_tl
       {
         \tl_set:Nn \exp_not:c { l_@@_ #1 _tl }
           { \exp_not:o {#3} }
@@ -1648,19 +1648,19 @@ Copyright and Licence
   }
 \cs_new_protected:Npn \@@_add_reset_financial:n #1
   {
-    \tl_put_right:Nx \l_@@_set_normal_tl
+    \tl_put_right:Ne \l_@@_set_normal_tl
       {
         \tl_set_eq:NN
           \exp_not:c { l_@@_normal_ #1 _tl }
           \exp_not:c { l_@@_ #1 _tl }
       }
-    \tl_put_right:Nx \l_@@_reset_normal_tl
+    \tl_put_right:Ne \l_@@_reset_normal_tl
       {
         \tl_set_eq:NN
           \exp_not:c { l_@@_ #1 _tl }
           \exp_not:c { l_@@_normal_ #1 _tl }
       }
-    \tl_put_right:Nx \l_@@_reset_financial_tl
+    \tl_put_right:Ne \l_@@_reset_financial_tl
       {
         \tl_set_eq:NN
           \exp_not:c { l_@@_ #1 _tl }
@@ -1669,12 +1669,12 @@ Copyright and Licence
   }
 \cs_new_protected:Npn \@@_add_reset_ancient:nN #1#2
   {
-    \tl_put_right:Nx \l_@@_reset_ancient_tl
+    \tl_put_right:Ne \l_@@_reset_ancient_tl
       {
         \tl_set:Nn \exp_not:c { l_@@_ #1 _tl }
           { \exp_not:o {#2} }
       }
-    \tl_put_right:Nx \l_@@_set_ancient_tl
+    \tl_put_right:Ne \l_@@_set_ancient_tl
       {
         \tl_concat:NNN
           \exp_not:c { l_@@_ #1 _tl }
@@ -1693,7 +1693,7 @@ Copyright and Licence
 %    \begin{macrocode}
 \cs_new_protected:Npn \zhnum_set_week_day:
   {
-    \cs_set_protected:Npx \zhnum_reset_week_day:
+    \cs_set_protected:Npe \zhnum_reset_week_day:
       {
         \@@_set_week_day:nn { mon } { 1 }
         \@@_set_week_day:nn { tue } { 2 }
@@ -1707,7 +1707,7 @@ Copyright and Licence
 \cs_new_eq:NN \zhnum_reset_week_day: \prg_do_nothing:
 \cs_new:Npn \@@_set_week_day:nn #1#2
   {
-    \tl_set:Nx \exp_not:c { l_@@_ #1 _tl }
+    \tl_set:Ne \exp_not:c { l_@@_ #1 _tl }
       {
         \exp_not:N \exp_not:o { \exp_not:N \l_@@_weekday_tl }
         \exp_not:N \exp_not:n { \exp_not:v { l_@@_ #2 _tl } }
@@ -1745,7 +1745,7 @@ Copyright and Licence
       \exp_not:c { l_@@_tiangan_ \zhnum_zero_mod:nn {#1} { 10 } _tl }
       \exp_not:c { l_@@_dizhi_   \zhnum_zero_mod:nn {#1} { 12 } _tl }
   }
-\cs_new_protected:Npx \zhnum_reset_ganzhi:
+\cs_new_protected:Npe \zhnum_reset_ganzhi:
   {
     \tl_set_eq:NN
       \exp_not:c { l_@@_dizhi_ 0 _tl }
@@ -1797,7 +1797,7 @@ Copyright and Licence
       \l_@@_reset_financial_tl
       \l_@@_set_ancient_tl
   }
-\tl_const:Nx \c_@@_set_zero_tl
+\tl_const:Ne \c_@@_set_zero_tl
   {
     \tl_set_eq:NN
       \exp_not:N \l_@@_zero_tl
@@ -1831,7 +1831,7 @@ Copyright and Licence
       { \tl_use:N \l_@@_reset_ancient_tl }
       { \tl_use:N \l_@@_set_ancient_tl }
   }
-\cs_new_protected:Npx \@@_reset_zero:
+\cs_new_protected:Npe \@@_reset_zero:
   {
     \exp_not:n { \bool_if:NT \l_@@_null_bool }
       {
@@ -1881,7 +1881,7 @@ Copyright and Licence
         \group_end:
         \@@_set_cfg_prop:
       }
-      { \msg_error:nnx { zhnumber } { file-not-found } {#1} }
+      { \msg_error:nne { zhnumber } { file-not-found } {#1} }
   }
 \tl_new:N \l_@@_cfg_file_tl
 \cs_new_protected:Npn \@@_update_cfg_prop:N
@@ -1941,7 +1941,7 @@ Copyright and Licence
     \cs_new_eq:NN \zhnum_set_catcode: \prg_do_nothing:
     \cs_new_protected:Npn \zhnum_set_cfg_name:Nn #1#2
       {
-        \str_set:Nx \l_@@_encoding_str {#2}
+        \str_set:Ne \l_@@_encoding_str {#2}
         \str_set_eq:NN #1 \l_@@_encoding_str
       }
   }
@@ -1952,20 +1952,20 @@ Copyright and Licence
           { \zhnum_set_active: }
           { \zhnum_set_other: }
       }
-    \cs_new_protected:Npx \zhnum_set_active:
+    \cs_new_protected:Npe \zhnum_set_active:
       {
         \int_step_function:nnN
           { 128 } { 255 } \char_set_catcode_active:n
       }
-    \cs_new_protected:Npx \zhnum_set_other:
+    \cs_new_protected:Npe \zhnum_set_other:
       {
         \int_step_function:nnN
           { 128 } { 255 } \char_set_catcode_other:n
       }
     \cs_new_protected:Npn \zhnum_set_cfg_name:Nn #1#2
       {
-        \str_set:Nx \l_@@_encoding_str {#2}
-        \str_set:Nx #1
+        \str_set:Ne \l_@@_encoding_str {#2}
+        \str_set:Ne #1
           {
             \l_@@_encoding_str
             \bool_if:NTF \l_@@_active_char_bool
@@ -1984,7 +1984,7 @@ Copyright and Licence
 %    \begin{macrocode}
 \cs_new_protected:Npn \zhnum_set_encoding:n #1
   {
-    \str_set:Nx \l_@@_encoding_str
+    \str_set:Ne \l_@@_encoding_str
       { \str_lowercase:n {#1} }
     \zhnum_load_cfg:o { \l_@@_encoding_str }
   }


### PR DESCRIPTION
## Summary

跟进 l3kernel 变化（latex3/latex3#1271），将 x-type expansion variant 替换为 e-type。

- **xeCJK**: 102 处替换，80/80 测试通过
- **zhnumber**: 29 处替换，3/3 测试通过
- **ctex**: 69 处替换，181/181 测试通过

### 未替换的部分

- **ctex `Npx` 定义体内的 `\exp_args:Nnx`**：e-type `\exp_args` 是 expandable 的（而 x-type 是 protected），在 `\edef` 体内会被提前展开导致崩溃。保持原样。
- **ctex `Npx`/`cpx` 定义本身**：`\cs_new_protected:Npx` → `\cs_new_protected:Npe` 的转换需逐一审查，本次不涉及。
- **xCJK2uni / jiazhu**：无测试保护，不做机械替换。

Closes #679

## Test plan

- [x] `l3build check` xeCJK 80/80
- [x] `l3build check` zhnumber 3/3
- [x] `l3build check` ctex 181/181（含 config-contrib）
- [ ] CI 三平台验证