### PR TITLE
fix: pre-push hook stash 检测误报

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -9,8 +9,9 @@ if ! command -v l3build &>/dev/null; then
   exit 0
 fi
 
+stash_before=$(git rev-parse --verify refs/stash 2>/dev/null || echo "")
 git stash push -q -- '*.dtx'
-stashed=$?
+stash_after=$(git rev-parse --verify refs/stash 2>/dev/null || echo "")
 
 for dir in ctex xeCJK zhnumber xpinyin jiazhu xCJK2uni zhmetrics; do
   if [ -d "$dir" ] && [ -f "$dir/build.lua" ]; then
@@ -27,7 +28,7 @@ if ! git diff --quiet -- '*.dtx'; then
   mismatch=1
 fi
 
-if [ "$stashed" -eq 0 ]; then
+if [ "$stash_before" != "$stash_after" ]; then
   git stash pop -q || echo "pre-push: warning: failed to restore stashed .dtx changes, run 'git stash pop' manually" >&2
 fi
 


### PR DESCRIPTION
## Summary
- `git stash push -q -- '*.dtx'` 在无可 stash 内容时仍返回 0，导致后续 `git stash pop` 因栈空而失败，打印误导性警告
- 改为比较 stash 前后的 `refs/stash` SHA，仅在确实 stash 了内容时才 pop

## Test plan
- [ ] 在无 `.dtx` 改动时 push，不再出现 stash 警告
- [ ] 在有未提交 `.dtx` 改动时 push，改动被正确保护和恢复