### PR TITLE
feat: 添加 agentic-patrol 巡查工作流，修复字体解压问题

### DIFF
--- a/.claude/skills/patrol/SKILL.md
+++ b/.claude/skills/patrol/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: patrol
+description: 定期巡查仓库，监控 CI 状态、扫描未处理 Issue，自动分发到对应 skill 处理。
+---
+
+# patrol
+
+定期巡查 CTeX-kit 仓库，监控 CI 和 Issue。
+
+> 遵循 `github-comment` 规范。
+
+## 准确性要求（最高优先级）
+
+**禁止凭训练知识推断技术细节。** 所有对外发布的内容必须基于源码验证。
+
+- 涉及命令、选项、默认值、行为机制 → 先 grep/read `.dtx` 文件确认
+- 引用其他 Issue → 先 `gh issue view` 读内容确认相关性
+- 无法从源码确证 → 只说"我们会调查"，不给猜测性技术细节
+
+## 禁止操作
+
+- **禁止合并 PR**（`gh pr merge`）
+- **禁止在 PR 上评论或 review**
+- PR 由人工处理，巡查只关注 Issue 和 CI
+
+## 执行流程
+
+### 1. 检查 CI 状态
+
+```bash
+gh run list --workflow=test.yml --limit=5 --json status,conclusion,event,createdAt,url
+```
+
+关注：
+- 最近是否有失败的 CI
+- `schedule` 触发的周五定时构建是否正常
+
+### 2. 扫描 Issue
+
+```bash
+gh issue list --state=open --limit=20 --json number,title,labels,comments
+```
+
+**跳过已处理的 Issue**：检查评论中是否已有 `github-actions[bot]` 的回复。
+
+### 3. 分发处理
+
+根据 Issue 标签和内容选择对应 skill：
+
+| 类型 | Skill | 后续 |
+|------|-------|------|
+| `bug` 标签 | `bug-analyze` | 分析根因；简单 Bug 用 `implement` 修复 |
+| `enhancement` / 功能需求 | `feature-review` | 评审可行性，等用户确认 |
+| 提问 / 无标签 | `answer-question` | 直接回复 |
+
+每个 Issue 处理完成后，用 `gh issue comment` 发布分析结果。
+
+### 4. CI 失败处理
+
+1. 用 `gh run view --log-failed` 读取失败日志
+2. 用 `bug-analyze` 思路定位根因
+3. 简单问题直接修复（本环境有完整 TeX Live）
+4. 复杂问题开 Issue 说明
+
+### 5. 修复环境
+
+本环境已安装 TeX Live 和 Noto CJK 字体，可运行编译和测试：
+
+```bash
+cd <project> && l3build check -q -H
+cd <project> && l3build save <test-name>
+```
+
+环境变量已配置：`diffext=.diff`，`diffexe="git diff --no-index --text --"`
+
+修复分支命名：`fix/patrol/{desc}` 或 `feat/patrol/{desc}`
+
+**修复后必须**：
+- 运行 `l3build check` 确认测试通过
+- 开 PR（绝不合并）
+- 在 Issue 中评论修复进展

--- a/.claude/skills/patrol/SKILL.md
+++ b/.claude/skills/patrol/SKILL.md
@@ -62,14 +62,26 @@ gh issue list --state=open --limit=20 --json number,title,labels,comments,stateR
 
 每个 Issue 处理完成后，用 `gh issue comment` 发布分析结果。
 
-### 4. CI 失败处理
+### 4. 自动修复边界
+
+**可以自动修复**：
+- 测试基线更新：上游 TeX Live 变化导致 `.tlg` 输出变化，`l3build save` 即可
+- Checksum 不匹配：`l3build checksum` 即可
+- 单文件 `.dtx` 改动，且本地 `l3build check` 能复现和验证
+
+**不自动修复**（开 Issue 说明，等人工介入）：
+- 涉及宏逻辑变更（影响用户可见行为）
+- 需要设计决策（多种修复路径）
+- 跨多个子项目的改动
+
+### 5. CI 失败处理
 
 1. 用 `gh run view --log-failed` 读取失败日志
 2. 用 `bug-analyze` 思路定位根因
-3. 简单问题直接修复（本环境有完整 TeX Live）
-4. 复杂问题开 Issue 说明
+3. 符合自动修复标准的问题直接修复（本环境有完整 TeX Live）
+4. 不符合的开 Issue 说明
 
-### 5. 修复环境
+### 6. 修复环境
 
 本环境已安装 TeX Live 和 Noto CJK 字体，可运行编译和测试：
 

--- a/.claude/skills/patrol/SKILL.md
+++ b/.claude/skills/patrol/SKILL.md
@@ -38,10 +38,17 @@ gh run list --workflow=test.yml --limit=5 --json status,conclusion,event,created
 ### 2. 扫描 Issue
 
 ```bash
-gh issue list --state=open --limit=20 --json number,title,labels,comments
+gh issue list --state=open --limit=20 --json number,title,labels,comments,stateReason
 ```
 
-**跳过已处理的 Issue**：检查评论中是否已有 `github-actions[bot]` 的回复。
+**判断是否需要处理**：
+
+对每个 Issue，用 `gh issue view <number> --json comments` 获取完整评论列表，检查最后一条评论的作者：
+
+- **最后一条评论来自 `github-actions[bot]`** → 跳过（bot 已回复，无新用户活动）
+- **最后一条评论来自用户**（非 bot）→ 需要处理（用户在 bot 回复后追问或补充了信息）
+- **无评论** → 需要处理（新 Issue）
+- **`stateReason` 为 `reopened`** → 需要处理（即使 bot 之前回复过，重新打开意味着问题未解决）
 
 ### 3. 分发处理
 

--- a/.github/workflows/agentic-patrol.yml
+++ b/.github/workflows/agentic-patrol.yml
@@ -14,7 +14,6 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
-  id-token: write
 
 jobs:
   patrol:
@@ -61,6 +60,7 @@ jobs:
     - name: Run Patrol
       id: patrol
       timeout-minutes: 60
+      # claude-code-action v0.0.19 (pinned by commit hash)
       uses: anthropics/claude-code-action@e7b588b6eaa5263c2e7c6c7b34a29e190d32ee68
       env:
         ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
@@ -78,7 +78,7 @@ jobs:
           本环境已安装完整 TeX Live 和 Noto CJK 字体，可运行 l3build check/save 等命令。
           l3build 测试所需环境变量已配置（diffext=.diff, diffexe="git diff --no-index --text --"）。
         claude_args: |
-          --model opus --allowedTools "Bash,Read,Write,Edit,Glob,Grep,Task,Skill"
+          --model opus --allowedTools "Bash,Read,Write,Edit,Glob,Grep,Task,TodoWrite,Agent,Skill"
           --json-schema '{"type":"object","properties":{"description":{"type":"string","description":"巡查结果摘要"},"ci_status":{"type":"string","enum":["pass","fail","unknown"],"description":"CI 整体状态"},"issues_processed":{"type":"integer","description":"处理的 Issue 数"},"prs_created":{"type":"integer","description":"创建的 PR 数"},"actions_taken":{"type":"array","items":{"type":"string"},"description":"本次巡查采取的操作"}},"required":["description","ci_status","issues_processed"]}'
 
     - name: Output Result

--- a/.github/workflows/agentic-patrol.yml
+++ b/.github/workflows/agentic-patrol.yml
@@ -31,6 +31,7 @@ jobs:
       run: |
         git config user.name "github-actions[bot]"
         git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git config core.hooksPath .githooks
 
     - name: Install TeX Live
       timeout-minutes: 30

--- a/.github/workflows/agentic-patrol.yml
+++ b/.github/workflows/agentic-patrol.yml
@@ -45,7 +45,8 @@ jobs:
       run: |
         curl -LO ${{ env.NOTO_SANS_URL }}
         curl -LO ${{ env.NOTO_SERIF_URL }}
-        unzip -ojd /usr/share/fonts/truetype "*OTC.zip" "*.ttc"
+        for f in *OTC.zip; do unzip -ojd /usr/share/fonts/truetype "$f" "*.ttc"; done
+        fc-cache -f
 
     - name: Install Claude Code CLI
       id: setup_claude
@@ -59,6 +60,7 @@ jobs:
 
     - name: Run Patrol
       id: patrol
+      timeout-minutes: 60
       uses: anthropics/claude-code-action@e7b588b6eaa5263c2e7c6c7b34a29e190d32ee68
       env:
         ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
@@ -81,17 +83,21 @@ jobs:
 
     - name: Output Result
       if: always()
+      env:
+        STRUCTURED_OUTPUT: ${{ steps.patrol.outputs.structured_output }}
       run: |
         echo "## Patrol Result" >> $GITHUB_STEP_SUMMARY
         echo '```json' >> $GITHUB_STEP_SUMMARY
-        echo '${{ steps.patrol.outputs.structured_output }}' >> $GITHUB_STEP_SUMMARY
+        echo "$STRUCTURED_OUTPUT" >> $GITHUB_STEP_SUMMARY
         echo '```' >> $GITHUB_STEP_SUMMARY
 
     - name: Parse Patrol Output
       if: always()
       id: parse
+      env:
+        STRUCTURED_OUTPUT: ${{ steps.patrol.outputs.structured_output }}
+        JOB_STATUS: ${{ job.status }}
       run: |
-        STRUCTURED_OUTPUT='${{ steps.patrol.outputs.structured_output }}'
         if [ -n "$STRUCTURED_OUTPUT" ] && [ "$STRUCTURED_OUTPUT" != "null" ]; then
           DESCRIPTION=$(echo "$STRUCTURED_OUTPUT" | jq -r '.description // "巡查完成"')
           CI_STATUS=$(echo "$STRUCTURED_OUTPUT" | jq -r '.ci_status // "unknown"')
@@ -107,9 +113,12 @@ jobs:
           TITLE="巡查完成"
           DESCRIPTION="未能获取结构化输出"
           STATUS="warning"
+          ISSUES=0
+          PRS=0
+          CI_STATUS="unknown"
         fi
 
-        if [ "${{ job.status }}" != "success" ]; then
+        if [ "$JOB_STATUS" != "success" ]; then
           STATUS="warning"
           DESCRIPTION="GitHub Action 执行失败"
         fi

--- a/.github/workflows/agentic-patrol.yml
+++ b/.github/workflows/agentic-patrol.yml
@@ -1,0 +1,153 @@
+name: Agentic Patrol
+
+on:
+  schedule:
+    # 每 4 小时巡查一次
+    - cron: '7 */4 * * *'
+  workflow_dispatch:
+
+env:
+  NOTO_SANS_URL: https://github.com/notofonts/noto-cjk/releases/download/Sans2.004/03_NotoSansCJK-OTC.zip
+  NOTO_SERIF_URL: https://github.com/notofonts/noto-cjk/releases/download/Serif2.002/04_NotoSerifCJKOTC.zip
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  id-token: write
+
+jobs:
+  patrol:
+    runs-on: ubuntu-latest
+    env:
+      diffext: .diff
+      diffexe: git diff --no-index --text --
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+        token: ${{ secrets.PAT_TOKEN || github.token }}
+
+    - name: Configure git
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+    - name: Install TeX Live
+      timeout-minutes: 30
+      uses: TeX-Live/setup-texlive-action@v4
+      with:
+        package-file: .github/tl_packages
+        repository: https://ctan.math.illinois.edu/systems/texlive/tlnet
+        update-all-packages: true
+
+    - name: Install Noto fonts
+      run: |
+        curl -LO ${{ env.NOTO_SANS_URL }}
+        curl -LO ${{ env.NOTO_SERIF_URL }}
+        unzip -ojd /usr/share/fonts/truetype "*OTC.zip" "*.ttc"
+
+    - name: Install Claude Code CLI
+      id: setup_claude
+      run: |
+        CLAUDE_INSTALL_DIR="$RUNNER_TEMP/claude-code"
+        rm -rf "$CLAUDE_INSTALL_DIR"
+        npm install --prefix "$CLAUDE_INSTALL_DIR" @anthropic-ai/claude-code@2.1.80
+        CLAUDE_CODE_PATH="$CLAUDE_INSTALL_DIR/node_modules/.bin/claude"
+        echo "path=$CLAUDE_CODE_PATH" >> $GITHUB_OUTPUT
+        "$CLAUDE_CODE_PATH" --version
+
+    - name: Run Patrol
+      id: patrol
+      uses: anthropics/claude-code-action@e7b588b6eaa5263c2e7c6c7b34a29e190d32ee68
+      env:
+        ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
+        DISABLE_AUTOUPDATER: "1"
+      with:
+        github_token: ${{ secrets.PAT_TOKEN || github.token }}
+        anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+        path_to_claude_code_executable: ${{ steps.setup_claude.outputs.path }}
+        prompt: |
+          仓库: ${{ github.repository }}
+          仓库 URL: https://github.com/${{ github.repository }}
+
+          使用 `patrol` skill 执行仓库定期巡查。
+
+          本环境已安装完整 TeX Live 和 Noto CJK 字体，可运行 l3build check/save 等命令。
+          l3build 测试所需环境变量已配置（diffext=.diff, diffexe="git diff --no-index --text --"）。
+        claude_args: |
+          --model opus --allowedTools "Bash,Read,Write,Edit,Glob,Grep,Task,Skill"
+          --json-schema '{"type":"object","properties":{"description":{"type":"string","description":"巡查结果摘要"},"ci_status":{"type":"string","enum":["pass","fail","unknown"],"description":"CI 整体状态"},"issues_processed":{"type":"integer","description":"处理的 Issue 数"},"prs_created":{"type":"integer","description":"创建的 PR 数"},"actions_taken":{"type":"array","items":{"type":"string"},"description":"本次巡查采取的操作"}},"required":["description","ci_status","issues_processed"]}'
+
+    - name: Output Result
+      if: always()
+      run: |
+        echo "## Patrol Result" >> $GITHUB_STEP_SUMMARY
+        echo '```json' >> $GITHUB_STEP_SUMMARY
+        echo '${{ steps.patrol.outputs.structured_output }}' >> $GITHUB_STEP_SUMMARY
+        echo '```' >> $GITHUB_STEP_SUMMARY
+
+    - name: Parse Patrol Output
+      if: always()
+      id: parse
+      run: |
+        STRUCTURED_OUTPUT='${{ steps.patrol.outputs.structured_output }}'
+        if [ -n "$STRUCTURED_OUTPUT" ] && [ "$STRUCTURED_OUTPUT" != "null" ]; then
+          DESCRIPTION=$(echo "$STRUCTURED_OUTPUT" | jq -r '.description // "巡查完成"')
+          CI_STATUS=$(echo "$STRUCTURED_OUTPUT" | jq -r '.ci_status // "unknown"')
+          ISSUES=$(echo "$STRUCTURED_OUTPUT" | jq -r '.issues_processed // 0')
+          PRS=$(echo "$STRUCTURED_OUTPUT" | jq -r '.prs_created // 0')
+          case "$CI_STATUS" in
+            "fail") STATUS="error" ;;
+            "pass") STATUS="success" ;;
+            *) STATUS="info" ;;
+          esac
+          TITLE="巡查: CI ${CI_STATUS}, ${ISSUES} issues, ${PRS} PRs"
+        else
+          TITLE="巡查完成"
+          DESCRIPTION="未能获取结构化输出"
+          STATUS="warning"
+        fi
+
+        if [ "${{ job.status }}" != "success" ]; then
+          STATUS="warning"
+          DESCRIPTION="GitHub Action 执行失败"
+        fi
+
+        echo "status=${STATUS}" >> $GITHUB_OUTPUT
+        echo "title=${TITLE}" >> $GITHUB_OUTPUT
+        {
+          echo 'description<<EOF'
+          echo "**${{ github.repository }}**"
+          echo "${DESCRIPTION}"
+          echo 'EOF'
+        } >> $GITHUB_OUTPUT
+
+        # 判断是否需要通知（有实质操作时才通知）
+        if [ "$ISSUES" -gt 0 ] || [ "$PRS" -gt 0 ] || [ "$CI_STATUS" = "fail" ] || [ "$STATUS" = "warning" ]; then
+          echo "should_notify=true" >> $GITHUB_OUTPUT
+        else
+          echo "should_notify=false" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Checkout Action
+      if: always() && steps.parse.outputs.should_notify == 'true'
+      uses: actions/checkout@v6
+      with:
+        repository: Lightspeed-Intelligence/agentic-workflow-template
+        ref: main
+        token: ${{ secrets.PAT_TOKEN || github.token }}
+        path: .agentic-actions
+        sparse-checkout: .github/actions
+        sparse-checkout-cone-mode: false
+
+    - name: Notify Feishu
+      if: always() && steps.parse.outputs.should_notify == 'true'
+      uses: ./.agentic-actions/.github/actions/feishu-notify
+      with:
+        webhook_token: ${{ secrets.FEISHU_WEBHOOK_TOKEN }}
+        title: ${{ steps.parse.outputs.title }}
+        description: ${{ steps.parse.outputs.description }}
+        link_text: "🔗 查看运行"
+        link_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        status: ${{ steps.parse.outputs.status }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,8 +93,8 @@ jobs:
         curl -fsSL -o HanaMinB.ttf "$HANAMINB_URL"
         curl -LO "$NOTO_SYMBOLS2_URL"
         sudo mkdir -p /usr/share/fonts/truetype
-        unzip -ojd /usr/share/fonts/truetype "*OTC.zip" "*.ttc"
-        unzip -ojd /usr/share/fonts/truetype "NotoSansSymbols2-*.zip" "*.ttf"
+        for f in *OTC.zip; do unzip -ojd /usr/share/fonts/truetype "$f" "*.ttc"; done
+        for f in NotoSansSymbols2-*.zip; do unzip -ojd /usr/share/fonts/truetype "$f" "*.ttf"; done
         cp HanaMinB.ttf /usr/share/fonts/truetype/
         fc-cache -f
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,7 +82,7 @@ jobs:
       run: |
         curl -LO ${{ env.NOTO_SANS_URL }}
         curl -LO ${{ env.NOTO_SERIF_URL }}
-        unzip -ojd ${{ matrix.font-dir }} "*OTC.zip" "*.ttc"
+        for f in *OTC.zip; do unzip -ojd ${{ matrix.font-dir }} "$f" "*.ttc"; done
 
     - name: Test ctex
       id: test-ctex

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,6 +83,7 @@ jobs:
         curl -LO ${{ env.NOTO_SANS_URL }}
         curl -LO ${{ env.NOTO_SERIF_URL }}
         for f in *OTC.zip; do unzip -ojd ${{ matrix.font-dir }} "$f" "*.ttc"; done
+        fc-cache -f
 
     - name: Test ctex
       id: test-ctex


### PR DESCRIPTION
## Summary
- 将本地 cron 巡查任务（CI 监控 + Issue 处理 + Bug 修复）迁移到 GitHub Actions
- 新增 `agentic-patrol.yml` 工作流，安装完整 TeX Live + Noto 字体，具备编译和测试能力
- 新增 `patrol` skill 负责巡查编排，复用已有 skill（`bug-analyze`、`answer-question`、`feature-review`、`implement`、`github-comment`）
- 每 4 小时定时运行，有实质操作（Issue 处理 / CI 失败 / 创建 PR）时才通知飞书
- **修复 test.yml 和 agentic-patrol.yml 中字体解压 bug**：`unzip` 不接受多个 archive，原来的 glob 写法只解压了 Sans 字体，Serif 被忽略
- 合并后可删除本地 cron 任务

## 与本地 cron 的差异
| 项目 | 本地 cron | agentic-patrol |
|------|-----------|----------------|
| 环境 | 本地机器 | GitHub Actions (ubuntu + TeX Live) |
| 续期 | 需自动续期绕过 7 天限制 | schedule 原生支持 |
| 巡查日志 | 追加到 #812 | 移除，改用 step summary + 飞书通知 |
| Skill 复用 | 无 | 复用 5 个已有 skill |
| 手动触发 | 无 | 支持 workflow_dispatch |

## Test plan
- [ ] workflow_dispatch 手动触发，验证 TeX Live 安装和 Claude 运行
- [ ] 确认 CI 监控和 Issue 扫描逻辑正常
- [ ] 合并后删除本地 cron 任务