### PR TITLE
fix(xeCJK): 修复 listings + rulecolor 组合导致 Missing number 错误

### DIFF
--- a/xeCJK/xeCJK.dtx
+++ b/xeCJK/xeCJK.dtx
@@ -300,7 +300,7 @@ Copyright and Licence
 % \changes{v3.10.0}{2026/05/13}{修复 \cs{textcolor} 包裹 \pkg{ulem}
 %   类下划线命令时 CJK 字间距异常的问题（\#830）。}
 %
-% \CheckSum{11378}
+% \CheckSum{11382}
 % \GetFileId{xeCJK.sty}
 %
 % \title{\bfseries\pkg{xeCJK} 宏包}

--- a/xeCJK/xeCJK.dtx
+++ b/xeCJK/xeCJK.dtx
@@ -9654,6 +9654,10 @@ Copyright and Licence
 %   当 color pop 后最后节点为 hlist 时设置 \cs{g_@@_reset_color_pending_bool}，
 %   延迟到 \cs{@@_check_for_glue_skip:} 中处理 \tn{colorbox} 等命令
 %   右侧间距（\#831）。}
+% \changes{v3.10.0}{2026/05/14}{修复颜色补丁在
+%   \cs{g_@@_last_node_tl} 被无关的 \tn{set@color} 清空后
+%   仍尝试重放节点导致 \texttt{Missing number} 错误的问题，
+%   影响 \pkg{listings} 与 \tn{rulecolor} 组合（\#836）。}
 % \changes{v3.10.0}{2026/05/02}{使用 \cs{l_keys_key_str} 和
 %   \cs{l_keys_choice_str} 替代已废弃的 \texttt{\_tl} 版本（\#806）。}
 %
@@ -9678,7 +9682,8 @@ Copyright and Licence
             \xeCJK_if_last_node:TF
               {
                 \@@_orig_set_color:
-                \exp_args:No \xeCJK_make_node:n { \g_@@_last_node_tl }
+                \tl_if_empty:NF \g_@@_last_node_tl
+                  { \exp_args:No \xeCJK_make_node:n { \g_@@_last_node_tl } }
               }
               { \tl_gclear:N \g_@@_last_node_tl \@@_orig_set_color: }
           }
@@ -9691,8 +9696,11 @@ Copyright and Licence
             \xeCJK_if_last_node:TF
               {
                 \@@_orig_reset_color:
-                \exp_args:No \xeCJK_make_node:n { \g_@@_last_node_tl }
-                \bool_gset_true:N \g_@@_glue_check_pending_bool
+                \tl_if_empty:NF \g_@@_last_node_tl
+                  {
+                    \exp_args:No \xeCJK_make_node:n { \g_@@_last_node_tl }
+                    \bool_gset_true:N \g_@@_glue_check_pending_bool
+                  }
               }
               {
                 \@@_if_last_hlist:TF


### PR DESCRIPTION
## Summary

修复 #836：`\lstinline` 与 `rulecolor=\color{blue}` 和 `emphstyle={\color{red}}` 组合使用时，在 CJK 文本之后出现 `Missing number, treated as zero` 错误。

## 根因

1. `rulecolor=\color{blue}` 在 lstinline 的 frame 处理时触发 `\set@color`
2. 此时无 kern pair → 进入 false 分支 → **清空** `\g_@@_last_node_tl`
3. 随后 `\color{red}`（emph 样式）触发 `\set@color`
4. 找到了来自 CJK 文本的 kern pair → 进入 true 分支
5. 但 `\g_@@_last_node_tl` 已在步骤 2 中被清空
6. `\xeCJK_make_node:n {}` 构造出未定义的 `\c__xeCJK__node_dim` → 报错

## 修复

在 `\set@color` 和 `\reset@color` 补丁的 true 分支中，添加 `\tl_if_empty:NF` 守卫，避免用空参数调用 `\xeCJK_make_node:n`。

## Test plan

- [x] MWE 编译通过（之前报 Missing number 错误）
- [x] xeCJK 回归测试 80/80 全部通过