### PR TITLE
fix(xeCJK): 补丁 l3color 后端颜色机制以保持 CJK 间距 (#832)

### DIFF
--- a/xeCJK/testfiles/fntef-nest01.tlg
+++ b/xeCJK/testfiles/fntef-nest01.tlg
@@ -117,9 +117,9 @@ TEST 1: CJKunderline~nesting~CJKunderdot
 ....\hbox(1.06+0.0)x2.78
 .....\special{pdf:bc [0]}
 .....\TU/lmr/m/n/10 .
+.....\special{pdf:ec}
 .....\kern -0.0002
 .....\kern 0.0002
-.....\special{pdf:ec}
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ..\penalty 10000
 ..\TU/FandolSong-Regular.otf(0)/m/n/10 吉
@@ -152,9 +152,9 @@ TEST 1: CJKunderline~nesting~CJKunderdot
 ....\hbox(1.06+0.0)x2.78
 .....\special{pdf:bc [0]}
 .....\TU/lmr/m/n/10 .
+.....\special{pdf:ec}
 .....\kern -0.0002
 .....\kern 0.0002
-.....\special{pdf:ec}
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ..\penalty 10000
 ..\TU/FandolSong-Regular.otf(0)/m/n/10 祥

--- a/xeCJK/testfiles/fntef-space01.tlg
+++ b/xeCJK/testfiles/fntef-space01.tlg
@@ -15,9 +15,9 @@ PASS:~ widths~ match
 ...\hbox(1.06+0.0)x2.78
 ....\special{pdf:bc [0]}
 ....\TU/lmr/m/n/10 .
+....\special{pdf:ec}
 ....\kern -0.0002
 ....\kern 0.0002
-....\special{pdf:ec}
 ...\glue 0.0 plus 1.0fil minus 1.0fil
 .\penalty 10000
 .\TU/FandolSong-Regular.otf(0)/m/n/10 文
@@ -29,9 +29,9 @@ PASS:~ widths~ match
 ...\hbox(1.06+0.0)x2.78
 ....\special{pdf:bc [0]}
 ....\TU/lmr/m/n/10 .
+....\special{pdf:ec}
 ....\kern -0.0002
 ....\kern 0.0002
-....\special{pdf:ec}
 ...\glue 0.0 plus 1.0fil minus 1.0fil
 .\penalty 10000
 .\TU/FandolSong-Regular.otf(0)/m/n/10 字
@@ -43,9 +43,9 @@ PASS:~ widths~ match
 ...\hbox(1.06+0.0)x2.78
 ....\special{pdf:bc [0]}
 ....\TU/lmr/m/n/10 .
+....\special{pdf:ec}
 ....\kern -0.0002
 ....\kern 0.0002
-....\special{pdf:ec}
 ...\glue 0.0 plus 1.0fil minus 1.0fil
 .\penalty 10000
 .\TU/FandolSong-Regular.otf(0)/b/n/10 文
@@ -57,9 +57,9 @@ PASS:~ widths~ match
 ...\hbox(1.06+0.0)x2.78
 ....\special{pdf:bc [0]}
 ....\TU/lmr/m/n/10 .
+....\special{pdf:ec}
 ....\kern -0.0002
 ....\kern 0.0002
-....\special{pdf:ec}
 ...\glue 0.0 plus 1.0fil minus 1.0fil
 .\penalty 10000
 .\TU/FandolSong-Regular.otf(0)/b/n/10 字
@@ -71,9 +71,9 @@ PASS:~ widths~ match
 ...\hbox(1.06+0.0)x2.78
 ....\special{pdf:bc [0]}
 ....\TU/lmr/m/n/10 .
+....\special{pdf:ec}
 ....\kern -0.0002
 ....\kern 0.0002
-....\special{pdf:ec}
 ...\glue 0.0 plus 1.0fil minus 1.0fil
 .\penalty 10000
 .\TU/FandolSong-Regular.otf(0)/m/n/10 文
@@ -85,9 +85,9 @@ PASS:~ widths~ match
 ...\hbox(1.06+0.0)x2.78
 ....\special{pdf:bc [0]}
 ....\TU/lmr/m/n/10 .
+....\special{pdf:ec}
 ....\kern -0.0002
 ....\kern 0.0002
-....\special{pdf:ec}
 ...\glue 0.0 plus 1.0fil minus 1.0fil
 .\penalty 10000
 .\TU/FandolSong-Regular.otf(0)/m/n/10 字

--- a/xeCJK/testfiles/fntef-space02.tlg
+++ b/xeCJK/testfiles/fntef-space02.tlg
@@ -14,9 +14,9 @@ plain+quad~ width:~ 50.0pt
 ...\hbox(1.06+0.0)x2.78
 ....\special{pdf:bc [0]}
 ....\TU/lmr/m/n/10 .
+....\special{pdf:ec}
 ....\kern -0.0002
 ....\kern 0.0002
-....\special{pdf:ec}
 ...\glue 0.0 plus 1.0fil minus 1.0fil
 .\penalty 10000
 .\TU/FandolSong-Regular.otf(0)/m/n/10 文
@@ -28,9 +28,9 @@ plain+quad~ width:~ 50.0pt
 ...\hbox(1.06+0.0)x2.78
 ....\special{pdf:bc [0]}
 ....\TU/lmr/m/n/10 .
+....\special{pdf:ec}
 ....\kern -0.0002
 ....\kern 0.0002
-....\special{pdf:ec}
 ...\glue 0.0 plus 1.0fil minus 1.0fil
 .\penalty 10000
 .\TU/FandolSong-Regular.otf(0)/m/n/10 字

--- a/xeCJK/testfiles/l3color01.lvt
+++ b/xeCJK/testfiles/l3color01.lvt
@@ -1,0 +1,29 @@
+\input{regression-test}
+
+\documentclass{article}
+
+\usepackage{xeCJK}
+\setCJKmainfont{FandolSong-Regular.otf}
+
+\ExplSyntaxOn
+\cs_new_protected:Npn \TestColorSelect #1
+  {
+    \color_group_begin:
+    \color_select:n {#1}
+  }
+\cs_new_eq:NN \TestColorEnd \color_group_end:
+\ExplSyntaxOff
+
+\begin{document}
+
+\START
+
+\BEGINTEST{l3color~CJK~ecglue~(issue~832)}
+\loggingoutput
+前文\TestColorSelect{red}彩色\TestColorEnd 后文
+\clearpage
+\ENDTEST
+
+\END
+
+\end{document}

--- a/xeCJK/testfiles/l3color01.tlg
+++ b/xeCJK/testfiles/l3color01.tlg
@@ -1,0 +1,51 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+============================================================
+TEST 1: l3color~CJK~ecglue~(issue~832)
+============================================================
+Completed box being shipped out [1]
+\vbox(633.0+0.0)x407.0
+.\glue 16.0
+.\vbox(617.0+0.0)x345.0, shifted 62.0
+..\vbox(12.0+0.0)x345.0, glue set 12.0fil
+...\glue 0.0 plus 1.0fil
+...\hbox(0.0+0.0)x345.0
+....\hbox(0.0+0.0)x345.0
+..\glue 25.0
+..\glue(\lineskip) 0.0
+..\vbox(550.0+0.0)x345.0, glue set 539.94232fil
+...\write-{}
+...\glue(\topskip) 2.29
+...\hbox(7.71+1.75998)x345.0, glue set 270.0fil
+....\hbox(0.0+0.0)x15.0
+....\TU/FandolSong-Regular.otf(0)/m/n/10 前
+....\glue 0.0 plus 0.96002
+....\TU/FandolSong-Regular.otf(0)/m/n/10 文
+....\special{pdf:bc [1.0 0.0 0.0]}
+....\glue 0.0 plus 0.96002
+....\TU/FandolSong-Regular.otf(0)/m/n/10 彩
+....\glue 0.0 plus 0.96002
+....\TU/FandolSong-Regular.otf(0)/m/n/10 色
+....\special{pdf:ec}
+....\glue 0.0 plus 0.96002
+....\TU/FandolSong-Regular.otf(0)/m/n/10 后
+....\glue 0.0 plus 0.96002
+....\TU/FandolSong-Regular.otf(0)/m/n/10 文
+....\kern -0.00018
+....\kern 0.00018
+....\penalty 10000
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
+...\glue -1.75998
+...\glue 0.0 plus 1.0fil
+...\glue 0.0
+...\glue 0.0 plus 0.0001fil
+..\glue(\baselineskip) 23.34
+..\hbox(6.66+0.0)x345.0
+...\hbox(6.66+0.0)x345.0, glue set 170.0fil
+....\glue 0.0 plus 1.0fil
+....\TU/lmr/m/n/10 1
+....\kern -0.0002
+....\kern 0.0002
+....\glue 0.0 plus 1.0fil
+============================================================

--- a/xeCJK/xeCJK.dtx
+++ b/xeCJK/xeCJK.dtx
@@ -9718,6 +9718,61 @@ Copyright and Licence
 \@@_package_hook:nn { xcolor } { \@@_patch_set_color: }
 %    \end{macrocode}
 %
+% \changes{v3.10.0}{2026/05/14}{补丁 \pkg{l3color} 后端的
+%   \cs{__color_select:N} 和 \cs{__color_backend_reset:}，
+%   使 \pkg{l3color} 接口的颜色切换也能正确保持 xeCJK 间距（\#832）。}
+%
+% \pkg{l3color}（\pkg{expl3} 内置）的颜色机制使用独立的后端代码路径，
+% 不经过 \tn{set@color}/\tn{reset@color}。
+% \cs{__color_select:N} 负责颜色推入（调用后端 select 并注册
+% aftergroup reset），\cs{__color_backend_reset:} 负责颜色弹出。
+% 此处对这两个函数施加与上面相同的 kern 对保护。
+%    \begin{macrocode}
+\cs_new_protected:Npn \@@_patch_l3color:
+  {
+    \cs_if_exist:NF \@@_orig_color_select:N
+      {
+        \cs_set_eq:NN \@@_orig_color_select:N \__color_select:N
+        \cs_gset_protected:Npn \__color_select:N ##1
+          {
+            \xeCJK_if_last_node:TF
+              {
+                \@@_orig_color_select:N ##1
+                \tl_if_empty:NF \g_@@_last_node_tl
+                  { \exp_args:No \xeCJK_make_node:n { \g_@@_last_node_tl } }
+              }
+              { \tl_gclear:N \g_@@_last_node_tl \@@_orig_color_select:N ##1 }
+          }
+      }
+    \cs_if_exist:NF \@@_orig_color_backend_reset:
+      {
+        \cs_set_eq:NN \@@_orig_color_backend_reset: \__color_backend_reset:
+        \cs_gset_protected:Npn \__color_backend_reset:
+          {
+            \xeCJK_if_last_node:TF
+              {
+                \@@_orig_color_backend_reset:
+                \tl_if_empty:NF \g_@@_last_node_tl
+                  {
+                    \exp_args:No \xeCJK_make_node:n { \g_@@_last_node_tl }
+                    \bool_gset_true:N \g_@@_glue_check_pending_bool
+                  }
+              }
+              {
+                \@@_if_last_hlist:TF
+                  {
+                    \tl_if_empty:NF \g_@@_last_node_tl
+                      { \bool_gset_true:N \g_@@_reset_color_pending_bool }
+                    \@@_orig_color_backend_reset:
+                  }
+                  { \@@_orig_color_backend_reset: }
+              }
+          }
+      }
+  }
+\@@_patch_l3color:
+%    \end{macrocode}
+%
 % \changes{v3.1.0}{2012/11/13}{取消 \tn{cprotect} 的外部宏限制。}
 % 当探测到 \pkg{cprotect} 宏包被引入时，则取消 \tn{cprotect} 宏的 \tn{outer} 定义。
 %    \begin{macrocode}

--- a/xeCJK/xeCJK.dtx
+++ b/xeCJK/xeCJK.dtx
@@ -300,7 +300,7 @@ Copyright and Licence
 % \changes{v3.10.0}{2026/05/13}{修复 \cs{textcolor} 包裹 \pkg{ulem}
 %   类下划线命令时 CJK 字间距异常的问题（\#830）。}
 %
-% \CheckSum{11382}
+% \CheckSum{11425}
 % \GetFileId{xeCJK.sty}
 %
 % \title{\bfseries\pkg{xeCJK} 宏包}


### PR DESCRIPTION
## Summary

- 补丁 `\__color_select:N`（颜色推入）和 `\__color_backend_reset:`（颜色弹出），在 color whatsit 前后保持 xeCJK kern pair 标记
- l3color（expl3 内置）使用独立的后端代码路径，不经过 `\set@color` / `\reset@color`，因此 PR #830 的补丁不覆盖此路径
- 新增 `l3color01` 回归测试，验证 l3color 颜色切换后 CJK 间距正确
- 更新 3 个 fntef 测试参考文件（hbox 内 `pdf:ec` 与 kern pair 顺序变化，不影响渲染）

Closes #832

## Test plan

- [x] `l3build check` 全部 82 个测试通过
- [x] `l3color01` 在旧代码上失败（kern pair 残留在 whatsit 前），在新代码上通过
- [x] fntef 测试变化仅为 hbox 内部节点顺序（零宽 kern 对与 whatsit），不影响视觉输出