### PR TITLE
fix: llmdoc updater 补回 id-token: write 权限

### DIFF
--- a/.github/workflows/agentic-llmdoc-updater.yml
+++ b/.github/workflows/agentic-llmdoc-updater.yml
@@ -16,6 +16,7 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
+  id-token: write
 
 jobs:
   prepare-llmdoc:


### PR DESCRIPTION
## Summary
- `agentic-llmdoc-updater.yml` 拆分时遗漏了 `id-token: write` 权限
- reusable workflow 内部的 `claude-code-action` 需要此权限

## Test plan
- [ ] workflow_dispatch 触发 llmdoc updater 不再 startup_failure