### PR TITLE
fix: 修复 PR review workflow secrets 上下文错误

### DIFF
--- a/.github/workflows/agentic-pr-review.yml
+++ b/.github/workflows/agentic-pr-review.yml
@@ -18,6 +18,8 @@ jobs:
   pr-review:
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
+    env:
+      HAS_FEISHU_TOKEN: ${{ secrets.FEISHU_WEBHOOK_TOKEN != '' }}
 
     steps:
       - name: Checkout repository
@@ -70,8 +72,6 @@ jobs:
       - name: Notify Feishu
         if: always() && env.HAS_FEISHU_TOKEN == 'true'
         uses: actions/checkout@v6
-        env:
-          HAS_FEISHU_TOKEN: ${{ secrets.FEISHU_WEBHOOK_TOKEN != '' }}
         with:
           repository: Lightspeed-Intelligence/agentic-workflow-template
           ref: main
@@ -82,8 +82,6 @@ jobs:
 
       - name: Send Feishu Notification
         if: always() && env.HAS_FEISHU_TOKEN == 'true'
-        env:
-          HAS_FEISHU_TOKEN: ${{ secrets.FEISHU_WEBHOOK_TOKEN != '' }}
         uses: ./.agentic-actions/.github/actions/feishu-notify
         with:
           webhook_token: ${{ secrets.FEISHU_WEBHOOK_TOKEN }}

--- a/.github/workflows/agentic-pr-review.yml
+++ b/.github/workflows/agentic-pr-review.yml
@@ -47,7 +47,7 @@ jobs:
             审查完成后必须调用 `gh pr comment ${{ github.event.pull_request.number }} --body "..."` 发表审查结果。
             注意: 所有代码链接必须使用 https://github.com/${{ github.repository }}/blob/main/... 格式。
           claude_args: |
-            --model opus --allowedTools "Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Read,Glob,Grep,Task,Skill"
+            --model opus --effort max --allowedTools "Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Read,Glob,Grep,Task,Skill"
             --json-schema '{"type":"object","properties":{"description":{"type":"string","description":"审查结论一句话摘要，如：代码良好，发现2个小问题"},"conclusion":{"type":"string","enum":["APPROVE","REQUEST_CHANGES","COMMENT"],"description":"审查结论"},"critical_count":{"type":"number","description":"阻塞问题数量"},"important_count":{"type":"number","description":"重要建议数量"},"suggestion_count":{"type":"number","description":"小问题数量"}},"required":["description","conclusion","critical_count","important_count","suggestion_count"]}'
 
       - name: Output Structured Result

--- a/.github/workflows/agentic-pr-review.yml
+++ b/.github/workflows/agentic-pr-review.yml
@@ -25,6 +25,13 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install pinned Claude Code CLI
+        id: setup_claude
+        run: |
+          CLAUDE_INSTALL_DIR="$RUNNER_TEMP/claude-code-2.1.80"
+          npm install --prefix "$CLAUDE_INSTALL_DIR" @anthropic-ai/claude-code@2.1.80
+          echo "path=$CLAUDE_INSTALL_DIR/node_modules/.bin/claude" >> $GITHUB_OUTPUT
+
       - name: PR Review with Claude
         id: review
         uses: anthropics/claude-code-action@v1
@@ -35,6 +42,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           use_sticky_comment: true
           allowed_non_write_users: "*"
+          path_to_claude_code_executable: ${{ steps.setup_claude.outputs.path }}
           prompt: |
             仓库: ${{ github.repository }}
             仓库 URL: https://github.com/${{ github.repository }}
@@ -47,7 +55,7 @@ jobs:
             审查完成后必须调用 `gh pr comment ${{ github.event.pull_request.number }} --body "..."` 发表审查结果。
             注意: 所有代码链接必须使用 https://github.com/${{ github.repository }}/blob/main/... 格式。
           claude_args: |
-            --model opus --effort max --allowedTools "Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Read,Glob,Grep,Task,Skill"
+            --model opus --allowedTools "Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Read,Glob,Grep,Task,Skill"
             --json-schema '{"type":"object","properties":{"description":{"type":"string","description":"审查结论一句话摘要，如：代码良好，发现2个小问题"},"conclusion":{"type":"string","enum":["APPROVE","REQUEST_CHANGES","COMMENT"],"description":"审查结论"},"critical_count":{"type":"number","description":"阻塞问题数量"},"important_count":{"type":"number","description":"重要建议数量"},"suggestion_count":{"type":"number","description":"小问题数量"}},"required":["description","conclusion","critical_count","important_count","suggestion_count"]}'
 
       - name: Output Structured Result

--- a/.github/workflows/agentic-pr-review.yml
+++ b/.github/workflows/agentic-pr-review.yml
@@ -60,8 +60,10 @@ jobs:
           echo '```' >> $GITHUB_STEP_SUMMARY
 
       - name: Notify Feishu
-        if: always() && secrets.FEISHU_WEBHOOK_TOKEN != ''
+        if: always() && env.HAS_FEISHU_TOKEN == 'true'
         uses: actions/checkout@v6
+        env:
+          HAS_FEISHU_TOKEN: ${{ secrets.FEISHU_WEBHOOK_TOKEN != '' }}
         with:
           repository: Lightspeed-Intelligence/agentic-workflow-template
           ref: main
@@ -71,7 +73,9 @@ jobs:
           sparse-checkout-cone-mode: false
 
       - name: Send Feishu Notification
-        if: always() && secrets.FEISHU_WEBHOOK_TOKEN != ''
+        if: always() && env.HAS_FEISHU_TOKEN == 'true'
+        env:
+          HAS_FEISHU_TOKEN: ${{ secrets.FEISHU_WEBHOOK_TOKEN != '' }}
         uses: ./.agentic-actions/.github/actions/feishu-notify
         with:
           webhook_token: ${{ secrets.FEISHU_WEBHOOK_TOKEN }}


### PR DESCRIPTION
## Summary
- `secrets` 上下文不能在 step 的 `if` 条件中使用（仅 `env`、`github`、`steps` 等可用）
- 改为通过 `env` 变量间接传递 secret 存在性判断
- 经 `actionlint` 验证通过

Fixes: #851 合并后 workflow 实际无法执行飞书通知步骤

## Test plan
- [ ] 本 PR 的 review action 成功运行（验证 workflow 语法正确）
- [ ] 确认飞书通知步骤正常跳过或执行