### PR TITLE
chore: `zhmetrics-uptex` 迁移到 `l3build` 构建后添加相应的 `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -184,6 +184,9 @@ zhmetrics/zhmCJK-test.tex
 
 zhmetrics-uptex/*.tfm
 zhmetrics-uptex/*.vf
+zhmetrics-uptex/build/**/*.*
+!zhmetrics-uptex/build/**/*.diff
+!zhmetrics-uptex/build/**/*.fc
 zhmetrics-uptex/*.pdf
 zhmetrics-uptex/ctan/*
 zhmetrics-uptex/tds/*


### PR DESCRIPTION
对 e06949dad88f8a0a8914e4252cff146178a425e3 添加相应的 `.gitignore`.