### PR TITLE
refactor: 拆分 agentic-ci 为独立工作流

### DIFF
--- a/.github/workflows/agentic-llmdoc-updater.yml
+++ b/.github/workflows/agentic-llmdoc-updater.yml
@@ -1,5 +1,4 @@
-# 本仓库的 CI 配置 - 调用自身的 reusable workflows
-name: Agentic CI
+name: Agentic llmdoc Updater
 
 on:
   schedule:
@@ -12,30 +11,14 @@ on:
         required: false
         type: string
         default: '24 hours ago'
-  pull_request:
-    types: [opened, synchronize, reopened]
 
-# 授予所有 jobs 所需的权限
 permissions:
   contents: write
   issues: write
   pull-requests: write
-  id-token: write
 
 jobs:
-  pr-review:
-    if: github.event_name == 'pull_request'
-    uses: Lightspeed-Intelligence/agentic-workflow-template/.github/workflows/pr-review.yml@main
-    secrets:
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-      ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
-      PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
-      FEISHU_WEBHOOK_TOKEN: ${{ secrets.FEISHU_WEBHOOK_TOKEN }}
-    with:
-      use_feishu_notify: true
-
   prepare-llmdoc:
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     outputs:
       since_period: ${{ steps.check.outputs.since_period }}
@@ -63,7 +46,6 @@ jobs:
           fi
 
   update-llmdoc:
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     needs: prepare-llmdoc
     uses: Lightspeed-Intelligence/agentic-workflow-template/.github/workflows/update-llmdoc.yml@main
     secrets:

--- a/.github/workflows/agentic-pr-review.yml
+++ b/.github/workflows/agentic-pr-review.yml
@@ -1,0 +1,21 @@
+name: Agentic PR Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  pr-review:
+    uses: Lightspeed-Intelligence/agentic-workflow-template/.github/workflows/pr-review.yml@main
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
+      PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
+      FEISHU_WEBHOOK_TOKEN: ${{ secrets.FEISHU_WEBHOOK_TOKEN }}
+    with:
+      use_feishu_notify: true

--- a/.github/workflows/agentic-pr-review.yml
+++ b/.github/workflows/agentic-pr-review.yml
@@ -8,6 +8,7 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
+  id-token: write
 
 jobs:
   pr-review:


### PR DESCRIPTION
## Summary
- 将 `agentic-ci.yml` 拆分为两个职责单一的工作流：
  - `agentic-pr-review.yml`: PR 审查，仅 `pull_request` 事件触发
  - `agentic-llmdoc-updater.yml`: llmdoc 文档更新，每日定时 + `workflow_dispatch`
- 移除了两个工作流都不需要的 `id-token: write` 权限

## Test plan
- [ ] 新 PR 触发时 agentic-pr-review 正常运行
- [ ] workflow_dispatch 手动触发 agentic-llmdoc-updater 正常运行