### PR TITLE
fix: PR review 支持 fork PR 的自动审查

### DIFF
--- a/.github/workflows/agentic-pr-review.yml
+++ b/.github/workflows/agentic-pr-review.yml
@@ -1,7 +1,7 @@
 name: Agentic PR Review
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
 
 concurrency:


### PR DESCRIPTION
## Summary
- 将触发事件从 `pull_request` 改为 `pull_request_target`
- `pull_request` 事件不向 fork PR 注入 secrets，导致外部贡献者的 PR 审查失败（`ANTHROPIC_API_KEY` 为空）
- `pull_request_target` 在 base 分支上下文中运行，可访问 secrets
- checkout 的是 base 分支代码，review 仅通过 `gh pr diff` 读取 PR 变更，不执行 PR 代码，无安全风险

Fixes: #850 review 失败（fork PR 无法访问 secrets）

## Test plan
- [ ] 合并后关闭再重新打开 #850，验证 review 成功运行