### PR TITLE
fix(xeCJK): 修复标点补偿 glue 被 unskip 移除的问题 (#859)

### DIFF
--- a/ctex/test/testfiles-contrib/elegantbook.tlg
+++ b/ctex/test/testfiles-contrib/elegantbook.tlg
@@ -4,6 +4,9 @@ Don't change this file in any respect.
 TEST 1: elegantbook
 ============================================================
 Package hyperref Info: Option `pageanchor' set `false' on input line ....
+Underfull \hbox (badness 10000) in paragraph at lines ...
+\hbox(0.0+0.0)x597.50787
+.\glue(\rightskip) 0.0
 LaTeX Font Info:    Font shape `TU/TeXGyreTermesX(0)/b/n' will be
 (Font)              scaled to size 24.88pt on input line ....
 LaTeX Font Info:    Font shape `TU/TeXGyreTermesX(0)/b/n' will be
@@ -35,7 +38,7 @@ Completed box being shipped out [1]
 .....\special{color pop}
 ...\glue 11.38109
 ...\glue(\lineskip) 0.0
-...\vbox(845.04684+0.0)x597.50787, glue set 55.23897fill
+...\vbox(845.04684+0.0)x597.50787, glue set 55.75777fill
 ....\write-{}
 ....\write-{}
 ....\write-{}
@@ -57,40 +60,17 @@ Completed box being shipped out [1]
 ........\glue 0.0 plus 1.0fil minus 1.0fil
 .....\glue(\rightskip) 0.0
 ....\penalty 300
-....\glue(\lineskip) 1.0
-....\hbox(36.135+0.0)x597.50787
-.....\special{color push rgb 1 0.5255 0.09413}
-.....\special{color push rgb 1 0.5255 0.09413}
-.....\hbox(36.135+0.0)x0.0, glue set - 597.50787fil
-......\rule(36.135+0.0)x597.50787
-......\glue 0.0 plus 1.0fil minus 1.0fil
-.....\special{color pop}
-.....\hbox(36.135+0.0)x597.50787
-......\kern 0.0
-......\special{color push gray 0}
-......\hbox(36.135+0.0)x597.50787, glue set 298.75394fil
-.......\glue 0.0 plus 1.0fil minus 1.0fil
-.......\vbox(36.135+0.0)x0.0
-........\hbox(0.0+0.0)x0.0
-.........\glue(\tabskip) 0.0
-.........\hbox(0.0+0.0)x0.0
-..........\glue 0.0 plus 1.0fil minus 1.0fil
-..........\glue 0.0 plus 1.0fil minus 1.0fil
-.........\glue(\tabskip) 0.0
-........\glue 36.135
-........\glue 0.0
-.......\glue 0.0 plus 1.0fil minus 1.0fil
-......\special{color pop}
-......\kern 0.0
-.....\special{color pop}
-.....\penalty 10000
-.....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\baselineskip) 15.60004
+....\hbox(0.0+0.0)x597.50787
 .....\glue(\rightskip) 0.0
+....\glue -15.60004
+....\special{color push rgb 1 0.5255 0.09413}
+....\rule(36.135+0.0)x597.50787
+....\special{color pop}
 ....\glue 0.0 plus 1.0fill
 ....\glue -9.0
 ....\glue(\parskip) 0.0 plus 1.0
 ....\glue(\parskip) 0.0
-....\glue(\baselineskip) 1.07521
 ....\hbox(14.52483+9.38484)x597.50787, glue set 96.99976fil
 .....\hbox(0.0+0.0)x0.0
 .....\glue 20.0
@@ -329,7 +309,7 @@ Completed box being shipped out [1]
 ............\special{pdf:code 0 J [] 0 d}
 ............\special{pdf:bcolor [1]}
 ............\special{pdf:bcolor [0]}
-............\special{pdf:btrans matrix 1.0 0.0 0.0 1.0 -10.10123 -91.87323}
+............\special{pdf:btrans matrix 1.0 0.0 0.0 1.0 -10.10123 -92.90695}
 ............\hbox(0.0+0.0)x0.0
 .............\hbox(89.62416+0.0)x119.50148
 ..............\special{pdf:code 0 G }
@@ -1314,10 +1294,6 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue -7.80002 plus -1.0
 ....\glue 7.80002 plus 1.0
-....\glue -7.80002 plus 1.0
-....\marks2{\__mark_value:nn {6}{1.1\protect \, Lebesgue 积分}}
-....\marks3{\__mark_value:nn {7}{1.1\protect \, Lebesgue 积分}}
-....\glue 7.80002 plus 1.0
 ....\glue -12.48007 plus -1.0
 ....\penalty -300
 ....\glue 4.68005
@@ -1356,8 +1332,8 @@ Completed box being shipped out [1]
 .....\glue(\rightskip) 0.0 plus 1.0fil
 ....\special{color pop}
 ....\penalty 10000
-....\marks2{\__mark_value:nn {8}{1.1\protect \, Lebesgue 积分}}
-....\marks3{\__mark_value:nn {9}{1.1\protect \, Lebesgue 积分}}
+....\marks2{\__mark_value:nn {6}{1.1\protect \, Lebesgue 积分}}
+....\marks3{\__mark_value:nn {7}{1.1\protect \, Lebesgue 积分}}
 ....\write7{\protect \BOOKMARK [1][]{section.1.1}{\376\377\0001\000.\0001\000\040\000L\000e\000b\000e\000s\000g\000u\000e\000\040\171\357\122\006}{chapter.1}% 2}
 ....\write1{\@writefile{toc}{\protect \contentsline {section}{\protect \numberline {1.1}Lebesgue 积分}{\thepage }{section.1.1}\protected@file@percent }}
 ....\penalty 10000
@@ -6098,8 +6074,8 @@ Completed box being shipped out [2]
 ....\glue 10.0 plus 4.0 minus 5.0
 ....\write7{\protect \BOOKMARK [1][]{section*.3}{\376\377\176\303\116\140}{chapter.1}% 3}
 ....\write1{\@writefile{toc}{\protect \contentsline {section}{第一章~练习}{\thepage }{section*.3}\protected@file@percent }}
-....\marks2{\__mark_value:nn {10}{第一章~练习}}
-....\marks3{\__mark_value:nn {11}{第一章~练习}}
+....\marks2{\__mark_value:nn {8}{第一章~练习}}
+....\marks3{\__mark_value:nn {9}{第一章~练习}}
 ....\glue(\parskip) 0.0 plus 1.0
 ....\glue(\parskip) 0.0
 ....\glue(\baselineskip) 2.96965

--- a/ctex/test/testfiles-contrib/elegantbook.tlg
+++ b/ctex/test/testfiles-contrib/elegantbook.tlg
@@ -4,9 +4,6 @@ Don't change this file in any respect.
 TEST 1: elegantbook
 ============================================================
 Package hyperref Info: Option `pageanchor' set `false' on input line ....
-Underfull \hbox (badness 10000) in paragraph at lines ...
-\hbox(0.0+0.0)x597.50787
-.\glue(\rightskip) 0.0
 LaTeX Font Info:    Font shape `TU/TeXGyreTermesX(0)/b/n' will be
 (Font)              scaled to size 24.88pt on input line ....
 LaTeX Font Info:    Font shape `TU/TeXGyreTermesX(0)/b/n' will be
@@ -38,7 +35,7 @@ Completed box being shipped out [1]
 .....\special{color pop}
 ...\glue 11.38109
 ...\glue(\lineskip) 0.0
-...\vbox(845.04684+0.0)x597.50787, glue set 55.75777fill
+...\vbox(845.04684+0.0)x597.50787, glue set 55.23897fill
 ....\write-{}
 ....\write-{}
 ....\write-{}
@@ -60,17 +57,40 @@ Completed box being shipped out [1]
 ........\glue 0.0 plus 1.0fil minus 1.0fil
 .....\glue(\rightskip) 0.0
 ....\penalty 300
-....\glue(\baselineskip) 15.60004
-....\hbox(0.0+0.0)x597.50787
+....\glue(\lineskip) 1.0
+....\hbox(36.135+0.0)x597.50787
+.....\special{color push rgb 1 0.5255 0.09413}
+.....\special{color push rgb 1 0.5255 0.09413}
+.....\hbox(36.135+0.0)x0.0, glue set - 597.50787fil
+......\rule(36.135+0.0)x597.50787
+......\glue 0.0 plus 1.0fil minus 1.0fil
+.....\special{color pop}
+.....\hbox(36.135+0.0)x597.50787
+......\kern 0.0
+......\special{color push gray 0}
+......\hbox(36.135+0.0)x597.50787, glue set 298.75394fil
+.......\glue 0.0 plus 1.0fil minus 1.0fil
+.......\vbox(36.135+0.0)x0.0
+........\hbox(0.0+0.0)x0.0
+.........\glue(\tabskip) 0.0
+.........\hbox(0.0+0.0)x0.0
+..........\glue 0.0 plus 1.0fil minus 1.0fil
+..........\glue 0.0 plus 1.0fil minus 1.0fil
+.........\glue(\tabskip) 0.0
+........\glue 36.135
+........\glue 0.0
+.......\glue 0.0 plus 1.0fil minus 1.0fil
+......\special{color pop}
+......\kern 0.0
+.....\special{color pop}
+.....\penalty 10000
+.....\glue(\parfillskip) 0.0 plus 1.0fil
 .....\glue(\rightskip) 0.0
-....\glue -15.60004
-....\special{color push rgb 1 0.5255 0.09413}
-....\rule(36.135+0.0)x597.50787
-....\special{color pop}
 ....\glue 0.0 plus 1.0fill
 ....\glue -9.0
 ....\glue(\parskip) 0.0 plus 1.0
 ....\glue(\parskip) 0.0
+....\glue(\baselineskip) 1.07521
 ....\hbox(14.52483+9.38484)x597.50787, glue set 96.99976fil
 .....\hbox(0.0+0.0)x0.0
 .....\glue 20.0
@@ -155,7 +175,7 @@ Completed box being shipped out [1]
 ...........\kern -0.99649
 ...........\kern 0.99649
 ...........\glue 6.97 minus 5.0
-...........\penalty 0
+...........\penalty 10000
 ...........\TU/TeXGyreTermesX(0)/m/n/10 CTeX
 ...........\glue 2.5 plus 1.24875 minus 0.83415
 ...........\TU/TeXGyreTermesX(0)/m/n/10 Kit
@@ -182,7 +202,7 @@ Completed box being shipped out [1]
 ...........\kern -0.99649
 ...........\kern 0.99649
 ...........\glue 6.97 minus 5.0
-...........\penalty 0
+...........\penalty 10000
 ...........\TU/TeXGyreTermesX(0)/m/n/10 Regression
 ...........\glue 2.5 plus 1.25 minus 0.83333
 ...........\TU/TeXGyreTermesX(0)/m/n/10 Test
@@ -209,7 +229,7 @@ Completed box being shipped out [1]
 ...........\kern -0.99649
 ...........\kern 0.99649
 ...........\glue 6.97 minus 5.0
-...........\penalty 0
+...........\penalty 10000
 ...........\TU/TeXGyreTermesX(0)/m/n/10 January
 ...........\glue 2.5 plus 1.25 minus 0.83333
 ...........\TU/TeXGyreTermesX(0)/m/n/10 1,
@@ -309,7 +329,7 @@ Completed box being shipped out [1]
 ............\special{pdf:code 0 J [] 0 d}
 ............\special{pdf:bcolor [1]}
 ............\special{pdf:bcolor [0]}
-............\special{pdf:btrans matrix 1.0 0.0 0.0 1.0 -10.10123 -92.90695}
+............\special{pdf:btrans matrix 1.0 0.0 0.0 1.0 -10.10123 -91.87323}
 ............\hbox(0.0+0.0)x0.0
 .............\hbox(89.62416+0.0)x119.50148
 ..............\special{pdf:code 0 G }
@@ -1294,6 +1314,10 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue -7.80002 plus -1.0
 ....\glue 7.80002 plus 1.0
+....\glue -7.80002 plus 1.0
+....\marks2{\__mark_value:nn {6}{1.1\protect \, Lebesgue 积分}}
+....\marks3{\__mark_value:nn {7}{1.1\protect \, Lebesgue 积分}}
+....\glue 7.80002 plus 1.0
 ....\glue -12.48007 plus -1.0
 ....\penalty -300
 ....\glue 4.68005
@@ -1332,8 +1356,8 @@ Completed box being shipped out [1]
 .....\glue(\rightskip) 0.0 plus 1.0fil
 ....\special{color pop}
 ....\penalty 10000
-....\marks2{\__mark_value:nn {6}{1.1\protect \, Lebesgue 积分}}
-....\marks3{\__mark_value:nn {7}{1.1\protect \, Lebesgue 积分}}
+....\marks2{\__mark_value:nn {8}{1.1\protect \, Lebesgue 积分}}
+....\marks3{\__mark_value:nn {9}{1.1\protect \, Lebesgue 积分}}
 ....\write7{\protect \BOOKMARK [1][]{section.1.1}{\376\377\0001\000.\0001\000\040\000L\000e\000b\000e\000s\000g\000u\000e\000\040\171\357\122\006}{chapter.1}% 2}
 ....\write1{\@writefile{toc}{\protect \contentsline {section}{\protect \numberline {1.1}Lebesgue 积分}{\thepage }{section.1.1}\protected@file@percent }}
 ....\penalty 10000
@@ -1431,7 +1455,7 @@ Completed box being shipped out [1]
 .....\glue(\rightskip) 0.0
 ....\penalty 10150
 ....\glue(\baselineskip) 5.62006
-....\hbox(7.8+2.17998)x483.69687, glue set 58.20686fil
+....\hbox(7.8+2.17998)x483.69687, glue set 51.76686fil
 .....\TU/FandolSong-Regular(0)/m/n/10 分
 .....\penalty 10000
 .....\TU/FandolSong-Regular(0)/m/n/10 ，
@@ -1513,6 +1537,8 @@ Completed box being shipped out [1]
 .....\kern -0.0004
 .....\kern -0.18753
 .....\kern 0.18753
+.....\glue 6.44 minus 5.0
+.....\penalty 10000
 .....\penalty 10000
 .....\glue(\parfillskip) 0.0 plus 1.0fil
 .....\glue(\rightskip) 0.0
@@ -1613,7 +1639,7 @@ Completed box being shipped out [1]
 .....\glue(\rightskip) 0.0
 ....\penalty 300
 ....\glue(\baselineskip) 5.70006
-....\hbox(7.72+1.75998)x483.69687, glue set 430.13687fil
+....\hbox(7.72+1.75998)x483.69687, glue set 423.69687fil
 .....\TU/FandolSong-Regular(0)/m/n/10 积
 .....\glue 0.0 plus 0.29776
 .....\TU/FandolSong-Regular(0)/m/n/10 分
@@ -1630,6 +1656,8 @@ Completed box being shipped out [1]
 .....\kern -0.0004
 .....\kern -0.18753
 .....\kern 0.18753
+.....\glue 6.44 minus 5.0
+.....\penalty 10000
 .....\penalty 10000
 .....\glue(\parfillskip) 0.0 plus 1.0fil
 .....\glue(\rightskip) 0.0
@@ -1680,7 +1708,7 @@ Completed box being shipped out [1]
 ....\glue(\parskip) 0.0 plus 1.0
 ....\glue(\parskip) 0.0
 ....\glue(\baselineskip) 2.33997
-....\hbox(7.8+1.82999)x483.69687, glue set 10.5588fil
+....\hbox(7.8+1.82999)x483.69687, glue set 4.1188fil
 .....\hbox(0.0+0.0)x20.0
 .....\TU/FandolSong-Regular(0)/m/n/10 我
 .....\glue 0.0 plus 0.29776
@@ -1788,6 +1816,8 @@ Completed box being shipped out [1]
 .....\kern -0.0004
 .....\kern -0.18753
 .....\kern 0.18753
+.....\glue 6.44 minus 5.0
+.....\penalty 10000
 .....\penalty 10000
 .....\glue(\parfillskip) 0.0 plus 1.0fil
 .....\glue(\rightskip) 0.0
@@ -2631,7 +2661,7 @@ Completed box being shipped out [1]
 ...........\penalty 0
 ...........\glue(\belowdisplayskip) 3.90001
 ...........\glue(\lineskip) 1.0
-...........\hbox(8.1256+3.35062)x454.24417, glue set 166.14072fil
+...........\hbox(8.1256+3.35062)x454.24417, glue set 159.70071fil
 ............\TU/FandolKai-Regular(0)/m/n/10 一
 ............\glue 0.0 plus 0.29776
 ............\TU/FandolKai-Regular(0)/m/n/10 般
@@ -2725,6 +2755,8 @@ Completed box being shipped out [1]
 ............\kern -0.0004
 ............\kern -0.18753
 ............\kern 0.18753
+............\glue 6.44 minus 5.0
+............\penalty 10000
 ............\penalty 10000
 ............\glue(\parfillskip) 0.0 plus 1.0fil
 ............\glue(\rightskip) 0.0
@@ -2911,6 +2943,7 @@ Completed box being shipped out [1]
 .....\kern -0.99628
 .....\kern 0.99628
 .....\glue 6.92 minus 5.0
+.....\penalty 10000
 .....\mathon
 .....\OML/ntxmi/m/it/10 D
 .....\LMS/ntxsy/m/n/10 ^^b9
@@ -3043,7 +3076,7 @@ Completed box being shipped out [1]
 ....\penalty 0
 ....\glue(\belowdisplayskip) 3.90001
 ....\glue(\lineskip) 1.0
-....\hbox(7.84+2.17998)x483.69687, glue set 243.20534fil
+....\hbox(7.84+2.17998)x483.69687, glue set 236.76534fil
 .....\TU/FandolSong-Regular(0)/m/n/10 即
 .....\glue 2.5 plus 1.25 minus 0.83333
 .....\mathon
@@ -3101,13 +3134,15 @@ Completed box being shipped out [1]
 .....\kern -0.0004
 .....\kern -0.18753
 .....\kern 0.18753
+.....\glue 6.44 minus 5.0
+.....\penalty 10000
 .....\penalty 10000
 .....\glue(\parfillskip) 0.0 plus 1.0fil
 .....\glue(\rightskip) 0.0
 ....\glue(\parskip) 0.0 plus 1.0
 ....\glue(\parskip) 0.0
 ....\glue(\baselineskip) 5.56006
-....\hbox(7.86+1.83998)x483.69687, glue set 102.63687fil
+....\hbox(7.86+1.83998)x483.69687, glue set 96.19687fil
 .....\hbox(0.0+0.0)x20.0
 .....\TU/FandolSong-Regular(0)/m/n/10 有
 .....\glue 0.0 plus 0.29776
@@ -3194,6 +3229,8 @@ Completed box being shipped out [1]
 .....\kern -0.0004
 .....\kern -0.18753
 .....\kern 0.18753
+.....\glue 6.44 minus 5.0
+.....\penalty 10000
 .....\penalty 10000
 .....\glue(\parfillskip) 0.0 plus 1.0fil
 .....\glue(\rightskip) 0.0
@@ -3254,6 +3291,7 @@ Completed box being shipped out [1]
 .....\kern -0.99628
 .....\kern 0.99628
 .....\glue 6.92 minus 5.0
+.....\penalty 10000
 .....\mathon
 .....\OML/ntxmi/m/it/10 g
 .....\kern0.205
@@ -3384,7 +3422,7 @@ Completed box being shipped out [1]
 ....\penalty 0
 ....\glue(\belowdisplayskip) 3.90001
 ....\glue(\lineskip) 1.0
-....\hbox(8.55748+1.80998)x483.69687, glue set 393.49689fil
+....\hbox(8.55748+1.80998)x483.69687, glue set 387.05688fil
 .....\TU/FandolSong-Regular(0)/m/n/10 是
 .....\glue 2.5 plus 1.25 minus 0.83333
 .....\mathon
@@ -3412,13 +3450,15 @@ Completed box being shipped out [1]
 .....\kern -0.0004
 .....\kern -0.18753
 .....\kern 0.18753
+.....\glue 6.44 minus 5.0
+.....\penalty 10000
 .....\penalty 10000
 .....\glue(\parfillskip) 0.0 plus 1.0fil
 .....\glue(\rightskip) 0.0
 ....\glue(\parskip) 0.0 plus 1.0
 ....\glue(\parskip) 0.0
 ....\glue(\baselineskip) 6.05005
-....\hbox(7.74+2.17998)x483.69687, glue set 233.20534fil
+....\hbox(7.74+2.17998)x483.69687, glue set 226.76534fil
 .....\special{color push rgb 0 0.65099 0.32158}
 .....\TU/FandolSong-Regular(0)/b/n/10 解
 .....\special{color pop}
@@ -3480,13 +3520,15 @@ Completed box being shipped out [1]
 .....\kern -0.0004
 .....\kern -0.18753
 .....\kern 0.18753
+.....\glue 6.44 minus 5.0
+.....\penalty 10000
 .....\penalty 10000
 .....\glue(\parfillskip) 0.0 plus 1.0fil
 .....\glue(\rightskip) 0.0
 ....\glue(\parskip) 0.0 plus 1.0
 ....\glue(\parskip) 0.0
 ....\glue(\baselineskip) 5.48006
-....\hbox(7.94+2.17998)x483.69687, glue set 217.92839fil
+....\hbox(7.94+2.17998)x483.69687, glue set 211.48839fil
 .....\special{color push rgb 1 0.5255 0.09413}
 .....\TU/FandolSong-Regular(0)/b/n/10 证
 .....\glue 0.0 plus 0.29776
@@ -3554,6 +3596,8 @@ Completed box being shipped out [1]
 .....\kern -0.0004
 .....\kern -0.18753
 .....\kern 0.18753
+.....\glue 6.44 minus 5.0
+.....\penalty 10000
 .....\penalty 10000
 .....\glue(\parfillskip) 0.0 plus 1.0fil
 .....\glue(\rightskip) 0.0
@@ -4056,6 +4100,7 @@ Completed box being shipped out [1]
 ............\kern -0.99628
 ............\kern 0.99628
 ............\glue 6.92 minus 5.0
+............\penalty 10000
 ............\mathon
 ............\OML/ntxmi/m/it/10 f
 ............\kern1.66
@@ -4575,7 +4620,7 @@ Completed box being shipped out [2]
 ..........\special{color push gray 0}
 ..........\vbox(7.59+2.09499)x454.24417
 ...........\glue(\splittopskip) 0.0
-...........\hbox(7.59+2.09499)x454.24417, glue set 231.17812fil
+...........\hbox(7.59+2.09499)x454.24417, glue set 224.73811fil
 ............\TU/FandolKai-Regular(0)/m/n/10 若
 ............\glue 2.5 plus 1.25 minus 0.83333
 ............\mathon
@@ -4655,6 +4700,8 @@ Completed box being shipped out [2]
 ............\kern -0.0004
 ............\kern -0.18753
 ............\kern 0.18753
+............\glue 6.44 minus 5.0
+............\penalty 10000
 ............\penalty 10000
 ............\glue(\parfillskip) 0.0 plus 1.0fil
 ............\glue(\rightskip) 0.0
@@ -4684,7 +4731,7 @@ Completed box being shipped out [2]
 ....\glue(\parskip) 0.0 plus 1.0
 ....\glue(\parskip) 0.0
 ....\glue(\lineskip) 1.0
-....\hbox(12.9498+1.91998)x483.69687, glue set 223.13687fil
+....\hbox(12.9498+1.91998)x483.69687, glue set 216.69687fil
 .....\hbox(12.9498+0.0)x-3.0, glue set - 22.22224fil
 ......\glue 0.0 plus 1.0fil minus 1.0fil
 ......\glue 2.5 plus 1.25 minus 0.83333
@@ -4766,6 +4813,8 @@ Completed box being shipped out [2]
 .....\kern -0.0004
 .....\kern -0.18753
 .....\kern 0.18753
+.....\glue 6.44 minus 5.0
+.....\penalty 10000
 .....\penalty 10000
 .....\glue(\parfillskip) 0.0 plus 1.0fil
 .....\glue(\rightskip) 0.0
@@ -5223,7 +5272,7 @@ Completed box being shipped out [2]
 ...........\special{color push gray 0}
 ...........\glue(\parskip) 0.0
 ...........\glue(\parskip) 0.0
-...........\hbox(7.88+1.965)x454.24417, glue set 156.1745fil
+...........\hbox(7.88+1.965)x454.24417, glue set 149.7345fil
 ............\hbox(0.0+0.0)x0.0
 ............\TU/FandolKai-Regular(0)/m/n/10 如
 ............\glue 0.0 plus 0.29776
@@ -5313,6 +5362,8 @@ Completed box being shipped out [2]
 ............\kern -0.0004
 ............\kern -0.18753
 ............\kern 0.18753
+............\glue 6.44 minus 5.0
+............\penalty 10000
 ............\penalty 10000
 ............\glue(\parfillskip) 0.0 plus 1.0fil
 ............\glue(\rightskip) 0.0
@@ -5561,7 +5612,7 @@ Completed box being shipped out [2]
 .....\glue(\rightskip) 0.0
 ....\penalty 300
 ....\glue(\baselineskip) 5.85005
-....\hbox(7.82+1.81999)x483.69687, glue set 272.63687fil
+....\hbox(7.82+1.81999)x483.69687, glue set 266.19687fil
 .....\TU/FandolSong-Regular(0)/m/n/10 称
 .....\glue 0.0 plus 0.29776
 .....\TU/FandolSong-Regular(0)/m/n/10 为
@@ -5617,6 +5668,8 @@ Completed box being shipped out [2]
 .....\kern -0.0004
 .....\kern -0.18753
 .....\kern 0.18753
+.....\glue 6.44 minus 5.0
+.....\penalty 10000
 .....\penalty 10000
 .....\glue(\parfillskip) 0.0 plus 1.0fil
 .....\glue(\rightskip) 0.0
@@ -5659,7 +5712,7 @@ Completed box being shipped out [2]
 ....\glue(\parskip) 0.0
 ....\glue(\parskip) 0.0
 ....\glue(\baselineskip) 5.69553
-....\hbox(8.25453+3.64696)x458.69687, glue set 270.0373fil, shifted 25.0
+....\hbox(8.25453+3.64696)x458.69687, glue set 263.59729fil, shifted 25.0
 .....\hbox(6.76+0.10999)x0.0
 ......\glue 0.0
 ......\glue -20.0
@@ -5736,6 +5789,8 @@ Completed box being shipped out [2]
 .....\kern -0.0004
 .....\kern -0.18753
 .....\kern 0.18753
+.....\glue 6.44 minus 5.0
+.....\penalty 10000
 .....\penalty 10000
 .....\glue(\parfillskip) 0.0 plus 1.0fil
 .....\glue(\rightskip) 0.0
@@ -5746,7 +5801,7 @@ Completed box being shipped out [2]
 ....\glue(\parskip) 0.0
 ....\glue(\parskip) 0.0
 ....\glue(\baselineskip) 4.22308
-....\hbox(7.73+2.09499)x458.69687, glue set 137.8074fil, shifted 25.0
+....\hbox(7.73+2.09499)x458.69687, glue set 131.3674fil, shifted 25.0
 .....\hbox(6.76+0.10999)x0.0
 ......\glue 0.0
 ......\glue -20.0
@@ -5787,6 +5842,7 @@ Completed box being shipped out [2]
 .....\kern -0.99628
 .....\kern 0.99628
 .....\glue 6.92 minus 5.0
+.....\penalty 10000
 .....\mathon
 .....\OML/ntxmi/m/it/10 ^^Z
 .....\kern0.15999
@@ -5840,6 +5896,7 @@ Completed box being shipped out [2]
 .....\kern -0.99628
 .....\kern 0.99628
 .....\glue 6.92 minus 5.0
+.....\penalty 10000
 .....\mathon
 .....\LMS/ntxsy/m/n/10 ^^b9
 .....\kern0.4
@@ -5874,6 +5931,8 @@ Completed box being shipped out [2]
 .....\kern -0.0004
 .....\kern -0.18753
 .....\kern 0.18753
+.....\glue 6.44 minus 5.0
+.....\penalty 10000
 .....\penalty 10000
 .....\glue(\parfillskip) 0.0 plus 1.0fil
 .....\glue(\rightskip) 0.0
@@ -5989,7 +6048,7 @@ Completed box being shipped out [2]
 .....\glue(\rightskip) 0.0
 ....\penalty 300
 ....\glue(\baselineskip) 5.98006
-....\hbox(7.7+1.59999)x483.69687, glue set 350.13687fil
+....\hbox(7.7+1.59999)x483.69687, glue set 343.69687fil
 .....\TU/FandolKai-Regular(0)/m/n/10 分
 .....\glue 0.0 plus 0.29776
 .....\TU/FandolKai-Regular(0)/m/n/10 为
@@ -6022,6 +6081,8 @@ Completed box being shipped out [2]
 .....\kern -0.0004
 .....\kern -0.18753
 .....\kern 0.18753
+.....\glue 6.44 minus 5.0
+.....\penalty 10000
 .....\penalty 10000
 .....\glue(\parfillskip) 0.0 plus 1.0fil
 .....\glue(\rightskip) 0.0
@@ -6037,8 +6098,8 @@ Completed box being shipped out [2]
 ....\glue 10.0 plus 4.0 minus 5.0
 ....\write7{\protect \BOOKMARK [1][]{section*.3}{\376\377\176\303\116\140}{chapter.1}% 3}
 ....\write1{\@writefile{toc}{\protect \contentsline {section}{第一章~练习}{\thepage }{section*.3}\protected@file@percent }}
-....\marks2{\__mark_value:nn {8}{第一章~练习}}
-....\marks3{\__mark_value:nn {9}{第一章~练习}}
+....\marks2{\__mark_value:nn {10}{第一章~练习}}
+....\marks3{\__mark_value:nn {11}{第一章~练习}}
 ....\glue(\parskip) 0.0 plus 1.0
 ....\glue(\parskip) 0.0
 ....\glue(\baselineskip) 2.96965
@@ -6229,7 +6290,7 @@ Completed box being shipped out [2]
 .....\glue(\rightskip) 0.0
 ....\penalty 300
 ....\glue(\baselineskip) 5.90005
-....\hbox(7.77+1.55998)x458.69687, glue set 445.13687fil, shifted 25.0
+....\hbox(7.77+1.55998)x458.69687, glue set 438.69687fil, shifted 25.0
 .....\TU/FandolSong-Regular(0)/m/n/10 阵
 .....\penalty 10000
 .....\TU/FandolSong-Regular(0)/m/n/10 。
@@ -6238,6 +6299,8 @@ Completed box being shipped out [2]
 .....\kern -0.0004
 .....\kern -0.18753
 .....\kern 0.18753
+.....\glue 6.44 minus 5.0
+.....\penalty 10000
 .....\penalty 10000
 .....\glue(\parfillskip) 0.0 plus 1.0fil
 .....\glue(\rightskip) 0.0
@@ -6248,7 +6311,7 @@ Completed box being shipped out [2]
 ....\glue(\parskip) 0.0
 ....\glue(\parskip) 0.0
 ....\glue(\baselineskip) 6.24005
-....\hbox(7.8+1.81999)x458.69687, glue set 275.13687fil, shifted 25.0
+....\hbox(7.8+1.81999)x458.69687, glue set 268.69687fil, shifted 25.0
 .....\hbox(6.76+0.10999)x0.0
 ......\glue 0.0
 ......\glue -20.0
@@ -6311,6 +6374,8 @@ Completed box being shipped out [2]
 .....\kern -0.0004
 .....\kern -0.18753
 .....\kern 0.18753
+.....\glue 6.44 minus 5.0
+.....\penalty 10000
 .....\penalty 10000
 .....\glue(\parfillskip) 0.0 plus 1.0fil
 .....\glue(\rightskip) 0.0
@@ -6471,7 +6536,7 @@ Completed box being shipped out [2]
 .....\glue(\rightskip) 0.0
 ....\penalty 300
 ....\glue(\baselineskip) 4.76706
-....\hbox(7.8+1.965)x458.69687, glue set 294.25945fil, shifted 25.0
+....\hbox(7.8+1.965)x458.69687, glue set 287.81944fil, shifted 25.0
 .....\OML/ntxmi/m/it/10 a
 .....\hbox(4.92749+0.12408)x7.41672, shifted 1.49998
 ......\OML/ntxmi/m/it/7.3 k
@@ -6528,6 +6593,8 @@ Completed box being shipped out [2]
 .....\kern -0.0004
 .....\kern -0.18753
 .....\kern 0.18753
+.....\glue 6.44 minus 5.0
+.....\penalty 10000
 .....\penalty 10000
 .....\glue(\parfillskip) 0.0 plus 1.0fil
 .....\glue(\rightskip) 0.0

--- a/ctex/test/testfiles-contrib/pkuthss.tlg
+++ b/ctex/test/testfiles-contrib/pkuthss.tlg
@@ -182,6 +182,7 @@ Completed box being shipped out [1]
 .....\kern -0.99649
 .....\kern 0.99649
 .....\glue 15.3915 minus 11.04124
+.....\penalty 10000
 .....\hbox(16.80478+3.57735)x0.0, glue set - 287.71378fil
 ......\vbox(16.80478+3.57735)x287.71378
 .......\hbox(16.80478+3.57735)x287.71378, glue set 99.69191fil
@@ -273,7 +274,7 @@ Completed box being shipped out [1]
 .........\kern -0.99649
 .........\kern 0.99649
 .........\glue 10.79231 minus 8.03
-.........\penalty 0
+.........\penalty 10000
 .........\glue 0.0 plus 1.0fil
 ........\glue(\tabskip) 3.21194
 ........\hbox(23.6081+10.11789)x257.74872
@@ -336,7 +337,7 @@ Completed box being shipped out [1]
 .........\kern -0.99649
 .........\kern 0.99649
 .........\glue 10.79231 minus 8.03
-.........\penalty 0
+.........\penalty 10000
 .........\glue 0.0 plus 1.0fil
 ........\glue(\tabskip) 3.21194
 ........\hbox(23.6081+10.11789)x257.74872
@@ -397,7 +398,7 @@ Completed box being shipped out [1]
 .........\kern -0.99649
 .........\kern 0.99649
 .........\glue 10.79231 minus 8.03
-.........\penalty 0
+.........\penalty 10000
 .........\glue 0.0 plus 1.0fil
 ........\glue(\tabskip) 3.21194
 ........\hbox(23.6081+10.11789)x257.74872
@@ -460,7 +461,7 @@ Completed box being shipped out [1]
 .........\kern -0.99649
 .........\kern 0.99649
 .........\glue 10.79231 minus 8.03
-.........\penalty 0
+.........\penalty 10000
 .........\glue 0.0 plus 1.0fil
 ........\glue(\tabskip) 3.21194
 ........\hbox(23.6081+10.11789)x257.74872
@@ -525,7 +526,7 @@ Completed box being shipped out [1]
 .........\kern -0.99649
 .........\kern 0.99649
 .........\glue 10.79231 minus 8.03
-.........\penalty 0
+.........\penalty 10000
 .........\glue 0.0 plus 1.0fil
 ........\glue(\tabskip) 3.21194
 ........\hbox(23.6081+10.11789)x257.74872
@@ -588,7 +589,7 @@ Completed box being shipped out [1]
 .........\kern -0.99649
 .........\kern 0.99649
 .........\glue 10.79231 minus 8.03
-.........\penalty 0
+.........\penalty 10000
 .........\glue 0.0 plus 1.0fil
 ........\glue(\tabskip) 3.21194
 ........\hbox(23.6081+10.11789)x257.74872
@@ -888,6 +889,7 @@ Completed box being shipped out [1]
 .....\penalty 10000
 .....\TU/FandolSong-Regular(0)/b/n/12.045 ：
 .....\rule(0.0+0.0)x-8.09424
+.....\penalty 10000
 .....\glue 8.09424 minus 6.02249
 .....\glue 0.0 plus 0.45523
 .....\TU/FandolSong-Regular(0)/m/n/12.045 其
@@ -1954,7 +1956,7 @@ Completed box being shipped out [3]
 ....\glue(\parskip) 0.0 plus 1.0
 ....\glue(\parskip) 0.0
 ....\glue(\baselineskip) 8.33815
-....\hbox(9.35896+2.21626)x449.55322, glue set 333.84898fil
+....\hbox(9.35896+2.21626)x449.55322, glue set 326.09201fil
 .....\hbox(0.0+0.0)x24.09
 .....\TU/FandolSong-Regular(0)/m/n/12.045 第
 .....\kern -0.00017
@@ -1990,6 +1992,8 @@ Completed box being shipped out [3]
 .....\kern -0.00047
 .....\kern -0.18753
 .....\kern 0.18753
+.....\glue 7.75697 minus 6.02249
+.....\penalty 10000
 .....\penalty 10000
 .....\glue(\parfillskip) 0.0 plus 1.0fil
 .....\glue(\rightskip) 0.0

--- a/ctex/test/testfiles-contrib/thuthesis.tlg
+++ b/ctex/test/testfiles-contrib/thuthesis.tlg
@@ -197,7 +197,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
-............\penalty 0
+............\penalty 10000
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\TU/FandolFang(0)/m/n/16.06 计
@@ -254,7 +254,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
-............\penalty 0
+............\penalty 10000
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.75163+2.40898)x85.35826, glue set 21.11827fil
@@ -308,7 +308,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
-............\penalty 0
+............\penalty 10000
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.81587+3.05139)x85.35826, glue set 21.11827fil
@@ -873,7 +873,7 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 10.72807
-...\hbox(9.34692+2.09581)x426.79135, glue set 387.13922fil
+...\hbox(9.34692+2.09581)x426.79135, glue set 378.61136fil
 ....\TU/FandolHei(0)/m/n/12.045 关
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolHei(0)/m/n/12.045 键
@@ -886,6 +886,8 @@ Completed box being shipped out [1]
 ....\kern -0.00052
 ....\kern -0.99649
 ....\kern 0.99649
+....\glue 8.52786 minus 6.0225
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -1660,7 +1662,7 @@ Completed box being shipped out [2]
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 8.28497
-...\hbox(9.35896+2.21626)x426.79135, glue set 317.1096fil
+...\hbox(9.35896+2.21626)x426.79135, glue set 309.35263fil
 ....\hbox(0.0+0.0)x24.09
 ....\TU/FandolSong(0)/m/n/12.045 第
 ....\kern -0.00017
@@ -1694,6 +1696,8 @@ Completed box being shipped out [2]
 ....\kern -0.00047
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 7.75697 minus 6.02249
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -1724,7 +1728,7 @@ Completed box being shipped out [2]
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 8.18057
-...\hbox(9.40715+2.16809)x426.79135, glue set 239.82729fil
+...\hbox(9.40715+2.16809)x426.79135, glue set 232.07031fil
 ....\hbox(9.19034+1.89105)x62.22606
 .....\glue 0.0
 .....\glue 0.0
@@ -1752,7 +1756,7 @@ Completed box being shipped out [2]
 ......\kern -0.99649
 ......\kern 0.99649
 ......\glue 8.52786 minus 6.0225
-......\penalty 0
+......\penalty 10000
 ......\special{color pop}
 .....\glue 6.0
 ....\penalty 0
@@ -1782,6 +1786,8 @@ Completed box being shipped out [2]
 ....\kern -0.00047
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 7.75697 minus 6.02249
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -1865,7 +1871,7 @@ Completed box being shipped out [2]
 ........\kern -0.99623
 ........\kern 0.99623
 ........\glue 7.63654 minus 6.0225
-........\penalty 0
+........\penalty 10000
 ....\glue(\tabskip) 0.0
 ...\penalty 0
 ...\glue 0.0
@@ -1944,7 +1950,7 @@ Completed box being shipped out [2]
 ........\kern -0.99623
 ........\kern 0.99623
 ........\glue 7.63654 minus 6.0225
-........\penalty 0
+........\penalty 10000
 ....\glue(\tabskip) 0.0
 ...\penalty 0
 ...\glue 0.0
@@ -2019,7 +2025,7 @@ Completed box being shipped out [2]
 ........\kern -0.99623
 ........\kern 0.99623
 ........\glue 7.63654 minus 6.0225
-........\penalty 0
+........\penalty 10000
 ....\glue(\tabskip) 0.0
 ...\penalty 0
 ...\glue 0.0
@@ -2421,7 +2427,7 @@ Completed box being shipped out [3]
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 9.35896
-...\hbox(9.3951+2.32468)x426.79135, glue set 20.35155fil
+...\hbox(9.3951+2.32468)x426.79135, glue set 12.59457fil
 ....\TU/FandolSong(0)/m/n/12.045 所
 ....\glue 0.15054 plus 0.10037
 ....\TU/FandolSong(0)/m/n/12.045 涉
@@ -2496,6 +2502,8 @@ Completed box being shipped out [3]
 ....\kern -0.00047
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 7.75697 minus 6.02249
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -2519,6 +2527,7 @@ Completed box being shipped out [3]
 ....\kern -0.99649
 ....\kern 0.99649
 ....\glue 9.09497 minus 6.52437
+....\penalty 10000
 ....\glue 1.0
 ....\mathon
 ....\vbox(0.0+4.30565)x76.28499
@@ -2544,6 +2553,7 @@ Completed box being shipped out [3]
 ....\kern -0.99649
 ....\kern 0.99649
 ....\glue 9.09497 minus 6.52437
+....\penalty 10000
 ....\glue 1.0
 ....\mathon
 ....\vbox(0.0+4.30565)x65.24374

--- a/ctex/test/testfiles/abstract01.tlg
+++ b/ctex/test/testfiles/abstract01.tlg
@@ -95,7 +95,7 @@ Completed box being shipped out [1]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 5.81773 minus 4.51688
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -193,7 +193,7 @@ Completed box being shipped out [2]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 5.81773 minus 4.51688
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -248,7 +248,7 @@ Completed box being shipped out [2]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.78735 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0

--- a/ctex/test/testfiles/abstract01.tlg
+++ b/ctex/test/testfiles/abstract01.tlg
@@ -51,7 +51,7 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 5.60999
-...\hbox(7.02824+1.65315)x295.0, glue set 156.27794fil, shifted 25.0
+...\hbox(7.02824+1.65315)x295.0, glue set 150.4602fil, shifted 25.0
 ....\hbox(0.0+0.0)x18.06747
 .....\glue 18.06747
 .....\glue -20.0
@@ -94,6 +94,8 @@ Completed box being shipped out [1]
 ....\kern -0.00035
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 5.81773 minus 4.51688
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -167,7 +169,7 @@ Completed box being shipped out [2]
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 5.60999
-...\hbox(7.02824+1.58992)x295.0, glue set 237.58157fil, shifted 25.0
+...\hbox(7.02824+1.58992)x295.0, glue set 231.76384fil, shifted 25.0
 ....\hbox(0.0+0.0)x18.06747
 .....\glue 18.06747
 .....\glue -20.0
@@ -190,6 +192,8 @@ Completed box being shipped out [2]
 ....\kern -0.00035
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 5.81773 minus 4.51688
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -227,7 +231,7 @@ Completed box being shipped out [2]
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 5.93071
-...\hbox(8.14693+1.9287)x345.0, glue set 278.01178fil
+...\hbox(8.14693+1.9287)x345.0, glue set 271.22443fil
 ....\hbox(0.0+0.0)x21.07874
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 正
 ....\glue 0.0 plus 0.60931
@@ -243,6 +247,8 @@ Completed box being shipped out [2]
 ....\kern -0.00041
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.78735 minus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0

--- a/ctex/test/testfiles/amsmath01.tlg
+++ b/ctex/test/testfiles/amsmath01.tlg
@@ -40,7 +40,7 @@ Completed box being shipped out [1]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.78735 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -93,7 +93,7 @@ Completed box being shipped out [1]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.78735 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -146,7 +146,7 @@ Completed box being shipped out [2]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.78735 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -277,7 +277,7 @@ Completed box being shipped out [2]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.78735 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0

--- a/ctex/test/testfiles/amsmath01.tlg
+++ b/ctex/test/testfiles/amsmath01.tlg
@@ -23,7 +23,7 @@ Completed box being shipped out [1]
 ..\vbox(550.0+0.0)x345.0, glue set 501.06358fil
 ...\write-{}
 ...\glue(\topskip) 1.89523
-...\hbox(8.10477+1.85492)x345.0, glue set 278.01178fil
+...\hbox(8.10477+1.85492)x345.0, glue set 271.22443fil
 ....\hbox(0.0+0.0)x21.07874
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 文
 ....\glue 0.0 plus 0.60931
@@ -39,6 +39,8 @@ Completed box being shipped out [1]
 ....\kern -0.00041
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.78735 minus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -75,7 +77,7 @@ Completed box being shipped out [1]
 ...\penalty 0
 ...\glue(\belowdisplayshortskip) 6.0 plus 3.0 minus 3.0
 ...\glue(\baselineskip) 5.70186
-...\hbox(8.10477+1.84438)x345.0, glue set 299.09052fil
+...\hbox(8.10477+1.84438)x345.0, glue set 292.30316fil
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 文
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 字
@@ -90,6 +92,8 @@ Completed box being shipped out [1]
 ....\kern -0.00041
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.78735 minus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -121,7 +125,7 @@ Completed box being shipped out [2]
 ..\vbox(550.0+0.0)x345.0, glue set 467.6257fil
 ...\write-{}
 ...\glue(\topskip) 1.76875
-...\hbox(8.23125+1.87599)x345.0, glue set 256.93304fil
+...\hbox(8.23125+1.87599)x345.0, glue set 250.14569fil
 ....\hbox(0.0+0.0)x21.07874
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 对
 ....\glue 0.0 plus 0.60931
@@ -141,6 +145,8 @@ Completed box being shipped out [2]
 ....\kern -0.00041
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.78735 minus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -257,7 +263,7 @@ Completed box being shipped out [2]
 ...\penalty 0
 ...\glue(\belowdisplayskip) 10.0 plus 2.0 minus 5.0
 ...\glue(\baselineskip) 3.33043
-...\hbox(8.17854+1.70737)x345.0, glue set 309.62988fil
+...\hbox(8.17854+1.70737)x345.0, glue set 302.84253fil
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 对
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 齐
@@ -270,6 +276,8 @@ Completed box being shipped out [2]
 ....\kern -0.00041
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.78735 minus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0

--- a/ctex/test/testfiles/basic01.tlg
+++ b/ctex/test/testfiles/basic01.tlg
@@ -21,7 +21,7 @@ Completed box being shipped out [1]
 ..\vbox(550.0+0.0)x345.0, glue set 539.94232fil
 ...\write-{}
 ...\glue(\topskip) 1.88469
-...\hbox(8.11531+2.27122)x345.0, glue set 261.88339fil
+...\hbox(8.11531+2.27122)x345.0, glue set 254.53746fil
 ....\hbox(0.0+0.0)x21.07874
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 你
 ....\glue 0.0 plus 0.60931
@@ -52,6 +52,8 @@ Completed box being shipped out [1]
 ....\kern -0.00044
 ....\kern -0.99611
 ....\kern 0.99611
+....\glue 7.34593 minus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -356,7 +358,7 @@ Completed box being shipped out [2]
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 6.18666
-...\hbox(8.2207+1.82329)x345.0, glue set 256.93304fil
+...\hbox(8.2207+1.82329)x345.0, glue set 250.14569fil
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 同
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 类
@@ -379,6 +381,8 @@ Completed box being shipped out [2]
 ....\kern -0.00041
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.78735 minus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -506,7 +510,7 @@ Completed box being shipped out [2]
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 6.18666
-...\hbox(8.2207+2.04462)x345.0, glue set 50.7619fil
+...\hbox(8.2207+2.04462)x345.0, glue set 43.97455fil
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 和
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 中
@@ -528,6 +532,7 @@ Completed box being shipped out [2]
 ....\kern -0.18752
 ....\kern 0.18752
 ....\glue 6.87167 minus 5.26968
+....\penalty 0
 ....\TU/lmr/m/n/10.53937 ctexrep
 ....\penalty 10000
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 、
@@ -549,6 +554,8 @@ Completed box being shipped out [2]
 ....\kern -0.00041
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.78735 minus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -580,7 +587,7 @@ Completed box being shipped out [3]
 ..\vbox(550.0+0.0)x345.0, glue set 486.18689fil
 ...\write-{}
 ...\glue(\topskip) 1.75821
-...\hbox(8.24179+1.85492)x345.0, glue set 77.7638fil
+...\hbox(8.24179+1.85492)x345.0, glue set 70.97644fil
 ....\hbox(0.0+0.0)x21.07874
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 勾
 ....\glue 0.0 plus 0.60931
@@ -636,6 +643,8 @@ Completed box being shipped out [3]
 ....\kern -0.00041
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.78735 minus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0

--- a/ctex/test/testfiles/basic01.tlg
+++ b/ctex/test/testfiles/basic01.tlg
@@ -53,7 +53,7 @@ Completed box being shipped out [1]
 ....\kern -0.99611
 ....\kern 0.99611
 ....\glue 7.34593 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -382,7 +382,7 @@ Completed box being shipped out [2]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.78735 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -532,7 +532,7 @@ Completed box being shipped out [2]
 ....\kern -0.18752
 ....\kern 0.18752
 ....\glue 6.87167 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/m/n/10.53937 ctexrep
 ....\penalty 10000
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 、
@@ -555,7 +555,7 @@ Completed box being shipped out [2]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.78735 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -644,7 +644,7 @@ Completed box being shipped out [3]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.78735 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0

--- a/ctex/test/testfiles/basic02.tlg
+++ b/ctex/test/testfiles/basic02.tlg
@@ -17,7 +17,7 @@ Completed box being shipped out [1]
 ..\vbox(550.0+0.0)x345.0, glue set 539.94232fil
 ...\write-{}
 ...\glue(\topskip) 2.3
-...\hbox(7.7+2.155)x345.0, glue set 271.13702fil
+...\hbox(7.7+2.155)x345.0, glue set 264.16702fil
 ....\hbox(0.0+0.0)x15.0
 ....\TU/FandolSong-Regular(0)/m/n/10 你
 ....\glue 0.0 plus 0.46875
@@ -48,6 +48,8 @@ Completed box being shipped out [1]
 ....\kern -0.00043
 ....\kern -0.99611
 ....\kern 0.99611
+....\glue 6.97 minus 5.0
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -362,7 +364,7 @@ Completed box being shipped out [2]
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 2.34003
-...\hbox(7.73+1.72998)x345.0, glue set 321.44fil
+...\hbox(7.73+1.72998)x345.0, glue set 315.0fil
 ....\TU/FandolSong-Regular(0)/m/n/10 文
 ....\glue 0.0 plus 0.46875
 ....\TU/FandolSong-Regular(0)/m/n/10 档
@@ -373,6 +375,8 @@ Completed box being shipped out [2]
 ....\kern -0.0004
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.44 minus 5.0
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -504,7 +508,7 @@ Completed box being shipped out [2]
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 2.27002
-...\hbox(7.8+1.93999)x345.0, glue set 85.81999fil
+...\hbox(7.8+1.93999)x345.0, glue set 79.37999fil
 ....\TU/FandolSong-Regular(0)/m/n/10 文
 ....\glue 0.0 plus 0.46875
 ....\TU/FandolSong-Regular(0)/m/n/10 文
@@ -522,6 +526,7 @@ Completed box being shipped out [2]
 ....\kern -0.18752
 ....\kern 0.18752
 ....\glue 6.52 minus 5.0
+....\penalty 0
 ....\TU/lmr/m/n/10 ctexrep
 ....\penalty 10000
 ....\TU/FandolSong-Regular(0)/m/n/10 、
@@ -543,6 +548,8 @@ Completed box being shipped out [2]
 ....\kern -0.0004
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.44 minus 5.0
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -575,7 +582,7 @@ Completed box being shipped out [3]
 ..\vbox(550.0+0.0)x345.0, glue set 495.11378fil
 ...\write-{}
 ...\glue(\topskip) 2.18
-...\hbox(7.82+1.75998)x345.0, glue set 96.44fil
+...\hbox(7.82+1.75998)x345.0, glue set 90.0fil
 ....\hbox(0.0+0.0)x15.0
 ....\TU/FandolSong-Regular(0)/m/n/10 勾
 ....\glue 0.0 plus 0.46875
@@ -631,6 +638,8 @@ Completed box being shipped out [3]
 ....\kern -0.0004
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.44 minus 5.0
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0

--- a/ctex/test/testfiles/basic02.tlg
+++ b/ctex/test/testfiles/basic02.tlg
@@ -49,7 +49,7 @@ Completed box being shipped out [1]
 ....\kern -0.99611
 ....\kern 0.99611
 ....\glue 6.97 minus 5.0
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -376,7 +376,7 @@ Completed box being shipped out [2]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.44 minus 5.0
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -526,7 +526,7 @@ Completed box being shipped out [2]
 ....\kern -0.18752
 ....\kern 0.18752
 ....\glue 6.52 minus 5.0
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/m/n/10 ctexrep
 ....\penalty 10000
 ....\TU/FandolSong-Regular(0)/m/n/10 、
@@ -549,7 +549,7 @@ Completed box being shipped out [2]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.44 minus 5.0
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -639,7 +639,7 @@ Completed box being shipped out [3]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.44 minus 5.0
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0

--- a/ctex/test/testfiles/basic03.tlg
+++ b/ctex/test/testfiles/basic03.tlg
@@ -16,7 +16,7 @@ Completed box being shipped out [1]
 ..\glue(\lineskip) 0.0
 ..\vbox(578.15999+0.0)x469.75499, glue set 568.15999fil
 ...\glue(\topskip) 1.88469
-...\hbox(8.11531+2.27122)x469.75499, glue set 386.63838fil
+...\hbox(8.11531+2.27122)x469.75499, glue set 379.29245fil
 ....\hbox(0.0+0.0)x21.07874
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 你
 ....\glue 0.0 plus 0.39433
@@ -47,6 +47,8 @@ Completed box being shipped out [1]
 ....\kern -0.00044
 ....\kern -0.99611
 ....\kern 0.99611
+....\glue 7.34593 minus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -325,7 +327,7 @@ Completed box being shipped out [2]
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 6.16557
-...\hbox(8.24179+1.85492)x469.75499, glue set 297.3731fil
+...\hbox(8.24179+1.85492)x469.75499, glue set 290.58574fil
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 书
 ....\glue 0.0 plus 0.39433
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 籍
@@ -366,6 +368,8 @@ Completed box being shipped out [2]
 ....\kern -0.00041
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.78735 minus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -512,6 +516,7 @@ Completed box being shipped out [2]
 ....\kern -0.18752
 ....\kern 0.18752
 ....\glue 6.87167 minus 5.26968
+....\penalty 0
 ....\TU/lmr/m/n/10.53937 ctexrep
 ....\penalty 10000
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 、
@@ -525,7 +530,7 @@ Completed box being shipped out [2]
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 6.26044
-...\hbox(8.1364+1.79167)x469.75499, glue set 444.92424fil
+...\hbox(8.1364+1.79167)x469.75499, glue set 438.13689fil
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 实
 ....\glue 0.0 plus 0.39433
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 现
@@ -536,6 +541,8 @@ Completed box being shipped out [2]
 ....\kern -0.00041
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.78735 minus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -562,7 +569,7 @@ Completed box being shipped out [3]
 ..\vbox(578.15999+0.0)x469.75499, glue set 514.3988fil
 ...\write-{}
 ...\glue(\topskip) 1.75821
-...\hbox(8.24179+1.85492)x469.75499, glue set 202.51878fil
+...\hbox(8.24179+1.85492)x469.75499, glue set 195.73143fil
 ....\hbox(0.0+0.0)x21.07874
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 勾
 ....\glue 0.0 plus 0.39433
@@ -618,6 +625,8 @@ Completed box being shipped out [3]
 ....\kern -0.00041
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.78735 minus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0

--- a/ctex/test/testfiles/basic03.tlg
+++ b/ctex/test/testfiles/basic03.tlg
@@ -48,7 +48,7 @@ Completed box being shipped out [1]
 ....\kern -0.99611
 ....\kern 0.99611
 ....\glue 7.34593 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -369,7 +369,7 @@ Completed box being shipped out [2]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.78735 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -516,7 +516,7 @@ Completed box being shipped out [2]
 ....\kern -0.18752
 ....\kern 0.18752
 ....\glue 6.87167 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/m/n/10.53937 ctexrep
 ....\penalty 10000
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 、
@@ -542,7 +542,7 @@ Completed box being shipped out [2]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.78735 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -626,7 +626,7 @@ Completed box being shipped out [3]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.78735 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0

--- a/ctex/test/testfiles/basic04.tlg
+++ b/ctex/test/testfiles/basic04.tlg
@@ -17,7 +17,7 @@ Completed box being shipped out [1]
 ..\vbox(550.0+0.0)x345.0, glue set 539.94232fil
 ...\write-{}
 ...\glue(\topskip) 1.88469
-...\hbox(8.11531+2.27122)x345.0, glue set 261.88339fil
+...\hbox(8.11531+2.27122)x345.0, glue set 254.53746fil
 ....\hbox(0.0+0.0)x21.07874
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 你
 ....\glue 0.0 plus 0.60931
@@ -48,6 +48,8 @@ Completed box being shipped out [1]
 ....\kern -0.00044
 ....\kern -0.99611
 ....\kern 0.99611
+....\glue 7.34593 minus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -353,7 +355,7 @@ Completed box being shipped out [2]
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 6.18666
-...\hbox(8.2207+1.82329)x345.0, glue set 256.93304fil
+...\hbox(8.2207+1.82329)x345.0, glue set 250.14569fil
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 同
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 类
@@ -376,6 +378,8 @@ Completed box being shipped out [2]
 ....\kern -0.00041
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.78735 minus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -503,7 +507,7 @@ Completed box being shipped out [2]
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 6.18666
-...\hbox(8.2207+2.04462)x345.0, glue set 50.7619fil
+...\hbox(8.2207+2.04462)x345.0, glue set 43.97455fil
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 和
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 中
@@ -525,6 +529,7 @@ Completed box being shipped out [2]
 ....\kern -0.18752
 ....\kern 0.18752
 ....\glue 6.87167 minus 5.26968
+....\penalty 0
 ....\TU/lmr/m/n/10.53937 ctexrep
 ....\penalty 10000
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 、
@@ -546,6 +551,8 @@ Completed box being shipped out [2]
 ....\kern -0.00041
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.78735 minus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -578,7 +585,7 @@ Completed box being shipped out [3]
 ..\vbox(550.0+0.0)x345.0, glue set 486.18689fil
 ...\write-{}
 ...\glue(\topskip) 1.75821
-...\hbox(8.24179+1.85492)x345.0, glue set 77.7638fil
+...\hbox(8.24179+1.85492)x345.0, glue set 70.97644fil
 ....\hbox(0.0+0.0)x21.07874
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 勾
 ....\glue 0.0 plus 0.60931
@@ -634,6 +641,8 @@ Completed box being shipped out [3]
 ....\kern -0.00041
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.78735 minus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0

--- a/ctex/test/testfiles/basic04.tlg
+++ b/ctex/test/testfiles/basic04.tlg
@@ -49,7 +49,7 @@ Completed box being shipped out [1]
 ....\kern -0.99611
 ....\kern 0.99611
 ....\glue 7.34593 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -379,7 +379,7 @@ Completed box being shipped out [2]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.78735 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -529,7 +529,7 @@ Completed box being shipped out [2]
 ....\kern -0.18752
 ....\kern 0.18752
 ....\glue 6.87167 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/m/n/10.53937 ctexrep
 ....\penalty 10000
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 、
@@ -552,7 +552,7 @@ Completed box being shipped out [2]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.78735 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -642,7 +642,7 @@ Completed box being shipped out [3]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.78735 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0

--- a/ctex/test/testfiles/basic05.tlg
+++ b/ctex/test/testfiles/basic05.tlg
@@ -17,7 +17,7 @@ Completed box being shipped out [1]
 ..\vbox(550.0+0.0)x345.0, glue set 539.94232fil
 ...\write-{}
 ...\glue(\topskip) 1.88469
-...\hbox(8.11531+2.27122)x345.0, glue set 261.88339fil
+...\hbox(8.11531+2.27122)x345.0, glue set 254.53746fil
 ....\hbox(0.0+0.0)x21.07874
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 你
 ....\glue 0.0 plus 0.60931
@@ -48,6 +48,8 @@ Completed box being shipped out [1]
 ....\kern -0.00044
 ....\kern -0.99611
 ....\kern 0.99611
+....\glue 7.34593 minus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -353,7 +355,7 @@ Completed box being shipped out [2]
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 6.18666
-...\hbox(8.2207+1.82329)x345.0, glue set 256.93304fil
+...\hbox(8.2207+1.82329)x345.0, glue set 250.14569fil
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 同
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 类
@@ -376,6 +378,8 @@ Completed box being shipped out [2]
 ....\kern -0.00041
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.78735 minus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -503,7 +507,7 @@ Completed box being shipped out [2]
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 6.18666
-...\hbox(8.2207+2.04462)x345.0, glue set 50.7619fil
+...\hbox(8.2207+2.04462)x345.0, glue set 43.97455fil
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 和
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 中
@@ -525,6 +529,7 @@ Completed box being shipped out [2]
 ....\kern -0.18752
 ....\kern 0.18752
 ....\glue 6.87167 minus 5.26968
+....\penalty 0
 ....\TU/lmr/m/n/10.53937 ctexrep
 ....\penalty 10000
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 、
@@ -546,6 +551,8 @@ Completed box being shipped out [2]
 ....\kern -0.00041
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.78735 minus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -578,7 +585,7 @@ Completed box being shipped out [3]
 ..\vbox(550.0+0.0)x345.0, glue set 486.18689fil
 ...\write-{}
 ...\glue(\topskip) 1.75821
-...\hbox(8.24179+1.85492)x345.0, glue set 77.7638fil
+...\hbox(8.24179+1.85492)x345.0, glue set 70.97644fil
 ....\hbox(0.0+0.0)x21.07874
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 勾
 ....\glue 0.0 plus 0.60931
@@ -634,6 +641,8 @@ Completed box being shipped out [3]
 ....\kern -0.00041
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.78735 minus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0

--- a/ctex/test/testfiles/basic05.tlg
+++ b/ctex/test/testfiles/basic05.tlg
@@ -49,7 +49,7 @@ Completed box being shipped out [1]
 ....\kern -0.99611
 ....\kern 0.99611
 ....\glue 7.34593 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -379,7 +379,7 @@ Completed box being shipped out [2]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.78735 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -529,7 +529,7 @@ Completed box being shipped out [2]
 ....\kern -0.18752
 ....\kern 0.18752
 ....\glue 6.87167 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/m/n/10.53937 ctexrep
 ....\penalty 10000
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 、
@@ -552,7 +552,7 @@ Completed box being shipped out [2]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.78735 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -642,7 +642,7 @@ Completed box being shipped out [3]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.78735 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0

--- a/ctex/test/testfiles/beamer01.tlg
+++ b/ctex/test/testfiles/beamer01.tlg
@@ -729,7 +729,7 @@ Completed box being shipped out [3]
 .......\glue(\rightskip) 0.0 plus 1.0fil
 ......\penalty 150
 ......\glue(\baselineskip) 2.93472
-......\hbox(8.5848+2.03668)x307.28987, glue set 47.67087fil
+......\hbox(8.5848+2.03668)x307.28987, glue set 44.14497fil
 .......\TU/FandolHei-Regular(0)/m/n/10.95 报
 .......\glue 0.0 plus 0.4477
 .......\TU/FandolHei-Regular(0)/m/n/10.95 告
@@ -778,6 +778,8 @@ Completed box being shipped out [3]
 .......\kern -0.00043
 .......\kern -0.18753
 .......\kern 0.18753
+.......\glue 7.0518 minus 5.475
+.......\penalty 0
 .......\penalty 10000
 .......\glue(\parfillskip) 0.0 plus 1.0fil
 .......\glue(\rightskip) 0.0 plus 1.0fil
@@ -925,6 +927,7 @@ Completed box being shipped out [3]
 .......\kern -0.18752
 .......\kern 0.18752
 .......\glue 7.1394 minus 5.475
+.......\penalty 0
 .......\TU/lmss/m/n/10.95 ctexrep
 .......\penalty 10000
 .......\TU/FandolHei-Regular(0)/m/n/10.95 、
@@ -934,7 +937,7 @@ Completed box being shipped out [3]
 .......\glue(\rightskip) 0.0 plus 1.0fil
 ......\penalty 150
 ......\glue(\baselineskip) 3.03328
-......\hbox(8.44244+1.81769)x307.28987, glue set 105.5635fil
+......\hbox(8.44244+1.81769)x307.28987, glue set 102.03761fil
 .......\TU/FandolHei-Regular(0)/m/n/10.95 和
 .......\glue 3.64635 plus 1.82317 minus 1.21544
 .......\TU/lmss/m/n/10.95 ctexbeamer
@@ -949,6 +952,8 @@ Completed box being shipped out [3]
 .......\kern -0.00043
 .......\kern -0.18753
 .......\kern 0.18753
+.......\glue 7.0518 minus 5.475
+.......\penalty 0
 .......\penalty 10000
 .......\glue(\parfillskip) 0.0 plus 1.0fil
 .......\glue(\rightskip) 0.0 plus 1.0fil
@@ -1413,7 +1418,7 @@ Completed box being shipped out [5]
 ........\glue(\parskip) 0.0
 ........\glue(\parskip) 0.0
 ........\glue(\baselineskip) 5.01521
-........\hbox(8.5848+2.01479)x307.28987, glue set 53.14587fil
+........\hbox(8.5848+2.01479)x307.28987, glue set 49.61996fil
 .........\hbox(0.0+0.0)x0.0
 .........\TU/FandolHei-Regular(0)/m/n/10.95 直
 .........\glue 0.0 plus 0.4477
@@ -1457,6 +1462,8 @@ Completed box being shipped out [5]
 .........\kern -0.00043
 .........\kern -0.18753
 .........\kern 0.18753
+.........\glue 7.0518 minus 5.475
+.........\penalty 0
 .........\penalty 10000
 .........\glue(\parfillskip) 0.0 plus 1.0fil
 .........\glue(\rightskip) 0.0 plus 1.0fil

--- a/ctex/test/testfiles/beamer01.tlg
+++ b/ctex/test/testfiles/beamer01.tlg
@@ -779,7 +779,7 @@ Completed box being shipped out [3]
 .......\kern -0.18753
 .......\kern 0.18753
 .......\glue 7.0518 minus 5.475
-.......\penalty 0
+.......\penalty 10000
 .......\penalty 10000
 .......\glue(\parfillskip) 0.0 plus 1.0fil
 .......\glue(\rightskip) 0.0 plus 1.0fil
@@ -927,7 +927,7 @@ Completed box being shipped out [3]
 .......\kern -0.18752
 .......\kern 0.18752
 .......\glue 7.1394 minus 5.475
-.......\penalty 0
+.......\penalty 10000
 .......\TU/lmss/m/n/10.95 ctexrep
 .......\penalty 10000
 .......\TU/FandolHei-Regular(0)/m/n/10.95 、
@@ -953,7 +953,7 @@ Completed box being shipped out [3]
 .......\kern -0.18753
 .......\kern 0.18753
 .......\glue 7.0518 minus 5.475
-.......\penalty 0
+.......\penalty 10000
 .......\penalty 10000
 .......\glue(\parfillskip) 0.0 plus 1.0fil
 .......\glue(\rightskip) 0.0 plus 1.0fil
@@ -1463,7 +1463,7 @@ Completed box being shipped out [5]
 .........\kern -0.18753
 .........\kern 0.18753
 .........\glue 7.0518 minus 5.475
-.........\penalty 0
+.........\penalty 10000
 .........\penalty 10000
 .........\glue(\parfillskip) 0.0 plus 1.0fil
 .........\glue(\rightskip) 0.0 plus 1.0fil

--- a/ctex/test/testfiles/beamer02.tlg
+++ b/ctex/test/testfiles/beamer02.tlg
@@ -775,7 +775,7 @@ Completed box being shipped out [3]
 .......\kern -0.18753
 .......\kern 0.18753
 .......\glue 7.0518 minus 5.475
-.......\penalty 0
+.......\penalty 10000
 .......\penalty 10000
 .......\glue(\parfillskip) 0.0 plus 1.0fil
 .......\glue(\rightskip) 0.0 plus 1.0fil
@@ -923,7 +923,7 @@ Completed box being shipped out [3]
 .......\kern -0.18752
 .......\kern 0.18752
 .......\glue 7.1394 minus 5.475
-.......\penalty 0
+.......\penalty 10000
 .......\TU/lmss/m/n/10.95 ctexrep
 .......\penalty 10000
 .......\TU/FandolHei-Regular(0)/m/n/10.95 、
@@ -949,7 +949,7 @@ Completed box being shipped out [3]
 .......\kern -0.18753
 .......\kern 0.18753
 .......\glue 7.0518 minus 5.475
-.......\penalty 0
+.......\penalty 10000
 .......\penalty 10000
 .......\glue(\parfillskip) 0.0 plus 1.0fil
 .......\glue(\rightskip) 0.0 plus 1.0fil
@@ -1457,7 +1457,7 @@ Completed box being shipped out [5]
 .........\kern -0.18753
 .........\kern 0.18753
 .........\glue 7.0518 minus 5.475
-.........\penalty 0
+.........\penalty 10000
 .........\penalty 10000
 .........\glue(\parfillskip) 0.0 plus 1.0fil
 .........\glue(\rightskip) 0.0 plus 1.0fil

--- a/ctex/test/testfiles/beamer02.tlg
+++ b/ctex/test/testfiles/beamer02.tlg
@@ -725,7 +725,7 @@ Completed box being shipped out [3]
 .......\glue(\rightskip) 0.0 plus 1.0fil
 ......\penalty 150
 ......\glue(\baselineskip) 2.93472
-......\hbox(8.5848+2.03668)x307.28987, glue set 47.67087fil
+......\hbox(8.5848+2.03668)x307.28987, glue set 44.14497fil
 .......\TU/FandolHei-Regular(0)/m/n/10.95 报
 .......\glue 0.0 plus 0.4477
 .......\TU/FandolHei-Regular(0)/m/n/10.95 告
@@ -774,6 +774,8 @@ Completed box being shipped out [3]
 .......\kern -0.00043
 .......\kern -0.18753
 .......\kern 0.18753
+.......\glue 7.0518 minus 5.475
+.......\penalty 0
 .......\penalty 10000
 .......\glue(\parfillskip) 0.0 plus 1.0fil
 .......\glue(\rightskip) 0.0 plus 1.0fil
@@ -921,6 +923,7 @@ Completed box being shipped out [3]
 .......\kern -0.18752
 .......\kern 0.18752
 .......\glue 7.1394 minus 5.475
+.......\penalty 0
 .......\TU/lmss/m/n/10.95 ctexrep
 .......\penalty 10000
 .......\TU/FandolHei-Regular(0)/m/n/10.95 、
@@ -930,7 +933,7 @@ Completed box being shipped out [3]
 .......\glue(\rightskip) 0.0 plus 1.0fil
 ......\penalty 150
 ......\glue(\baselineskip) 3.03328
-......\hbox(8.44244+1.81769)x307.28987, glue set 105.5635fil
+......\hbox(8.44244+1.81769)x307.28987, glue set 102.03761fil
 .......\TU/FandolHei-Regular(0)/m/n/10.95 和
 .......\glue 3.64635 plus 1.82317 minus 1.21544
 .......\TU/lmss/m/n/10.95 ctexbeamer
@@ -945,6 +948,8 @@ Completed box being shipped out [3]
 .......\kern -0.00043
 .......\kern -0.18753
 .......\kern 0.18753
+.......\glue 7.0518 minus 5.475
+.......\penalty 0
 .......\penalty 10000
 .......\glue(\parfillskip) 0.0 plus 1.0fil
 .......\glue(\rightskip) 0.0 plus 1.0fil
@@ -1407,7 +1412,7 @@ Completed box being shipped out [5]
 ........\glue(\parskip) 0.0
 ........\glue(\parskip) 0.0
 ........\glue(\baselineskip) 5.01521
-........\hbox(8.5848+2.01479)x307.28987, glue set 53.14587fil
+........\hbox(8.5848+2.01479)x307.28987, glue set 49.61996fil
 .........\hbox(0.0+0.0)x0.0
 .........\TU/FandolHei-Regular(0)/m/n/10.95 直
 .........\glue 0.0 plus 0.4477
@@ -1451,6 +1456,8 @@ Completed box being shipped out [5]
 .........\kern -0.00043
 .........\kern -0.18753
 .........\kern 0.18753
+.........\glue 7.0518 minus 5.475
+.........\penalty 0
 .........\penalty 10000
 .........\glue(\parfillskip) 0.0 plus 1.0fil
 .........\glue(\rightskip) 0.0 plus 1.0fil

--- a/ctex/test/testfiles/bibliography01.tlg
+++ b/ctex/test/testfiles/bibliography01.tlg
@@ -59,7 +59,7 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 4.0 plus 2.0 minus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 5.93523
-...\hbox(8.05208+2.63483)x328.87042, glue set 272.42157fil, shifted 16.12958
+...\hbox(8.05208+2.63483)x328.87042, glue set 265.63422fil, shifted 16.12958
 ....\hbox(7.90453+2.63483)x0.0
 .....\glue 0.0
 .....\glue -11.12958
@@ -87,6 +87,8 @@ Completed box being shipped out [1]
 ....\kern -0.00041
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.78735 minus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -95,7 +97,7 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 4.0 plus 2.0 minus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 5.75455
-...\hbox(8.05208+2.63483)x328.87042, glue set 272.42157fil, shifted 16.12958
+...\hbox(8.05208+2.63483)x328.87042, glue set 265.63422fil, shifted 16.12958
 ....\hbox(7.90453+2.63483)x0.0
 .....\glue 0.0
 .....\glue -11.12958
@@ -123,6 +125,8 @@ Completed box being shipped out [1]
 ....\kern -0.00041
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.78735 minus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0

--- a/ctex/test/testfiles/bibliography01.tlg
+++ b/ctex/test/testfiles/bibliography01.tlg
@@ -88,7 +88,7 @@ Completed box being shipped out [1]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.78735 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -126,7 +126,7 @@ Completed box being shipped out [1]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.78735 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0

--- a/ctex/test/testfiles/ctexrep01.tlg
+++ b/ctex/test/testfiles/ctexrep01.tlg
@@ -345,6 +345,7 @@ Completed box being shipped out [3]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 13.91197 minus 11.04124
+....\penalty 0
 ....\TU/lmr/bx/n/22.08249 Part
 ....\kern -0.0002
 ....\kern 0.0002
@@ -402,6 +403,7 @@ Completed box being shipped out [4]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 13.91197 minus 11.04124
+....\penalty 0
 ....\TU/lmr/bx/n/22.08249 Chapter
 ....\kern -0.0002
 ....\kern 0.0002
@@ -448,6 +450,7 @@ Completed box being shipped out [4]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 9.48543 minus 7.52812
+....\penalty 0
 ....\TU/lmr/bx/n/15.05624 Section
 ....\kern -0.0002
 ....\kern 0.0002
@@ -495,6 +498,7 @@ Completed box being shipped out [4]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 7.58835 minus 6.02249
+....\penalty 0
 ....\TU/lmr/bx/n/12.045 Subsection
 ....\kern -0.0002
 ....\kern 0.0002

--- a/ctex/test/testfiles/ctexrep01.tlg
+++ b/ctex/test/testfiles/ctexrep01.tlg
@@ -345,7 +345,7 @@ Completed box being shipped out [3]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 13.91197 minus 11.04124
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/22.08249 Part
 ....\kern -0.0002
 ....\kern 0.0002
@@ -403,7 +403,7 @@ Completed box being shipped out [4]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 13.91197 minus 11.04124
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/22.08249 Chapter
 ....\kern -0.0002
 ....\kern 0.0002
@@ -450,7 +450,7 @@ Completed box being shipped out [4]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 9.48543 minus 7.52812
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/15.05624 Section
 ....\kern -0.0002
 ....\kern 0.0002
@@ -498,7 +498,7 @@ Completed box being shipped out [4]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 7.58835 minus 6.02249
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/12.045 Subsection
 ....\kern -0.0002
 ....\kern 0.0002

--- a/ctex/test/testfiles/ctexset-full01.tlg
+++ b/ctex/test/testfiles/ctexset-full01.tlg
@@ -54,7 +54,7 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 4.29962
-...\hbox(8.18909+1.93922)x345.0, glue set 235.85431fil
+...\hbox(8.18909+1.93922)x345.0, glue set 229.06696fil
 ....\hbox(0.0+0.0)x21.07874
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 本
 ....\glue 0.0 plus 0.60931
@@ -78,6 +78,8 @@ Completed box being shipped out [1]
 ....\kern -0.00041
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.78735 minus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -112,7 +114,7 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 5.78616
-...\hbox(8.12585+1.84438)x345.0, glue set 278.01178fil
+...\hbox(8.12585+1.84438)x345.0, glue set 271.22443fil
 ....\hbox(0.0+0.0)x21.07874
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 引
 ....\glue 0.0 plus 0.60931
@@ -128,6 +130,8 @@ Completed box being shipped out [1]
 ....\kern -0.00041
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.78735 minus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -162,7 +166,7 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 5.7967
-...\hbox(8.11531+1.84438)x345.0, glue set 278.01178fil
+...\hbox(8.11531+1.84438)x345.0, glue set 271.22443fil
 ....\hbox(0.0+0.0)x21.07874
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 背
 ....\glue 0.0 plus 0.60931
@@ -178,6 +182,8 @@ Completed box being shipped out [1]
 ....\kern -0.00041
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.78735 minus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0

--- a/ctex/test/testfiles/ctexset-full01.tlg
+++ b/ctex/test/testfiles/ctexset-full01.tlg
@@ -79,7 +79,7 @@ Completed box being shipped out [1]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.78735 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -131,7 +131,7 @@ Completed box being shipped out [1]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.78735 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -183,7 +183,7 @@ Completed box being shipped out [1]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.78735 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0

--- a/ctex/test/testfiles/fonts01.tlg
+++ b/ctex/test/testfiles/fonts01.tlg
@@ -72,7 +72,7 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 ，
 ....\rule(0.0+0.0)x-7.29324
-....\penalty 0
+....\penalty 10000
 ....\glue 7.29324 minus 5.26968
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolSong-Regular(0)/b/n/10.53937 宇
@@ -87,7 +87,7 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\TU/FandolSong-Regular(0)/b/n/10.53937 。
 ....\rule(0.0+0.0)x-6.78735
-....\penalty 0
+....\penalty 10000
 ....\glue 6.78735 minus 5.28023
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolSong-Regular(0)/m/it/10.53937 日
@@ -102,7 +102,7 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\TU/FandolSong-Regular(0)/m/it/10.53937 ，
 ....\rule(0.0+0.0)x-7.29324
-....\penalty 0
+....\penalty 10000
 ....\glue 7.29324 minus 5.26968
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolSong-Regular(0)/b/n/10.53937 辰
@@ -117,7 +117,7 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\TU/FandolSong-Regular(0)/b/n/10.53937 。
 ....\rule(0.0+0.0)x-6.78735
-....\penalty 0
+....\penalty 10000
 ....\glue 6.78735 minus 5.28023
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolHei-Regular(0)/m/n/10.53937 寒
@@ -135,7 +135,7 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\TU/FandolHei-Regular(0)/m/n/10.53937 ，
 ....\rule(0.0+0.0)x-7.46187
-....\penalty 0
+....\penalty 10000
 ....\glue 7.46187 minus 5.26968
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolHei-Regular(0)/b/n/10.53937 秋
@@ -150,7 +150,7 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\TU/FandolHei-Regular(0)/b/n/10.53937 。
 ....\rule(0.0+0.0)x-6.78735
-....\penalty 0
+....\penalty 10000
 ....\glue 6.78735 minus 5.26968
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolHei-Regular(0)/m/n/10.53937 闰
@@ -165,7 +165,7 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\TU/FandolHei-Regular(0)/m/n/10.53937 ，
 ....\rule(0.0+0.0)x-7.46187
-....\penalty 0
+....\penalty 10000
 ....\glue 7.46187 minus 5.26968
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolHei-Regular(0)/b/n/10.53937 律
@@ -180,7 +180,7 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\TU/FandolHei-Regular(0)/b/n/10.53937 。
 ....\rule(0.0+0.0)x-6.78735
-....\penalty 0
+....\penalty 10000
 ....\glue 6.78735 minus 5.26968
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolFang-Regular(0)/b/n/10.53937 云
@@ -195,7 +195,7 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\TU/FandolFang-Regular(0)/b/n/10.53937 ，
 ....\rule(0.0+0.0)x-7.29324
-....\penalty 0
+....\penalty 10000
 ....\glue 7.29324 minus 5.26968
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolFang-Regular(0)/b/n/10.53937 露
@@ -213,7 +213,7 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\TU/FandolFang-Regular(0)/b/n/10.53937 。
 ....\rule(0.0+0.0)x-6.78735
-....\penalty 0
+....\penalty 10000
 ....\glue 6.78735 minus 5.26968
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolFang-Regular(0)/b/n/10.53937 金
@@ -228,7 +228,7 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\TU/FandolFang-Regular(0)/b/n/10.53937 ，
 ....\rule(0.0+0.0)x-7.29324
-....\penalty 0
+....\penalty 10000
 ....\glue 7.29324 minus 5.26968
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolFang-Regular(0)/b/n/10.53937 玉
@@ -248,7 +248,7 @@ Completed box being shipped out [1]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.78735 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -325,7 +325,7 @@ Completed box being shipped out [2]
 ....\penalty 10000
 ....\TU/FandolSong-Regular(1)/m/n/10.53937 ，
 ....\rule(0.0+0.0)x-7.29324
-....\penalty 0
+....\penalty 10000
 ....\glue 7.29324 minus 5.26968
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolSong-Regular(1)/b/n/10.53937 珠
@@ -340,7 +340,7 @@ Completed box being shipped out [2]
 ....\penalty 10000
 ....\TU/FandolSong-Regular(1)/b/n/10.53937 。
 ....\rule(0.0+0.0)x-6.78735
-....\penalty 0
+....\penalty 10000
 ....\glue 6.78735 minus 5.28023
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolSong-Regular(1)/m/n/10.53937 果
@@ -355,7 +355,7 @@ Completed box being shipped out [2]
 ....\penalty 10000
 ....\TU/FandolSong-Regular(1)/m/n/10.53937 ，
 ....\rule(0.0+0.0)x-7.29324
-....\penalty 0
+....\penalty 10000
 ....\glue 7.29324 minus 5.26968
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolSong-Regular(1)/b/n/10.53937 菜
@@ -370,7 +370,7 @@ Completed box being shipped out [2]
 ....\penalty 10000
 ....\TU/FandolSong-Regular(1)/b/n/10.53937 。
 ....\rule(0.0+0.0)x-6.78735
-....\penalty 0
+....\penalty 10000
 ....\glue 6.78735 minus 5.28023
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolHei-Regular(0)/m/n/10.53937 海
@@ -388,7 +388,7 @@ Completed box being shipped out [2]
 ....\penalty 10000
 ....\TU/FandolHei-Regular(0)/m/n/10.53937 ，
 ....\rule(0.0+0.0)x-7.46187
-....\penalty 0
+....\penalty 10000
 ....\glue 7.46187 minus 5.26968
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolHei-Regular(0)/b/n/10.53937 鳞
@@ -403,7 +403,7 @@ Completed box being shipped out [2]
 ....\penalty 10000
 ....\TU/FandolHei-Regular(0)/b/n/10.53937 。
 ....\rule(0.0+0.0)x-6.78735
-....\penalty 0
+....\penalty 10000
 ....\glue 6.78735 minus 5.26968
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolHei-Regular(0)/m/n/10.53937 龙
@@ -418,7 +418,7 @@ Completed box being shipped out [2]
 ....\penalty 10000
 ....\TU/FandolHei-Regular(0)/m/n/10.53937 ，
 ....\rule(0.0+0.0)x-7.46187
-....\penalty 0
+....\penalty 10000
 ....\glue 7.46187 minus 5.26968
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolHei-Regular(0)/b/n/10.53937 鸟
@@ -433,7 +433,7 @@ Completed box being shipped out [2]
 ....\penalty 10000
 ....\TU/FandolHei-Regular(0)/b/n/10.53937 。
 ....\rule(0.0+0.0)x-6.78735
-....\penalty 0
+....\penalty 10000
 ....\glue 6.78735 minus 5.26968
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolFang-Regular(0)/b/n/10.53937 始
@@ -448,7 +448,7 @@ Completed box being shipped out [2]
 ....\penalty 10000
 ....\TU/FandolFang-Regular(0)/b/n/10.53937 ，
 ....\rule(0.0+0.0)x-7.29324
-....\penalty 0
+....\penalty 10000
 ....\glue 7.29324 minus 5.26968
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolFang-Regular(0)/b/n/10.53937 乃
@@ -465,7 +465,7 @@ Completed box being shipped out [2]
 ....\penalty 10000
 ....\TU/FandolFang-Regular(0)/b/n/10.53937 。
 ....\rule(0.0+0.0)x-6.78735
-....\penalty 0
+....\penalty 10000
 ....\glue 6.78735 minus 5.26968
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolFang-Regular(0)/b/n/10.53937 推
@@ -480,7 +480,7 @@ Completed box being shipped out [2]
 ....\penalty 10000
 ....\TU/FandolFang-Regular(0)/b/n/10.53937 ，
 ....\rule(0.0+0.0)x-7.29324
-....\penalty 0
+....\penalty 10000
 ....\glue 7.29324 minus 5.26968
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolFang-Regular(0)/b/n/10.53937 有
@@ -495,7 +495,7 @@ Completed box being shipped out [2]
 ....\penalty 10000
 ....\TU/FandolFang-Regular(0)/b/n/10.53937 。
 ....\rule(0.0+0.0)x-6.78735
-....\penalty 0
+....\penalty 10000
 ....\glue 6.78735 minus 5.26968
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolKai-Regular(0)/b/n/10.53937 吊
@@ -510,7 +510,7 @@ Completed box being shipped out [2]
 ....\penalty 10000
 ....\TU/FandolKai-Regular(0)/b/n/10.53937 ，
 ....\rule(0.0+0.0)x-7.29324
-....\penalty 0
+....\penalty 10000
 ....\glue 7.29324 minus 5.26968
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolKai-Regular(0)/b/n/10.53937 周
@@ -525,7 +525,7 @@ Completed box being shipped out [2]
 ....\penalty 10000
 ....\TU/FandolKai-Regular(0)/b/n/10.53937 。
 ....\rule(0.0+0.0)x-6.78735
-....\penalty 0
+....\penalty 10000
 ....\glue 6.78735 minus 5.26968
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolKai-Regular(0)/b/n/10.53937 坐
@@ -543,7 +543,7 @@ Completed box being shipped out [2]
 ....\penalty 10000
 ....\TU/FandolKai-Regular(0)/b/n/10.53937 ，
 ....\rule(0.0+0.0)x-7.29324
-....\penalty 0
+....\penalty 10000
 ....\glue 7.29324 minus 5.26968
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolKai-Regular(0)/b/n/10.53937 垂
@@ -563,7 +563,7 @@ Completed box being shipped out [2]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.78735 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -595,7 +595,7 @@ Completed box being shipped out [3]
 ..\vbox(550.0+0.0)x345.0, glue set 490.62325fil
 ...\write-{}
 ...\glue(\topskip) 1.83199
-...\hbox(8.16801+2.10786)x345.0, glue set 0.08685
+...\hbox(8.16801+2.10786)x345.0, glue set - 0.49318
 ....\hbox(0.0+0.0)x21.07874
 ....\TU/FandolSong-Regular(1)/m/n/10.53937 爱
 ....\glue 0.0 plus 0.60931
@@ -609,7 +609,7 @@ Completed box being shipped out [3]
 ....\penalty 10000
 ....\TU/FandolSong-Regular(1)/m/n/10.53937 ，
 ....\rule(0.0+0.0)x-7.29324
-....\penalty 0
+....\penalty 10000
 ....\glue 7.29324 minus 5.26968
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolSong-Regular(1)/b/n/10.53937 臣
@@ -624,7 +624,7 @@ Completed box being shipped out [3]
 ....\penalty 10000
 ....\TU/FandolSong-Regular(1)/b/n/10.53937 。
 ....\rule(0.0+0.0)x-6.78735
-....\penalty 0
+....\penalty 10000
 ....\glue 6.78735 minus 5.28023
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolSong-Regular(1)/m/n/10.53937 遐
@@ -639,7 +639,7 @@ Completed box being shipped out [3]
 ....\penalty 10000
 ....\TU/FandolSong-Regular(1)/m/n/10.53937 ，
 ....\rule(0.0+0.0)x-7.29324
-....\penalty 0
+....\penalty 10000
 ....\glue 7.29324 minus 5.26968
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolSong-Regular(1)/b/n/10.53937 率
@@ -654,7 +654,7 @@ Completed box being shipped out [3]
 ....\penalty 10000
 ....\TU/FandolSong-Regular(1)/b/n/10.53937 。
 ....\rule(0.0+0.0)x-6.78735
-....\penalty 0
+....\penalty 10000
 ....\glue 6.78735 minus 5.28023
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolHei-Regular(0)/m/n/10.53937 鸣
@@ -669,13 +669,14 @@ Completed box being shipped out [3]
 ....\penalty 10000
 ....\TU/FandolHei-Regular(0)/m/n/10.53937 ，
 ....\rule(0.0+0.0)x-7.46187
-....\penalty 0
+....\penalty 10000
+....\glue 7.46187 minus 5.26968
+....\glue 0.0 plus 0.60931
+....\TU/FandolHei-Regular(0)/b/n/10.53937 白
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 5.87047
 ...\hbox(8.46312+2.10786)x345.0, glue set 0.05281
-....\TU/FandolHei-Regular(0)/b/n/10.53937 白
-....\glue 0.0 plus 0.60931
 ....\TU/FandolHei-Regular(0)/b/n/10.53937 驹
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolHei-Regular(0)/b/n/10.53937 食
@@ -686,7 +687,7 @@ Completed box being shipped out [3]
 ....\penalty 10000
 ....\TU/FandolHei-Regular(0)/b/n/10.53937 。
 ....\rule(0.0+0.0)x-6.78735
-....\penalty 0
+....\penalty 10000
 ....\glue 6.78735 minus 5.26968
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolHei-Regular(0)/m/n/10.53937 化
@@ -701,7 +702,7 @@ Completed box being shipped out [3]
 ....\penalty 10000
 ....\TU/FandolHei-Regular(0)/m/n/10.53937 ，
 ....\rule(0.0+0.0)x-7.46187
-....\penalty 0
+....\penalty 10000
 ....\glue 7.46187 minus 5.26968
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolHei-Regular(0)/b/n/10.53937 赖
@@ -716,7 +717,7 @@ Completed box being shipped out [3]
 ....\penalty 10000
 ....\TU/FandolHei-Regular(0)/b/n/10.53937 。
 ....\rule(0.0+0.0)x-6.78735
-....\penalty 0
+....\penalty 10000
 ....\glue 6.78735 minus 5.26968
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolFang-Regular(0)/b/n/10.53937 盖
@@ -731,7 +732,7 @@ Completed box being shipped out [3]
 ....\penalty 10000
 ....\TU/FandolFang-Regular(0)/b/n/10.53937 ，
 ....\rule(0.0+0.0)x-7.29324
-....\penalty 0
+....\penalty 10000
 ....\glue 7.29324 minus 5.26968
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolFang-Regular(0)/b/n/10.53937 四
@@ -746,15 +747,15 @@ Completed box being shipped out [3]
 ....\penalty 10000
 ....\TU/FandolFang-Regular(0)/b/n/10.53937 。
 ....\rule(0.0+0.0)x-6.78735
-....\penalty 0
+....\penalty 10000
 ....\glue 6.78735 minus 5.26968
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolFang-Regular(0)/b/n/10.53937 恭
-....\glue(\rightskip) 0.0
-...\glue(\baselineskip) 5.97588
-...\hbox(8.35771+2.10786)x345.0, glue set - 0.04768
-....\TU/FandolFang-Regular(0)/b/n/10.53937 惟
 ....\glue 0.0 plus 0.60931
+....\TU/FandolFang-Regular(0)/b/n/10.53937 惟
+....\glue(\rightskip) 0.0
+...\glue(\baselineskip) 5.99695
+...\hbox(8.33664+2.10786)x345.0, glue set - 0.04768
 ....\TU/FandolFang-Regular(0)/b/n/10.53937 鞠
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolFang-Regular(0)/b/n/10.53937 养
@@ -763,7 +764,7 @@ Completed box being shipped out [3]
 ....\penalty 10000
 ....\TU/FandolFang-Regular(0)/b/n/10.53937 ，
 ....\rule(0.0+0.0)x-7.29324
-....\penalty 0
+....\penalty 10000
 ....\glue 7.29324 minus 5.26968
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolFang-Regular(0)/b/n/10.53937 岂
@@ -778,7 +779,7 @@ Completed box being shipped out [3]
 ....\penalty 10000
 ....\TU/FandolFang-Regular(0)/b/n/10.53937 。
 ....\rule(0.0+0.0)x-6.78735
-....\penalty 0
+....\penalty 10000
 ....\glue 6.78735 minus 5.26968
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolKai-Regular(0)/b/n/10.53937 女
@@ -793,7 +794,7 @@ Completed box being shipped out [3]
 ....\penalty 10000
 ....\TU/FandolKai-Regular(0)/b/n/10.53937 ，
 ....\rule(0.0+0.0)x-7.29324
-....\penalty 0
+....\penalty 10000
 ....\glue 7.29324 minus 5.26968
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolKai-Regular(0)/b/n/10.53937 男
@@ -808,7 +809,7 @@ Completed box being shipped out [3]
 ....\penalty 10000
 ....\TU/FandolKai-Regular(0)/b/n/10.53937 。
 ....\rule(0.0+0.0)x-6.78735
-....\penalty 0
+....\penalty 10000
 ....\glue 6.78735 minus 5.26968
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolKai-Regular(0)/b/n/10.53937 知
@@ -823,18 +824,18 @@ Completed box being shipped out [3]
 ....\penalty 10000
 ....\TU/FandolKai-Regular(0)/b/n/10.53937 ，
 ....\rule(0.0+0.0)x-7.29324
-....\penalty 0
+....\penalty 10000
 ....\glue 7.29324 minus 5.26968
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolKai-Regular(0)/b/n/10.53937 得
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolKai-Regular(0)/b/n/10.53937 能
+....\glue 0.0 plus 0.60931
+....\TU/FandolKai-Regular(0)/b/n/10.53937 莫
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 6.35529
-...\hbox(7.9783+1.41226)x345.0, glue set 298.53194fil
-....\TU/FandolKai-Regular(0)/b/n/10.53937 莫
-....\glue 0.0 plus 0.60931
+...\hbox(7.9783+1.1277)x345.0, glue set 309.0713fil
 ....\TU/FandolKai-Regular(0)/b/n/10.53937 忘
 ....\glue 4.3633 plus 2.17946 minus 1.45587
 ....\TU/lmr/bx/it/10.53937 Ll
@@ -846,11 +847,11 @@ Completed box being shipped out [3]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.78735 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\glue -1.41226
+...\glue -1.1277
 ...\glue 0.0 plus 1.0fil
 ...\glue 0.0
 ...\glue 0.0 plus 0.0001fil

--- a/ctex/test/testfiles/fonts01.tlg
+++ b/ctex/test/testfiles/fonts01.tlg
@@ -72,6 +72,7 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 ，
 ....\rule(0.0+0.0)x-7.29324
+....\penalty 0
 ....\glue 7.29324 minus 5.26968
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolSong-Regular(0)/b/n/10.53937 宇
@@ -86,6 +87,7 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\TU/FandolSong-Regular(0)/b/n/10.53937 。
 ....\rule(0.0+0.0)x-6.78735
+....\penalty 0
 ....\glue 6.78735 minus 5.28023
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolSong-Regular(0)/m/it/10.53937 日
@@ -100,6 +102,7 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\TU/FandolSong-Regular(0)/m/it/10.53937 ，
 ....\rule(0.0+0.0)x-7.29324
+....\penalty 0
 ....\glue 7.29324 minus 5.26968
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolSong-Regular(0)/b/n/10.53937 辰
@@ -114,6 +117,7 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\TU/FandolSong-Regular(0)/b/n/10.53937 。
 ....\rule(0.0+0.0)x-6.78735
+....\penalty 0
 ....\glue 6.78735 minus 5.28023
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolHei-Regular(0)/m/n/10.53937 寒
@@ -131,6 +135,7 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\TU/FandolHei-Regular(0)/m/n/10.53937 ，
 ....\rule(0.0+0.0)x-7.46187
+....\penalty 0
 ....\glue 7.46187 minus 5.26968
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolHei-Regular(0)/b/n/10.53937 秋
@@ -145,6 +150,7 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\TU/FandolHei-Regular(0)/b/n/10.53937 。
 ....\rule(0.0+0.0)x-6.78735
+....\penalty 0
 ....\glue 6.78735 minus 5.26968
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolHei-Regular(0)/m/n/10.53937 闰
@@ -159,6 +165,7 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\TU/FandolHei-Regular(0)/m/n/10.53937 ，
 ....\rule(0.0+0.0)x-7.46187
+....\penalty 0
 ....\glue 7.46187 minus 5.26968
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolHei-Regular(0)/b/n/10.53937 律
@@ -173,6 +180,7 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\TU/FandolHei-Regular(0)/b/n/10.53937 。
 ....\rule(0.0+0.0)x-6.78735
+....\penalty 0
 ....\glue 6.78735 minus 5.26968
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolFang-Regular(0)/b/n/10.53937 云
@@ -187,6 +195,7 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\TU/FandolFang-Regular(0)/b/n/10.53937 ，
 ....\rule(0.0+0.0)x-7.29324
+....\penalty 0
 ....\glue 7.29324 minus 5.26968
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolFang-Regular(0)/b/n/10.53937 露
@@ -199,11 +208,12 @@ Completed box being shipped out [1]
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 6.13397
-...\hbox(8.29448+2.013)x345.0, glue set 191.58897fil
+...\hbox(8.29448+2.013)x345.0, glue set 184.80162fil
 ....\TU/lmtt/b/n/10.53937 Bb
 ....\penalty 10000
 ....\TU/FandolFang-Regular(0)/b/n/10.53937 。
 ....\rule(0.0+0.0)x-6.78735
+....\penalty 0
 ....\glue 6.78735 minus 5.26968
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolFang-Regular(0)/b/n/10.53937 金
@@ -218,6 +228,7 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\TU/FandolFang-Regular(0)/b/n/10.53937 ，
 ....\rule(0.0+0.0)x-7.29324
+....\penalty 0
 ....\glue 7.29324 minus 5.26968
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolFang-Regular(0)/b/n/10.53937 玉
@@ -236,6 +247,8 @@ Completed box being shipped out [1]
 ....\kern -0.00041
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.78735 minus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -312,6 +325,7 @@ Completed box being shipped out [2]
 ....\penalty 10000
 ....\TU/FandolSong-Regular(1)/m/n/10.53937 ，
 ....\rule(0.0+0.0)x-7.29324
+....\penalty 0
 ....\glue 7.29324 minus 5.26968
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolSong-Regular(1)/b/n/10.53937 珠
@@ -326,6 +340,7 @@ Completed box being shipped out [2]
 ....\penalty 10000
 ....\TU/FandolSong-Regular(1)/b/n/10.53937 。
 ....\rule(0.0+0.0)x-6.78735
+....\penalty 0
 ....\glue 6.78735 minus 5.28023
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolSong-Regular(1)/m/n/10.53937 果
@@ -340,6 +355,7 @@ Completed box being shipped out [2]
 ....\penalty 10000
 ....\TU/FandolSong-Regular(1)/m/n/10.53937 ，
 ....\rule(0.0+0.0)x-7.29324
+....\penalty 0
 ....\glue 7.29324 minus 5.26968
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolSong-Regular(1)/b/n/10.53937 菜
@@ -354,6 +370,7 @@ Completed box being shipped out [2]
 ....\penalty 10000
 ....\TU/FandolSong-Regular(1)/b/n/10.53937 。
 ....\rule(0.0+0.0)x-6.78735
+....\penalty 0
 ....\glue 6.78735 minus 5.28023
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolHei-Regular(0)/m/n/10.53937 海
@@ -371,6 +388,7 @@ Completed box being shipped out [2]
 ....\penalty 10000
 ....\TU/FandolHei-Regular(0)/m/n/10.53937 ，
 ....\rule(0.0+0.0)x-7.46187
+....\penalty 0
 ....\glue 7.46187 minus 5.26968
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolHei-Regular(0)/b/n/10.53937 鳞
@@ -385,6 +403,7 @@ Completed box being shipped out [2]
 ....\penalty 10000
 ....\TU/FandolHei-Regular(0)/b/n/10.53937 。
 ....\rule(0.0+0.0)x-6.78735
+....\penalty 0
 ....\glue 6.78735 minus 5.26968
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolHei-Regular(0)/m/n/10.53937 龙
@@ -399,6 +418,7 @@ Completed box being shipped out [2]
 ....\penalty 10000
 ....\TU/FandolHei-Regular(0)/m/n/10.53937 ，
 ....\rule(0.0+0.0)x-7.46187
+....\penalty 0
 ....\glue 7.46187 minus 5.26968
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolHei-Regular(0)/b/n/10.53937 鸟
@@ -413,6 +433,7 @@ Completed box being shipped out [2]
 ....\penalty 10000
 ....\TU/FandolHei-Regular(0)/b/n/10.53937 。
 ....\rule(0.0+0.0)x-6.78735
+....\penalty 0
 ....\glue 6.78735 minus 5.26968
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolFang-Regular(0)/b/n/10.53937 始
@@ -427,6 +448,7 @@ Completed box being shipped out [2]
 ....\penalty 10000
 ....\TU/FandolFang-Regular(0)/b/n/10.53937 ，
 ....\rule(0.0+0.0)x-7.29324
+....\penalty 0
 ....\glue 7.29324 minus 5.26968
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolFang-Regular(0)/b/n/10.53937 乃
@@ -443,6 +465,7 @@ Completed box being shipped out [2]
 ....\penalty 10000
 ....\TU/FandolFang-Regular(0)/b/n/10.53937 。
 ....\rule(0.0+0.0)x-6.78735
+....\penalty 0
 ....\glue 6.78735 minus 5.26968
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolFang-Regular(0)/b/n/10.53937 推
@@ -457,6 +480,7 @@ Completed box being shipped out [2]
 ....\penalty 10000
 ....\TU/FandolFang-Regular(0)/b/n/10.53937 ，
 ....\rule(0.0+0.0)x-7.29324
+....\penalty 0
 ....\glue 7.29324 minus 5.26968
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolFang-Regular(0)/b/n/10.53937 有
@@ -471,6 +495,7 @@ Completed box being shipped out [2]
 ....\penalty 10000
 ....\TU/FandolFang-Regular(0)/b/n/10.53937 。
 ....\rule(0.0+0.0)x-6.78735
+....\penalty 0
 ....\glue 6.78735 minus 5.26968
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolKai-Regular(0)/b/n/10.53937 吊
@@ -485,6 +510,7 @@ Completed box being shipped out [2]
 ....\penalty 10000
 ....\TU/FandolKai-Regular(0)/b/n/10.53937 ，
 ....\rule(0.0+0.0)x-7.29324
+....\penalty 0
 ....\glue 7.29324 minus 5.26968
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolKai-Regular(0)/b/n/10.53937 周
@@ -499,6 +525,7 @@ Completed box being shipped out [2]
 ....\penalty 10000
 ....\TU/FandolKai-Regular(0)/b/n/10.53937 。
 ....\rule(0.0+0.0)x-6.78735
+....\penalty 0
 ....\glue 6.78735 minus 5.26968
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolKai-Regular(0)/b/n/10.53937 坐
@@ -511,11 +538,12 @@ Completed box being shipped out [2]
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 5.97588
-...\hbox(8.30502+2.16055)x345.0, glue set 255.51022fil
+...\hbox(8.30502+2.16055)x345.0, glue set 248.72287fil
 ....\TU/lmr/m/it/10.53937 Gg
 ....\penalty 10000
 ....\TU/FandolKai-Regular(0)/b/n/10.53937 ，
 ....\rule(0.0+0.0)x-7.29324
+....\penalty 0
 ....\glue 7.29324 minus 5.26968
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolKai-Regular(0)/b/n/10.53937 垂
@@ -534,6 +562,8 @@ Completed box being shipped out [2]
 ....\kern -0.00041
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.78735 minus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -579,6 +609,7 @@ Completed box being shipped out [3]
 ....\penalty 10000
 ....\TU/FandolSong-Regular(1)/m/n/10.53937 ，
 ....\rule(0.0+0.0)x-7.29324
+....\penalty 0
 ....\glue 7.29324 minus 5.26968
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolSong-Regular(1)/b/n/10.53937 臣
@@ -593,6 +624,7 @@ Completed box being shipped out [3]
 ....\penalty 10000
 ....\TU/FandolSong-Regular(1)/b/n/10.53937 。
 ....\rule(0.0+0.0)x-6.78735
+....\penalty 0
 ....\glue 6.78735 minus 5.28023
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolSong-Regular(1)/m/n/10.53937 遐
@@ -607,6 +639,7 @@ Completed box being shipped out [3]
 ....\penalty 10000
 ....\TU/FandolSong-Regular(1)/m/n/10.53937 ，
 ....\rule(0.0+0.0)x-7.29324
+....\penalty 0
 ....\glue 7.29324 minus 5.26968
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolSong-Regular(1)/b/n/10.53937 率
@@ -621,6 +654,7 @@ Completed box being shipped out [3]
 ....\penalty 10000
 ....\TU/FandolSong-Regular(1)/b/n/10.53937 。
 ....\rule(0.0+0.0)x-6.78735
+....\penalty 0
 ....\glue 6.78735 minus 5.28023
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolHei-Regular(0)/m/n/10.53937 鸣
@@ -635,6 +669,7 @@ Completed box being shipped out [3]
 ....\penalty 10000
 ....\TU/FandolHei-Regular(0)/m/n/10.53937 ，
 ....\rule(0.0+0.0)x-7.46187
+....\penalty 0
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 5.87047
@@ -651,6 +686,7 @@ Completed box being shipped out [3]
 ....\penalty 10000
 ....\TU/FandolHei-Regular(0)/b/n/10.53937 。
 ....\rule(0.0+0.0)x-6.78735
+....\penalty 0
 ....\glue 6.78735 minus 5.26968
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolHei-Regular(0)/m/n/10.53937 化
@@ -665,6 +701,7 @@ Completed box being shipped out [3]
 ....\penalty 10000
 ....\TU/FandolHei-Regular(0)/m/n/10.53937 ，
 ....\rule(0.0+0.0)x-7.46187
+....\penalty 0
 ....\glue 7.46187 minus 5.26968
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolHei-Regular(0)/b/n/10.53937 赖
@@ -679,6 +716,7 @@ Completed box being shipped out [3]
 ....\penalty 10000
 ....\TU/FandolHei-Regular(0)/b/n/10.53937 。
 ....\rule(0.0+0.0)x-6.78735
+....\penalty 0
 ....\glue 6.78735 minus 5.26968
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolFang-Regular(0)/b/n/10.53937 盖
@@ -693,6 +731,7 @@ Completed box being shipped out [3]
 ....\penalty 10000
 ....\TU/FandolFang-Regular(0)/b/n/10.53937 ，
 ....\rule(0.0+0.0)x-7.29324
+....\penalty 0
 ....\glue 7.29324 minus 5.26968
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolFang-Regular(0)/b/n/10.53937 四
@@ -707,6 +746,7 @@ Completed box being shipped out [3]
 ....\penalty 10000
 ....\TU/FandolFang-Regular(0)/b/n/10.53937 。
 ....\rule(0.0+0.0)x-6.78735
+....\penalty 0
 ....\glue 6.78735 minus 5.26968
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolFang-Regular(0)/b/n/10.53937 恭
@@ -723,6 +763,7 @@ Completed box being shipped out [3]
 ....\penalty 10000
 ....\TU/FandolFang-Regular(0)/b/n/10.53937 ，
 ....\rule(0.0+0.0)x-7.29324
+....\penalty 0
 ....\glue 7.29324 minus 5.26968
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolFang-Regular(0)/b/n/10.53937 岂
@@ -737,6 +778,7 @@ Completed box being shipped out [3]
 ....\penalty 10000
 ....\TU/FandolFang-Regular(0)/b/n/10.53937 。
 ....\rule(0.0+0.0)x-6.78735
+....\penalty 0
 ....\glue 6.78735 minus 5.26968
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolKai-Regular(0)/b/n/10.53937 女
@@ -751,6 +793,7 @@ Completed box being shipped out [3]
 ....\penalty 10000
 ....\TU/FandolKai-Regular(0)/b/n/10.53937 ，
 ....\rule(0.0+0.0)x-7.29324
+....\penalty 0
 ....\glue 7.29324 minus 5.26968
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolKai-Regular(0)/b/n/10.53937 男
@@ -765,6 +808,7 @@ Completed box being shipped out [3]
 ....\penalty 10000
 ....\TU/FandolKai-Regular(0)/b/n/10.53937 。
 ....\rule(0.0+0.0)x-6.78735
+....\penalty 0
 ....\glue 6.78735 minus 5.26968
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolKai-Regular(0)/b/n/10.53937 知
@@ -779,6 +823,7 @@ Completed box being shipped out [3]
 ....\penalty 10000
 ....\TU/FandolKai-Regular(0)/b/n/10.53937 ，
 ....\rule(0.0+0.0)x-7.29324
+....\penalty 0
 ....\glue 7.29324 minus 5.26968
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolKai-Regular(0)/b/n/10.53937 得
@@ -787,7 +832,7 @@ Completed box being shipped out [3]
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 6.35529
-...\hbox(7.9783+1.41226)x345.0, glue set 305.31929fil
+...\hbox(7.9783+1.41226)x345.0, glue set 298.53194fil
 ....\TU/FandolKai-Regular(0)/b/n/10.53937 莫
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolKai-Regular(0)/b/n/10.53937 忘
@@ -800,6 +845,8 @@ Completed box being shipped out [3]
 ....\kern -0.00041
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.78735 minus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0

--- a/ctex/test/testfiles/fonts02.tlg
+++ b/ctex/test/testfiles/fonts02.tlg
@@ -60,6 +60,7 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\TU/NotoSerifCJKSC(0)/m/it/10.53937 ，
 ....\rule(0.0+0.0)x-8.12585
+....\penalty 0
 ....\glue 8.12585 minus 7.32486
 ....\glue 0.0 plus 0.60931
 ....\TU/NotoSerifCJKSC(0)/b/it/10.53937 宇
@@ -74,6 +75,7 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\TU/NotoSerifCJKSC(0)/b/it/10.53937 。
 ....\rule(0.0+0.0)x-7.12462
+....\penalty 0
 ....\glue 7.12462 minus 6.6925
 ....\glue 0.0 plus 0.60931
 ....\TU/NotoSerifCJKSC(0)/m/it/10.53937 日
@@ -88,6 +90,7 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\TU/NotoSerifCJKSC(0)/m/it/10.53937 ，
 ....\rule(0.0+0.0)x-8.12585
+....\penalty 0
 ....\glue 8.12585 minus 7.32486
 ....\glue 0.0 plus 0.60931
 ....\TU/NotoSerifCJKSC(0)/b/it/10.53937 辰
@@ -102,6 +105,7 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\TU/NotoSerifCJKSC(0)/b/it/10.53937 。
 ....\rule(0.0+0.0)x-7.12462
+....\penalty 0
 ....\glue 7.12462 minus 6.6925
 ....\glue 0.0 plus 0.60931
 ....\TU/NotoSansCJKSC(0)/m/it/10.53937 寒
@@ -119,6 +123,7 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\TU/NotoSansCJKSC(0)/m/it/10.53937 ，
 ....\rule(0.0+0.0)x-7.06137
+....\penalty 0
 ....\glue 7.06137 minus 5.63855
 ....\glue 0.0 plus 0.60931
 ....\TU/NotoSansCJKSC(0)/b/it/10.53937 秋
@@ -133,6 +138,7 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\TU/NotoSansCJKSC(0)/b/it/10.53937 。
 ....\rule(0.0+0.0)x-6.7979
+....\penalty 0
 ....\glue 6.7979 minus 6.46063
 ....\glue 0.0 plus 0.60931
 ....\TU/NotoSansCJKSC(0)/m/it/10.53937 闰
@@ -147,6 +153,7 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\TU/NotoSansCJKSC(0)/m/it/10.53937 ，
 ....\rule(0.0+0.0)x-7.06137
+....\penalty 0
 ....\glue 7.06137 minus 5.63855
 ....\glue 0.0 plus 0.60931
 ....\TU/NotoSansCJKSC(0)/b/it/10.53937 律
@@ -161,6 +168,7 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\TU/NotoSansCJKSC(0)/b/it/10.53937 。
 ....\rule(0.0+0.0)x-6.7979
+....\penalty 0
 ....\glue 6.7979 minus 6.46063
 ....\glue 0.0 plus 0.60931
 ....\TU/NotoSerifCJKSC(0)/m/it/10.53937 云
@@ -175,6 +183,7 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\TU/NotoSerifCJKSC(0)/m/it/10.53937 ，
 ....\rule(0.0+0.0)x-8.12585
+....\penalty 0
 ....\glue 8.12585 minus 7.32486
 ....\glue 0.0 plus 0.60931
 ....\TU/NotoSerifCJKSC(0)/b/it/10.53937 露
@@ -187,11 +196,12 @@ Completed box being shipped out [1]
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 5.43837
-...\hbox(8.93738+2.0657)x345.0, glue set 191.92624fil
+...\hbox(8.93738+2.0657)x345.0, glue set 184.80162fil
 ....\TU/lmtt/b/n/10.53937 Bb
 ....\penalty 10000
 ....\TU/NotoSerifCJKSC(0)/b/it/10.53937 。
 ....\rule(0.0+0.0)x-7.12462
+....\penalty 0
 ....\glue 7.12462 minus 6.6925
 ....\glue 0.0 plus 0.60931
 ....\TU/NotoSerifCJKSC(0)/m/it/10.53937 金
@@ -206,6 +216,7 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\TU/NotoSerifCJKSC(0)/m/it/10.53937 ，
 ....\rule(0.0+0.0)x-8.12585
+....\penalty 0
 ....\glue 8.12585 minus 7.32486
 ....\glue 0.0 plus 0.60931
 ....\TU/NotoSerifCJKSC(0)/b/it/10.53937 玉
@@ -224,6 +235,8 @@ Completed box being shipped out [1]
 ....\kern -0.00043
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 7.12462 minus 6.6925
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -287,6 +300,7 @@ Completed box being shipped out [2]
 ....\penalty 10000
 ....\TU/NotoSerifCJKTC(0)/m/it/10.53937 ，
 ....\rule(0.0+0.0)x-4.61624
+....\penalty 0
 ....\glue 4.61624 minus 0.38995
 ....\glue 0.0 plus 0.60931
 ....\TU/NotoSerifCJKTC(0)/b/it/10.53937 珠
@@ -301,6 +315,7 @@ Completed box being shipped out [2]
 ....\penalty 10000
 ....\TU/NotoSerifCJKTC(0)/b/it/10.53937 。
 ....\rule(0.0+0.0)x-3.77309
+....\penalty 0
 ....\glue 3.77309
 ....\glue 0.0 plus 0.60931
 ....\TU/NotoSerifCJKTC(0)/m/it/10.53937 果
@@ -315,6 +330,7 @@ Completed box being shipped out [2]
 ....\penalty 10000
 ....\TU/NotoSerifCJKTC(0)/m/it/10.53937 ，
 ....\rule(0.0+0.0)x-4.61624
+....\penalty 0
 ....\glue 4.61624 minus 0.38995
 ....\glue 0.0 plus 0.60931
 ....\TU/NotoSerifCJKTC(0)/b/it/10.53937 菜
@@ -329,6 +345,7 @@ Completed box being shipped out [2]
 ....\penalty 10000
 ....\TU/NotoSerifCJKTC(0)/b/it/10.53937 。
 ....\rule(0.0+0.0)x-3.77309
+....\penalty 0
 ....\glue 3.77309
 ....\glue 0.0 plus 0.60931
 ....\TU/NotoSansCJKTC(0)/m/it/10.53937 海
@@ -341,11 +358,12 @@ Completed box being shipped out [2]
 ....\glue(\rightskip) 0.0
 ...\penalty 300
 ...\glue(\baselineskip) 5.24866
-...\hbox(9.03224+2.16055)x345.0, glue set 115.8636fil
+...\hbox(9.03224+2.16055)x345.0, glue set 112.33292fil
 ....\TU/lmr/m/n/10.53937 Ee
 ....\penalty 10000
 ....\TU/NotoSansCJKTC(0)/m/it/10.53937 ，
 ....\rule(0.0+0.0)x-4.31061
+....\penalty 0
 ....\glue 4.31061 minus 0.13702
 ....\glue 0.0 plus 0.60931
 ....\TU/NotoSansCJKTC(0)/b/it/10.53937 鳞
@@ -360,6 +378,7 @@ Completed box being shipped out [2]
 ....\penalty 10000
 ....\TU/NotoSansCJKTC(0)/b/it/10.53937 。
 ....\rule(0.0+0.0)x-3.53069
+....\penalty 0
 ....\glue 3.53069
 ....\glue 0.0 plus 0.60931
 ....\TU/NotoSansCJKTC(0)/m/it/10.53937 龙
@@ -374,6 +393,7 @@ Completed box being shipped out [2]
 ....\penalty 10000
 ....\TU/NotoSansCJKTC(0)/m/it/10.53937 ，
 ....\rule(0.0+0.0)x-4.31061
+....\penalty 0
 ....\glue 4.31061 minus 0.13702
 ....\glue 0.0 plus 0.60931
 ....\TU/NotoSansCJKTC(0)/b/it/10.53937 鸟
@@ -392,6 +412,8 @@ Completed box being shipped out [2]
 ....\kern -0.00021
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 3.53069
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -437,6 +459,7 @@ Completed box being shipped out [3]
 ....\penalty 10000
 ....\TU/NotoSerifCJKTC(0)/m/it/10.53937 ，
 ....\rule(0.0+0.0)x-4.61624
+....\penalty 0
 ....\glue 4.61624 minus 0.38995
 ....\glue 0.0 plus 0.60931
 ....\TU/NotoSerifCJKTC(0)/b/it/10.53937 乃
@@ -451,6 +474,7 @@ Completed box being shipped out [3]
 ....\penalty 10000
 ....\TU/NotoSerifCJKTC(0)/b/it/10.53937 。
 ....\rule(0.0+0.0)x-3.77309
+....\penalty 0
 ....\glue 3.77309
 ....\glue 0.0 plus 0.60931
 ....\TU/NotoSerifCJKTC(0)/m/it/10.53937 推
@@ -465,6 +489,7 @@ Completed box being shipped out [3]
 ....\penalty 10000
 ....\TU/NotoSerifCJKTC(0)/m/it/10.53937 ，
 ....\rule(0.0+0.0)x-4.61624
+....\penalty 0
 ....\glue 4.61624 minus 0.38995
 ....\glue 0.0 plus 0.60931
 ....\TU/NotoSerifCJKTC(0)/b/it/10.53937 有
@@ -479,6 +504,7 @@ Completed box being shipped out [3]
 ....\penalty 10000
 ....\TU/NotoSerifCJKTC(0)/b/it/10.53937 。
 ....\rule(0.0+0.0)x-3.77309
+....\penalty 0
 ....\glue 3.77309
 ....\glue 0.0 plus 0.60931
 ....\TU/NotoSansCJKTC(0)/m/it/10.53937 吊
@@ -493,10 +519,11 @@ Completed box being shipped out [3]
 ....\penalty 10000
 ....\TU/NotoSansCJKTC(0)/m/it/10.53937 ，
 ....\rule(0.0+0.0)x-4.31061
+....\penalty 0
 ....\glue(\rightskip) 0.0
 ...\penalty 300
 ...\glue(\baselineskip) 5.24866
-...\hbox(9.08493+2.10786)x345.0, glue set 144.86797fil
+...\hbox(9.08493+2.10786)x345.0, glue set 141.33728fil
 ....\TU/NotoSansCJKTC(0)/b/it/10.53937 周
 ....\glue 0.0 plus 0.60931
 ....\TU/NotoSansCJKTC(0)/b/it/10.53937 发
@@ -509,6 +536,7 @@ Completed box being shipped out [3]
 ....\penalty 10000
 ....\TU/NotoSansCJKTC(0)/b/it/10.53937 。
 ....\rule(0.0+0.0)x-3.53069
+....\penalty 0
 ....\glue 3.53069
 ....\glue 0.0 plus 0.60931
 ....\TU/NotoSansCJKTC(0)/m/it/10.53937 坐
@@ -523,6 +551,7 @@ Completed box being shipped out [3]
 ....\penalty 10000
 ....\TU/NotoSansCJKTC(0)/m/it/10.53937 ，
 ....\rule(0.0+0.0)x-4.31061
+....\penalty 0
 ....\glue 4.31061 minus 0.13702
 ....\glue 0.0 plus 0.60931
 ....\TU/NotoSansCJKTC(0)/b/it/10.53937 垂
@@ -541,6 +570,8 @@ Completed box being shipped out [3]
 ....\kern -0.00021
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 3.53069
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0

--- a/ctex/test/testfiles/fonts02.tlg
+++ b/ctex/test/testfiles/fonts02.tlg
@@ -60,7 +60,7 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\TU/NotoSerifCJKSC(0)/m/it/10.53937 ，
 ....\rule(0.0+0.0)x-8.12585
-....\penalty 0
+....\penalty 10000
 ....\glue 8.12585 minus 7.32486
 ....\glue 0.0 plus 0.60931
 ....\TU/NotoSerifCJKSC(0)/b/it/10.53937 宇
@@ -75,7 +75,7 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\TU/NotoSerifCJKSC(0)/b/it/10.53937 。
 ....\rule(0.0+0.0)x-7.12462
-....\penalty 0
+....\penalty 10000
 ....\glue 7.12462 minus 6.6925
 ....\glue 0.0 plus 0.60931
 ....\TU/NotoSerifCJKSC(0)/m/it/10.53937 日
@@ -90,7 +90,7 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\TU/NotoSerifCJKSC(0)/m/it/10.53937 ，
 ....\rule(0.0+0.0)x-8.12585
-....\penalty 0
+....\penalty 10000
 ....\glue 8.12585 minus 7.32486
 ....\glue 0.0 plus 0.60931
 ....\TU/NotoSerifCJKSC(0)/b/it/10.53937 辰
@@ -105,7 +105,7 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\TU/NotoSerifCJKSC(0)/b/it/10.53937 。
 ....\rule(0.0+0.0)x-7.12462
-....\penalty 0
+....\penalty 10000
 ....\glue 7.12462 minus 6.6925
 ....\glue 0.0 plus 0.60931
 ....\TU/NotoSansCJKSC(0)/m/it/10.53937 寒
@@ -123,7 +123,7 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\TU/NotoSansCJKSC(0)/m/it/10.53937 ，
 ....\rule(0.0+0.0)x-7.06137
-....\penalty 0
+....\penalty 10000
 ....\glue 7.06137 minus 5.63855
 ....\glue 0.0 plus 0.60931
 ....\TU/NotoSansCJKSC(0)/b/it/10.53937 秋
@@ -138,7 +138,7 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\TU/NotoSansCJKSC(0)/b/it/10.53937 。
 ....\rule(0.0+0.0)x-6.7979
-....\penalty 0
+....\penalty 10000
 ....\glue 6.7979 minus 6.46063
 ....\glue 0.0 plus 0.60931
 ....\TU/NotoSansCJKSC(0)/m/it/10.53937 闰
@@ -153,7 +153,7 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\TU/NotoSansCJKSC(0)/m/it/10.53937 ，
 ....\rule(0.0+0.0)x-7.06137
-....\penalty 0
+....\penalty 10000
 ....\glue 7.06137 minus 5.63855
 ....\glue 0.0 plus 0.60931
 ....\TU/NotoSansCJKSC(0)/b/it/10.53937 律
@@ -168,7 +168,7 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\TU/NotoSansCJKSC(0)/b/it/10.53937 。
 ....\rule(0.0+0.0)x-6.7979
-....\penalty 0
+....\penalty 10000
 ....\glue 6.7979 minus 6.46063
 ....\glue 0.0 plus 0.60931
 ....\TU/NotoSerifCJKSC(0)/m/it/10.53937 云
@@ -183,7 +183,7 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\TU/NotoSerifCJKSC(0)/m/it/10.53937 ，
 ....\rule(0.0+0.0)x-8.12585
-....\penalty 0
+....\penalty 10000
 ....\glue 8.12585 minus 7.32486
 ....\glue 0.0 plus 0.60931
 ....\TU/NotoSerifCJKSC(0)/b/it/10.53937 露
@@ -201,7 +201,7 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\TU/NotoSerifCJKSC(0)/b/it/10.53937 。
 ....\rule(0.0+0.0)x-7.12462
-....\penalty 0
+....\penalty 10000
 ....\glue 7.12462 minus 6.6925
 ....\glue 0.0 plus 0.60931
 ....\TU/NotoSerifCJKSC(0)/m/it/10.53937 金
@@ -216,7 +216,7 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\TU/NotoSerifCJKSC(0)/m/it/10.53937 ，
 ....\rule(0.0+0.0)x-8.12585
-....\penalty 0
+....\penalty 10000
 ....\glue 8.12585 minus 7.32486
 ....\glue 0.0 plus 0.60931
 ....\TU/NotoSerifCJKSC(0)/b/it/10.53937 玉
@@ -236,7 +236,7 @@ Completed box being shipped out [1]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 7.12462 minus 6.6925
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -300,7 +300,7 @@ Completed box being shipped out [2]
 ....\penalty 10000
 ....\TU/NotoSerifCJKTC(0)/m/it/10.53937 ，
 ....\rule(0.0+0.0)x-4.61624
-....\penalty 0
+....\penalty 10000
 ....\glue 4.61624 minus 0.38995
 ....\glue 0.0 plus 0.60931
 ....\TU/NotoSerifCJKTC(0)/b/it/10.53937 珠
@@ -315,7 +315,7 @@ Completed box being shipped out [2]
 ....\penalty 10000
 ....\TU/NotoSerifCJKTC(0)/b/it/10.53937 。
 ....\rule(0.0+0.0)x-3.77309
-....\penalty 0
+....\penalty 10000
 ....\glue 3.77309
 ....\glue 0.0 plus 0.60931
 ....\TU/NotoSerifCJKTC(0)/m/it/10.53937 果
@@ -330,7 +330,7 @@ Completed box being shipped out [2]
 ....\penalty 10000
 ....\TU/NotoSerifCJKTC(0)/m/it/10.53937 ，
 ....\rule(0.0+0.0)x-4.61624
-....\penalty 0
+....\penalty 10000
 ....\glue 4.61624 minus 0.38995
 ....\glue 0.0 plus 0.60931
 ....\TU/NotoSerifCJKTC(0)/b/it/10.53937 菜
@@ -345,7 +345,7 @@ Completed box being shipped out [2]
 ....\penalty 10000
 ....\TU/NotoSerifCJKTC(0)/b/it/10.53937 。
 ....\rule(0.0+0.0)x-3.77309
-....\penalty 0
+....\penalty 10000
 ....\glue 3.77309
 ....\glue 0.0 plus 0.60931
 ....\TU/NotoSansCJKTC(0)/m/it/10.53937 海
@@ -363,7 +363,7 @@ Completed box being shipped out [2]
 ....\penalty 10000
 ....\TU/NotoSansCJKTC(0)/m/it/10.53937 ，
 ....\rule(0.0+0.0)x-4.31061
-....\penalty 0
+....\penalty 10000
 ....\glue 4.31061 minus 0.13702
 ....\glue 0.0 plus 0.60931
 ....\TU/NotoSansCJKTC(0)/b/it/10.53937 鳞
@@ -378,7 +378,7 @@ Completed box being shipped out [2]
 ....\penalty 10000
 ....\TU/NotoSansCJKTC(0)/b/it/10.53937 。
 ....\rule(0.0+0.0)x-3.53069
-....\penalty 0
+....\penalty 10000
 ....\glue 3.53069
 ....\glue 0.0 plus 0.60931
 ....\TU/NotoSansCJKTC(0)/m/it/10.53937 龙
@@ -393,7 +393,7 @@ Completed box being shipped out [2]
 ....\penalty 10000
 ....\TU/NotoSansCJKTC(0)/m/it/10.53937 ，
 ....\rule(0.0+0.0)x-4.31061
-....\penalty 0
+....\penalty 10000
 ....\glue 4.31061 minus 0.13702
 ....\glue 0.0 plus 0.60931
 ....\TU/NotoSansCJKTC(0)/b/it/10.53937 鸟
@@ -413,7 +413,7 @@ Completed box being shipped out [2]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 3.53069
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -445,7 +445,7 @@ Completed box being shipped out [3]
 ..\vbox(550.0+0.0)x345.0, glue set 523.50262fil
 ...\write-{}
 ...\glue(\topskip) 0.90453
-...\hbox(9.09547+2.10786)x345.0, glue set - 0.18279
+...\hbox(9.09547+2.10786)x345.0, glue set 0.78102
 ....\hbox(0.0+0.0)x21.07874
 ....\TU/NotoSerifCJKTC(0)/m/it/10.53937 始
 ....\glue 0.0 plus 0.60931
@@ -459,7 +459,7 @@ Completed box being shipped out [3]
 ....\penalty 10000
 ....\TU/NotoSerifCJKTC(0)/m/it/10.53937 ，
 ....\rule(0.0+0.0)x-4.61624
-....\penalty 0
+....\penalty 10000
 ....\glue 4.61624 minus 0.38995
 ....\glue 0.0 plus 0.60931
 ....\TU/NotoSerifCJKTC(0)/b/it/10.53937 乃
@@ -474,7 +474,7 @@ Completed box being shipped out [3]
 ....\penalty 10000
 ....\TU/NotoSerifCJKTC(0)/b/it/10.53937 。
 ....\rule(0.0+0.0)x-3.77309
-....\penalty 0
+....\penalty 10000
 ....\glue 3.77309
 ....\glue 0.0 plus 0.60931
 ....\TU/NotoSerifCJKTC(0)/m/it/10.53937 推
@@ -489,7 +489,7 @@ Completed box being shipped out [3]
 ....\penalty 10000
 ....\TU/NotoSerifCJKTC(0)/m/it/10.53937 ，
 ....\rule(0.0+0.0)x-4.61624
-....\penalty 0
+....\penalty 10000
 ....\glue 4.61624 minus 0.38995
 ....\glue 0.0 plus 0.60931
 ....\TU/NotoSerifCJKTC(0)/b/it/10.53937 有
@@ -504,7 +504,7 @@ Completed box being shipped out [3]
 ....\penalty 10000
 ....\TU/NotoSerifCJKTC(0)/b/it/10.53937 。
 ....\rule(0.0+0.0)x-3.77309
-....\penalty 0
+....\penalty 10000
 ....\glue 3.77309
 ....\glue 0.0 plus 0.60931
 ....\TU/NotoSansCJKTC(0)/m/it/10.53937 吊
@@ -514,16 +514,17 @@ Completed box being shipped out [3]
 ....\TU/NotoSansCJKTC(0)/m/it/10.53937 伐
 ....\glue 0.0 plus 0.60931
 ....\TU/NotoSansCJKTC(0)/m/it/10.53937 罪
-....\glue 3.50961 plus 1.75304 minus 1.17102
+....\glue(\rightskip) 0.0
+...\penalty 300
+...\glue(\baselineskip) 5.24866
+...\hbox(9.08493+2.10786)x345.0, glue set 124.06326fil
 ....\TU/lmr/m/n/10.53937 Ii
 ....\penalty 10000
 ....\TU/NotoSansCJKTC(0)/m/it/10.53937 ，
 ....\rule(0.0+0.0)x-4.31061
-....\penalty 0
-....\glue(\rightskip) 0.0
-...\penalty 300
-...\glue(\baselineskip) 5.24866
-...\hbox(9.08493+2.10786)x345.0, glue set 141.33728fil
+....\penalty 10000
+....\glue 4.31061 minus 0.13702
+....\glue 0.0 plus 0.60931
 ....\TU/NotoSansCJKTC(0)/b/it/10.53937 周
 ....\glue 0.0 plus 0.60931
 ....\TU/NotoSansCJKTC(0)/b/it/10.53937 发
@@ -536,7 +537,7 @@ Completed box being shipped out [3]
 ....\penalty 10000
 ....\TU/NotoSansCJKTC(0)/b/it/10.53937 。
 ....\rule(0.0+0.0)x-3.53069
-....\penalty 0
+....\penalty 10000
 ....\glue 3.53069
 ....\glue 0.0 plus 0.60931
 ....\TU/NotoSansCJKTC(0)/m/it/10.53937 坐
@@ -551,7 +552,7 @@ Completed box being shipped out [3]
 ....\penalty 10000
 ....\TU/NotoSansCJKTC(0)/m/it/10.53937 ，
 ....\rule(0.0+0.0)x-4.31061
-....\penalty 0
+....\penalty 10000
 ....\glue 4.31061 minus 0.13702
 ....\glue 0.0 plus 0.60931
 ....\TU/NotoSansCJKTC(0)/b/it/10.53937 垂
@@ -571,7 +572,7 @@ Completed box being shipped out [3]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 3.53069
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0

--- a/ctex/test/testfiles/footnote01.tlg
+++ b/ctex/test/testfiles/footnote01.tlg
@@ -29,7 +29,7 @@ Completed box being shipped out [1]
 ..\vbox(550.0+0.0)x345.0, glue set 520.79498fil
 ...\write-{}
 ...\glue(\topskip) 1.52736
-...\hbox(8.47264+1.9287)x345.0, glue set 273.52878fil
+...\hbox(8.47264+1.9287)x345.0, glue set 266.74142fil
 ....\hbox(0.0+0.0)x21.07874
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 正
 ....\glue 0.0 plus 0.60931
@@ -55,6 +55,8 @@ Completed box being shipped out [1]
 ....\kern -0.00041
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.78735 minus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -63,7 +65,7 @@ Completed box being shipped out [1]
 ...\kern -3.0
 ...\rule(0.4+0.0)x137.9979
 ...\kern 2.6
-...\hbox(8.22069+3.5232)x345.0, glue set 283.60063fil
+...\hbox(8.22069+3.5232)x345.0, glue set 278.75252fil
 ....\hbox(6.57549+0.0)x13.55063, glue set 9.64563fil
 .....\glue 0.0 plus 1.0fil minus 1.0fil
 .....\hbox(6.57549+0.0)x3.905
@@ -93,6 +95,8 @@ Completed box being shipped out [1]
 ....\kern -0.00029
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 4.84811 minus 3.76407
+....\penalty 0
 ....\penalty 10000
 ....\rule(0.0+3.5232)x0.0
 ....\penalty 10000
@@ -124,7 +128,7 @@ Completed box being shipped out [2]
 ..\vbox(550.0+0.0)x345.0, glue set 497.2465fil
 ...\write-{}
 ...\glue(\topskip) 1.45735
-...\hbox(8.54265+1.99193)x345.0, glue set 190.7872fil
+...\hbox(8.54265+1.99193)x345.0, glue set 183.99985fil
 ....\hbox(0.0+0.0)x21.07874
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 第
 ....\glue 0.0 plus 0.60931
@@ -188,6 +192,8 @@ Completed box being shipped out [2]
 ....\kern -0.00041
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.78735 minus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0

--- a/ctex/test/testfiles/footnote01.tlg
+++ b/ctex/test/testfiles/footnote01.tlg
@@ -56,7 +56,7 @@ Completed box being shipped out [1]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.78735 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -96,7 +96,7 @@ Completed box being shipped out [1]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 4.84811 minus 3.76407
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\rule(0.0+3.5232)x0.0
 ....\penalty 10000
@@ -193,7 +193,7 @@ Completed box being shipped out [2]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.78735 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0

--- a/ctex/test/testfiles/heading-afterskip01.tlg
+++ b/ctex/test/testfiles/heading-afterskip01.tlg
@@ -55,7 +55,7 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 5.2893
-...\hbox(8.23125+1.90761)x345.0, glue set 278.01178fil
+...\hbox(8.23125+1.90761)x345.0, glue set 271.22443fil
 ....\hbox(0.0+0.0)x21.07874
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 后
 ....\glue 0.0 plus 0.60931
@@ -71,6 +71,8 @@ Completed box being shipped out [1]
 ....\kern -0.00041
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.78735 minus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0

--- a/ctex/test/testfiles/heading-afterskip01.tlg
+++ b/ctex/test/testfiles/heading-afterskip01.tlg
@@ -72,7 +72,7 @@ Completed box being shipped out [1]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.78735 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0

--- a/ctex/test/testfiles/heading-beforeskip01.tlg
+++ b/ctex/test/testfiles/heading-beforeskip01.tlg
@@ -63,7 +63,7 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 5.08907
-...\hbox(8.43149+2.10786)x345.0, glue set 220.04526fil
+...\hbox(8.43149+2.10786)x345.0, glue set 213.2579fil
 ....\hbox(0.0+0.0)x21.07874
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 首
 ....\glue 0.0 plus 0.60931
@@ -92,6 +92,8 @@ Completed box being shipped out [1]
 ....\kern -0.00041
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.78735 minus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0

--- a/ctex/test/testfiles/heading-beforeskip01.tlg
+++ b/ctex/test/testfiles/heading-beforeskip01.tlg
@@ -93,7 +93,7 @@ Completed box being shipped out [1]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.78735 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0

--- a/ctex/test/testfiles/heading-break01.tlg
+++ b/ctex/test/testfiles/heading-break01.tlg
@@ -21,7 +21,7 @@ Completed box being shipped out [1]
 ..\vbox(550.0+0.0)x345.0, glue set 539.94232fil
 ...\write-{}
 ...\glue(\topskip) 1.81091
-...\hbox(8.18909+1.84438)x345.0, glue set 267.47241fil
+...\hbox(8.18909+1.84438)x345.0, glue set 260.68506fil
 ....\hbox(0.0+0.0)x21.07874
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 第
 ....\glue 0.0 plus 0.60931
@@ -39,6 +39,8 @@ Completed box being shipped out [1]
 ....\kern -0.00041
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.78735 minus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -111,7 +113,7 @@ Completed box being shipped out [2]
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 5.87349
-...\hbox(8.18909+1.84438)x345.0, glue set 267.47241fil
+...\hbox(8.18909+1.84438)x345.0, glue set 260.68506fil
 ....\hbox(0.0+0.0)x21.07874
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 第
 ....\glue 0.0 plus 0.60931
@@ -129,6 +131,8 @@ Completed box being shipped out [2]
 ....\kern -0.00041
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.78735 minus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -175,7 +179,7 @@ Completed box being shipped out [3]
 ..\vbox(550.0+0.0)x345.0, glue set 539.94232fil
 ...\write-{}
 ...\glue(\topskip) 1.81091
-...\hbox(8.18909+1.84438)x345.0, glue set 267.47241fil
+...\hbox(8.18909+1.84438)x345.0, glue set 260.68506fil
 ....\hbox(0.0+0.0)x21.07874
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 第
 ....\glue 0.0 plus 0.60931
@@ -193,6 +197,8 @@ Completed box being shipped out [3]
 ....\kern -0.00041
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.78735 minus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -260,7 +266,7 @@ Completed box being shipped out [4]
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 5.22607
-...\hbox(8.18909+1.84438)x345.0, glue set 267.47241fil
+...\hbox(8.18909+1.84438)x345.0, glue set 260.68506fil
 ....\hbox(0.0+0.0)x21.07874
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 第
 ....\glue 0.0 plus 0.60931
@@ -278,6 +284,8 @@ Completed box being shipped out [4]
 ....\kern -0.00041
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.78735 minus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -322,7 +330,7 @@ Completed box being shipped out [5]
 ..\vbox(550.0+0.0)x345.0, glue set 473.67387fil
 ...\write-{}
 ...\glue(\topskip) 1.89523
-...\hbox(8.10477+1.84438)x345.0, glue set 278.01178fil
+...\hbox(8.10477+1.84438)x345.0, glue set 271.22443fil
 ....\hbox(0.0+0.0)x21.07874
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 连
 ....\glue 0.0 plus 0.60931
@@ -338,6 +346,8 @@ Completed box being shipped out [5]
 ....\kern -0.00041
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.78735 minus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -372,7 +382,7 @@ Completed box being shipped out [5]
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 5.95781
-...\hbox(8.10477+1.84438)x345.0, glue set 267.47241fil
+...\hbox(8.10477+1.84438)x345.0, glue set 260.68506fil
 ....\hbox(0.0+0.0)x21.07874
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 紧
 ....\glue 0.0 plus 0.60931
@@ -390,6 +400,8 @@ Completed box being shipped out [5]
 ....\kern -0.00041
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.78735 minus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0

--- a/ctex/test/testfiles/heading-break01.tlg
+++ b/ctex/test/testfiles/heading-break01.tlg
@@ -40,7 +40,7 @@ Completed box being shipped out [1]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.78735 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -132,7 +132,7 @@ Completed box being shipped out [2]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.78735 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -198,7 +198,7 @@ Completed box being shipped out [3]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.78735 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -285,7 +285,7 @@ Completed box being shipped out [4]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.78735 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -347,7 +347,7 @@ Completed box being shipped out [5]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.78735 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -401,7 +401,7 @@ Completed box being shipped out [5]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.78735 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0

--- a/ctex/test/testfiles/heading-numbering02.tlg
+++ b/ctex/test/testfiles/heading-numbering02.tlg
@@ -99,7 +99,7 @@ Completed box being shipped out [1]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.78735 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0

--- a/ctex/test/testfiles/heading-numbering02.tlg
+++ b/ctex/test/testfiles/heading-numbering02.tlg
@@ -86,7 +86,7 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 5.85242
-...\hbox(8.10477+1.84438)x345.0, glue set 299.09052fil
+...\hbox(8.10477+1.84438)x345.0, glue set 292.30316fil
 ....\hbox(0.0+0.0)x21.07874
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 文
 ....\glue 0.0 plus 0.60931
@@ -98,6 +98,8 @@ Completed box being shipped out [1]
 ....\kern -0.00041
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.78735 minus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0

--- a/ctex/test/testfiles/heading-runin01.tlg
+++ b/ctex/test/testfiles/heading-runin01.tlg
@@ -56,7 +56,7 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 5.87048
-...\hbox(8.14693+1.9287)x345.0, glue set 235.85431fil
+...\hbox(8.14693+1.9287)x345.0, glue set 229.06696fil
 ....\hbox(0.0+0.0)x21.07874
 ....\glue 10.53937
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 紧
@@ -79,6 +79,8 @@ Completed box being shipped out [1]
 ....\kern -0.00041
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.78735 minus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -140,7 +142,7 @@ Completed box being shipped out [2]
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 6.46521
-...\hbox(8.07315+1.70737)x345.0, glue set 272.7421fil
+...\hbox(8.07315+1.70737)x345.0, glue set 265.95474fil
 ....\hbox(0.0+0.0)x21.07874
 ....\glue 5.26968
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 后
@@ -157,6 +159,8 @@ Completed box being shipped out [2]
 ....\kern -0.00041
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.78735 minus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -225,7 +229,7 @@ Completed box being shipped out [3]
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 6.04816
-...\hbox(8.10477+1.84438)x345.0, glue set 288.55115fil
+...\hbox(8.10477+1.84438)x345.0, glue set 281.7638fil
 ....\hbox(0.0+0.0)x21.07874
 ....\glue 10.53937
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 文
@@ -238,6 +242,8 @@ Completed box being shipped out [3]
 ....\kern -0.00041
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.78735 minus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -275,7 +281,7 @@ Completed box being shipped out [3]
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 5.98793
-...\hbox(8.10477+1.84438)x345.0, glue set 299.09052fil
+...\hbox(8.10477+1.84438)x345.0, glue set 292.30316fil
 ....\hbox(0.0+0.0)x21.07874
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 文
 ....\glue 0.0 plus 0.60931
@@ -287,6 +293,8 @@ Completed box being shipped out [3]
 ....\kern -0.00041
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.78735 minus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0

--- a/ctex/test/testfiles/heading-runin01.tlg
+++ b/ctex/test/testfiles/heading-runin01.tlg
@@ -80,7 +80,7 @@ Completed box being shipped out [1]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.78735 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -160,7 +160,7 @@ Completed box being shipped out [2]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.78735 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -243,7 +243,7 @@ Completed box being shipped out [3]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.78735 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -294,7 +294,7 @@ Completed box being shipped out [3]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.78735 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0

--- a/ctex/test/testfiles/heading-starred01.tlg
+++ b/ctex/test/testfiles/heading-starred01.tlg
@@ -58,7 +58,7 @@ Completed box being shipped out [1]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.78735 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -124,7 +124,7 @@ Completed box being shipped out [2]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.78735 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -195,7 +195,7 @@ Completed box being shipped out [3]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.78735 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0

--- a/ctex/test/testfiles/heading-starred01.tlg
+++ b/ctex/test/testfiles/heading-starred01.tlg
@@ -45,7 +45,7 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 6.02104
-...\hbox(7.93614+1.60197)x345.0, glue set 299.09052fil
+...\hbox(7.93614+1.60197)x345.0, glue set 292.30316fil
 ....\hbox(0.0+0.0)x21.07874
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 正
 ....\glue 0.0 plus 0.60931
@@ -57,6 +57,8 @@ Completed box being shipped out [1]
 ....\kern -0.00041
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.78735 minus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -109,7 +111,7 @@ Completed box being shipped out [2]
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 6.5179
-...\hbox(7.93614+1.60197)x345.0, glue set 299.09052fil
+...\hbox(7.93614+1.60197)x345.0, glue set 292.30316fil
 ....\hbox(0.0+0.0)x21.07874
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 正
 ....\glue 0.0 plus 0.60931
@@ -121,6 +123,8 @@ Completed box being shipped out [2]
 ....\kern -0.00041
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.78735 minus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -178,7 +182,7 @@ Completed box being shipped out [3]
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 6.02104
-...\hbox(7.93614+1.60197)x345.0, glue set 299.09052fil
+...\hbox(7.93614+1.60197)x345.0, glue set 292.30316fil
 ....\hbox(0.0+0.0)x21.07874
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 正
 ....\glue 0.0 plus 0.60931
@@ -190,6 +194,8 @@ Completed box being shipped out [3]
 ....\kern -0.00041
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.78735 minus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0

--- a/ctex/test/testfiles/heading01.tlg
+++ b/ctex/test/testfiles/heading01.tlg
@@ -74,6 +74,7 @@ Completed box being shipped out [1]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 9.48543 minus 7.52812
+....\penalty 0
 ....\TU/lmr/bx/n/15.05624 Part
 ....\kern -0.0002
 ....\kern 0.0002
@@ -146,6 +147,7 @@ Completed box being shipped out [1]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 9.48543 minus 7.52812
+....\penalty 0
 ....\TU/lmr/bx/n/15.05624 Section
 ....\kern -0.0002
 ....\kern 0.0002
@@ -230,6 +232,7 @@ Completed box being shipped out [1]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 7.58835 minus 6.02249
+....\penalty 0
 ....\TU/lmr/bx/n/12.045 Subsection
 ....\kern -0.0002
 ....\kern 0.0002
@@ -318,6 +321,7 @@ Completed box being shipped out [1]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
+....\penalty 0
 ....\TU/lmr/bx/n/10.53937 Subsubsection
 ....\kern -0.0002
 ....\kern 0.0002
@@ -387,6 +391,7 @@ Completed box being shipped out [1]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
+....\penalty 0
 ....\TU/lmr/bx/n/10.53937 Paragraph
 ....\kern -0.0002
 ....\kern 0.0002
@@ -453,6 +458,7 @@ Completed box being shipped out [1]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
+....\penalty 0
 ....\TU/lmr/bx/n/10.53937 Subparagraph
 ....\kern -0.0002
 ....\kern 0.0002
@@ -546,6 +552,7 @@ Completed box being shipped out [2]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 9.48543 minus 7.52812
+....\penalty 0
 ....\TU/lmr/bx/n/15.05624 Part
 ....\kern -0.0002
 ....\kern 0.0002
@@ -618,6 +625,7 @@ Completed box being shipped out [2]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 9.48543 minus 7.52812
+....\penalty 0
 ....\TU/lmr/bx/n/15.05624 Section
 ....\kern -0.0002
 ....\kern 0.0002
@@ -702,6 +710,7 @@ Completed box being shipped out [2]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 7.58835 minus 6.02249
+....\penalty 0
 ....\TU/lmr/bx/n/12.045 Subsection
 ....\kern -0.0002
 ....\kern 0.0002
@@ -790,6 +799,7 @@ Completed box being shipped out [2]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
+....\penalty 0
 ....\TU/lmr/bx/n/10.53937 Subsubsection
 ....\kern -0.0002
 ....\kern 0.0002
@@ -859,6 +869,7 @@ Completed box being shipped out [2]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
+....\penalty 0
 ....\TU/lmr/bx/n/10.53937 Paragraph
 ....\kern -0.0002
 ....\kern 0.0002
@@ -925,6 +936,7 @@ Completed box being shipped out [2]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
+....\penalty 0
 ....\TU/lmr/bx/n/10.53937 Subparagraph
 ....\kern -0.0002
 ....\kern 0.0002

--- a/ctex/test/testfiles/heading01.tlg
+++ b/ctex/test/testfiles/heading01.tlg
@@ -74,7 +74,7 @@ Completed box being shipped out [1]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 9.48543 minus 7.52812
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/15.05624 Part
 ....\kern -0.0002
 ....\kern 0.0002
@@ -147,7 +147,7 @@ Completed box being shipped out [1]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 9.48543 minus 7.52812
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/15.05624 Section
 ....\kern -0.0002
 ....\kern 0.0002
@@ -232,7 +232,7 @@ Completed box being shipped out [1]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 7.58835 minus 6.02249
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/12.045 Subsection
 ....\kern -0.0002
 ....\kern 0.0002
@@ -321,7 +321,7 @@ Completed box being shipped out [1]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/10.53937 Subsubsection
 ....\kern -0.0002
 ....\kern 0.0002
@@ -391,7 +391,7 @@ Completed box being shipped out [1]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/10.53937 Paragraph
 ....\kern -0.0002
 ....\kern 0.0002
@@ -458,7 +458,7 @@ Completed box being shipped out [1]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/10.53937 Subparagraph
 ....\kern -0.0002
 ....\kern 0.0002
@@ -552,7 +552,7 @@ Completed box being shipped out [2]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 9.48543 minus 7.52812
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/15.05624 Part
 ....\kern -0.0002
 ....\kern 0.0002
@@ -625,7 +625,7 @@ Completed box being shipped out [2]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 9.48543 minus 7.52812
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/15.05624 Section
 ....\kern -0.0002
 ....\kern 0.0002
@@ -710,7 +710,7 @@ Completed box being shipped out [2]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 7.58835 minus 6.02249
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/12.045 Subsection
 ....\kern -0.0002
 ....\kern 0.0002
@@ -799,7 +799,7 @@ Completed box being shipped out [2]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/10.53937 Subsubsection
 ....\kern -0.0002
 ....\kern 0.0002
@@ -869,7 +869,7 @@ Completed box being shipped out [2]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/10.53937 Paragraph
 ....\kern -0.0002
 ....\kern 0.0002
@@ -936,7 +936,7 @@ Completed box being shipped out [2]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/10.53937 Subparagraph
 ....\kern -0.0002
 ....\kern 0.0002

--- a/ctex/test/testfiles/heading02.tlg
+++ b/ctex/test/testfiles/heading02.tlg
@@ -112,7 +112,7 @@ Completed box being shipped out [2]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 13.91197 minus 11.04124
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/22.08249 Part
 ....\kern -0.0002
 ....\kern 0.0002
@@ -241,7 +241,7 @@ Completed box being shipped out [4]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 13.91197 minus 11.04124
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/22.08249 Chapter
 ....\kern -0.0002
 ....\kern 0.0002
@@ -324,7 +324,7 @@ Completed box being shipped out [4]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 9.48543 minus 7.52812
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/15.05624 Section
 ....\kern -0.0002
 ....\kern 0.0002
@@ -409,7 +409,7 @@ Completed box being shipped out [4]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 7.58835 minus 6.02249
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/12.045 Subsection
 ....\kern -0.0002
 ....\kern 0.0002
@@ -494,7 +494,7 @@ Completed box being shipped out [4]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/10.53937 Subsubsection
 ....\kern -0.0002
 ....\kern 0.0002
@@ -600,7 +600,7 @@ Completed box being shipped out [5]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/10.53937 Paragraph
 ....\kern -0.0002
 ....\kern 0.0002
@@ -667,7 +667,7 @@ Completed box being shipped out [5]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/10.53937 Subparagraph
 ....\kern -0.0002
 ....\kern 0.0002
@@ -799,7 +799,7 @@ Completed box being shipped out [7]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 13.91197 minus 11.04124
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/22.08249 Part
 ....\kern -0.0002
 ....\kern 0.0002
@@ -928,7 +928,7 @@ Completed box being shipped out [9]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 13.91197 minus 11.04124
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/22.08249 Chapter
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1011,7 +1011,7 @@ Completed box being shipped out [9]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 9.48543 minus 7.52812
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/15.05624 Section
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1096,7 +1096,7 @@ Completed box being shipped out [9]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 7.58835 minus 6.02249
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/12.045 Subsection
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1181,7 +1181,7 @@ Completed box being shipped out [9]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/10.53937 Subsubsection
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1285,7 +1285,7 @@ Completed box being shipped out [10]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/10.53937 Paragraph
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1352,7 +1352,7 @@ Completed box being shipped out [10]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/10.53937 Subparagraph
 ....\kern -0.0002
 ....\kern 0.0002

--- a/ctex/test/testfiles/heading02.tlg
+++ b/ctex/test/testfiles/heading02.tlg
@@ -112,6 +112,7 @@ Completed box being shipped out [2]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 13.91197 minus 11.04124
+....\penalty 0
 ....\TU/lmr/bx/n/22.08249 Part
 ....\kern -0.0002
 ....\kern 0.0002
@@ -240,6 +241,7 @@ Completed box being shipped out [4]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 13.91197 minus 11.04124
+....\penalty 0
 ....\TU/lmr/bx/n/22.08249 Chapter
 ....\kern -0.0002
 ....\kern 0.0002
@@ -322,6 +324,7 @@ Completed box being shipped out [4]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 9.48543 minus 7.52812
+....\penalty 0
 ....\TU/lmr/bx/n/15.05624 Section
 ....\kern -0.0002
 ....\kern 0.0002
@@ -406,6 +409,7 @@ Completed box being shipped out [4]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 7.58835 minus 6.02249
+....\penalty 0
 ....\TU/lmr/bx/n/12.045 Subsection
 ....\kern -0.0002
 ....\kern 0.0002
@@ -490,6 +494,7 @@ Completed box being shipped out [4]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
+....\penalty 0
 ....\TU/lmr/bx/n/10.53937 Subsubsection
 ....\kern -0.0002
 ....\kern 0.0002
@@ -595,6 +600,7 @@ Completed box being shipped out [5]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
+....\penalty 0
 ....\TU/lmr/bx/n/10.53937 Paragraph
 ....\kern -0.0002
 ....\kern 0.0002
@@ -661,6 +667,7 @@ Completed box being shipped out [5]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
+....\penalty 0
 ....\TU/lmr/bx/n/10.53937 Subparagraph
 ....\kern -0.0002
 ....\kern 0.0002
@@ -792,6 +799,7 @@ Completed box being shipped out [7]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 13.91197 minus 11.04124
+....\penalty 0
 ....\TU/lmr/bx/n/22.08249 Part
 ....\kern -0.0002
 ....\kern 0.0002
@@ -920,6 +928,7 @@ Completed box being shipped out [9]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 13.91197 minus 11.04124
+....\penalty 0
 ....\TU/lmr/bx/n/22.08249 Chapter
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1002,6 +1011,7 @@ Completed box being shipped out [9]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 9.48543 minus 7.52812
+....\penalty 0
 ....\TU/lmr/bx/n/15.05624 Section
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1086,6 +1096,7 @@ Completed box being shipped out [9]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 7.58835 minus 6.02249
+....\penalty 0
 ....\TU/lmr/bx/n/12.045 Subsection
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1170,6 +1181,7 @@ Completed box being shipped out [9]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
+....\penalty 0
 ....\TU/lmr/bx/n/10.53937 Subsubsection
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1273,6 +1285,7 @@ Completed box being shipped out [10]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
+....\penalty 0
 ....\TU/lmr/bx/n/10.53937 Paragraph
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1339,6 +1352,7 @@ Completed box being shipped out [10]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
+....\penalty 0
 ....\TU/lmr/bx/n/10.53937 Subparagraph
 ....\kern -0.0002
 ....\kern 0.0002

--- a/ctex/test/testfiles/heading03.tlg
+++ b/ctex/test/testfiles/heading03.tlg
@@ -130,6 +130,7 @@ Completed box being shipped out [3]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 13.91197 minus 11.04124
+....\penalty 0
 ....\TU/lmr/bx/n/22.08249 Part
 ....\kern -0.0002
 ....\kern 0.0002
@@ -294,6 +295,7 @@ Completed box being shipped out [7]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 13.91197 minus 11.04124
+....\penalty 0
 ....\TU/lmr/bx/n/22.08249 Chapter
 ....\kern -0.0002
 ....\kern 0.0002
@@ -378,6 +380,7 @@ Completed box being shipped out [7]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 9.48543 minus 7.52812
+....\penalty 0
 ....\TU/lmr/bx/n/15.05624 Section
 ....\kern -0.0002
 ....\kern 0.0002
@@ -462,6 +465,7 @@ Completed box being shipped out [7]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 7.58835 minus 6.02249
+....\penalty 0
 ....\TU/lmr/bx/n/12.045 Subsection
 ....\kern -0.0002
 ....\kern 0.0002
@@ -546,6 +550,7 @@ Completed box being shipped out [7]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
+....\penalty 0
 ....\TU/lmr/bx/n/10.53937 Subsubsection
 ....\kern -0.0002
 ....\kern 0.0002
@@ -640,6 +645,7 @@ Completed box being shipped out [8]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
+....\penalty 0
 ....\TU/lmr/bx/n/10.53937 Paragraph
 ....\kern -0.0002
 ....\kern 0.0002
@@ -706,6 +712,7 @@ Completed box being shipped out [8]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
+....\penalty 0
 ....\TU/lmr/bx/n/10.53937 Subparagraph
 ....\kern -0.0002
 ....\kern 0.0002
@@ -854,6 +861,7 @@ Completed box being shipped out [3]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 13.91197 minus 11.04124
+....\penalty 0
 ....\TU/lmr/bx/n/22.08249 Part
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1033,6 +1041,7 @@ Completed box being shipped out [7]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 13.91197 minus 11.04124
+....\penalty 0
 ....\TU/lmr/bx/n/22.08249 Chapter
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1117,6 +1126,7 @@ Completed box being shipped out [7]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 9.48543 minus 7.52812
+....\penalty 0
 ....\TU/lmr/bx/n/15.05624 Section
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1201,6 +1211,7 @@ Completed box being shipped out [7]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 7.58835 minus 6.02249
+....\penalty 0
 ....\TU/lmr/bx/n/12.045 Subsection
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1285,6 +1296,7 @@ Completed box being shipped out [7]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
+....\penalty 0
 ....\TU/lmr/bx/n/10.53937 Subsubsection
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1387,6 +1399,7 @@ Completed box being shipped out [8]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
+....\penalty 0
 ....\TU/lmr/bx/n/10.53937 Paragraph
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1453,6 +1466,7 @@ Completed box being shipped out [8]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
+....\penalty 0
 ....\TU/lmr/bx/n/10.53937 Subparagraph
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1601,6 +1615,7 @@ Completed box being shipped out [11]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 13.91197 minus 11.04124
+....\penalty 0
 ....\TU/lmr/bx/n/22.08249 Part
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1763,6 +1778,7 @@ Completed box being shipped out [15]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 13.91197 minus 11.04124
+....\penalty 0
 ....\TU/lmr/bx/n/22.08249 Chapter
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1847,6 +1863,7 @@ Completed box being shipped out [15]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 9.48543 minus 7.52812
+....\penalty 0
 ....\TU/lmr/bx/n/15.05624 Section
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1931,6 +1948,7 @@ Completed box being shipped out [15]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 7.58835 minus 6.02249
+....\penalty 0
 ....\TU/lmr/bx/n/12.045 Subsection
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2015,6 +2033,7 @@ Completed box being shipped out [15]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
+....\penalty 0
 ....\TU/lmr/bx/n/10.53937 Subsubsection
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2109,6 +2128,7 @@ Completed box being shipped out [16]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
+....\penalty 0
 ....\TU/lmr/bx/n/10.53937 Paragraph
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2175,6 +2195,7 @@ Completed box being shipped out [16]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
+....\penalty 0
 ....\TU/lmr/bx/n/10.53937 Subparagraph
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2322,6 +2343,7 @@ Completed box being shipped out [19]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 13.91197 minus 11.04124
+....\penalty 0
 ....\TU/lmr/bx/n/22.08249 Part
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2501,6 +2523,7 @@ Completed box being shipped out [23]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 13.91197 minus 11.04124
+....\penalty 0
 ....\TU/lmr/bx/n/22.08249 Chapter
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2585,6 +2608,7 @@ Completed box being shipped out [23]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 9.48543 minus 7.52812
+....\penalty 0
 ....\TU/lmr/bx/n/15.05624 Section
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2669,6 +2693,7 @@ Completed box being shipped out [23]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 7.58835 minus 6.02249
+....\penalty 0
 ....\TU/lmr/bx/n/12.045 Subsection
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2753,6 +2778,7 @@ Completed box being shipped out [23]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
+....\penalty 0
 ....\TU/lmr/bx/n/10.53937 Subsubsection
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2855,6 +2881,7 @@ Completed box being shipped out [24]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
+....\penalty 0
 ....\TU/lmr/bx/n/10.53937 Paragraph
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2921,6 +2948,7 @@ Completed box being shipped out [24]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
+....\penalty 0
 ....\TU/lmr/bx/n/10.53937 Subparagraph
 ....\kern -0.0002
 ....\kern 0.0002

--- a/ctex/test/testfiles/heading03.tlg
+++ b/ctex/test/testfiles/heading03.tlg
@@ -130,7 +130,7 @@ Completed box being shipped out [3]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 13.91197 minus 11.04124
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/22.08249 Part
 ....\kern -0.0002
 ....\kern 0.0002
@@ -295,7 +295,7 @@ Completed box being shipped out [7]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 13.91197 minus 11.04124
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/22.08249 Chapter
 ....\kern -0.0002
 ....\kern 0.0002
@@ -380,7 +380,7 @@ Completed box being shipped out [7]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 9.48543 minus 7.52812
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/15.05624 Section
 ....\kern -0.0002
 ....\kern 0.0002
@@ -465,7 +465,7 @@ Completed box being shipped out [7]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 7.58835 minus 6.02249
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/12.045 Subsection
 ....\kern -0.0002
 ....\kern 0.0002
@@ -550,7 +550,7 @@ Completed box being shipped out [7]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/10.53937 Subsubsection
 ....\kern -0.0002
 ....\kern 0.0002
@@ -645,7 +645,7 @@ Completed box being shipped out [8]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/10.53937 Paragraph
 ....\kern -0.0002
 ....\kern 0.0002
@@ -712,7 +712,7 @@ Completed box being shipped out [8]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/10.53937 Subparagraph
 ....\kern -0.0002
 ....\kern 0.0002
@@ -861,7 +861,7 @@ Completed box being shipped out [3]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 13.91197 minus 11.04124
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/22.08249 Part
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1041,7 +1041,7 @@ Completed box being shipped out [7]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 13.91197 minus 11.04124
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/22.08249 Chapter
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1126,7 +1126,7 @@ Completed box being shipped out [7]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 9.48543 minus 7.52812
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/15.05624 Section
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1211,7 +1211,7 @@ Completed box being shipped out [7]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 7.58835 minus 6.02249
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/12.045 Subsection
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1296,7 +1296,7 @@ Completed box being shipped out [7]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/10.53937 Subsubsection
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1399,7 +1399,7 @@ Completed box being shipped out [8]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/10.53937 Paragraph
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1466,7 +1466,7 @@ Completed box being shipped out [8]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/10.53937 Subparagraph
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1615,7 +1615,7 @@ Completed box being shipped out [11]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 13.91197 minus 11.04124
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/22.08249 Part
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1778,7 +1778,7 @@ Completed box being shipped out [15]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 13.91197 minus 11.04124
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/22.08249 Chapter
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1863,7 +1863,7 @@ Completed box being shipped out [15]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 9.48543 minus 7.52812
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/15.05624 Section
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1948,7 +1948,7 @@ Completed box being shipped out [15]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 7.58835 minus 6.02249
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/12.045 Subsection
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2033,7 +2033,7 @@ Completed box being shipped out [15]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/10.53937 Subsubsection
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2128,7 +2128,7 @@ Completed box being shipped out [16]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/10.53937 Paragraph
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2195,7 +2195,7 @@ Completed box being shipped out [16]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/10.53937 Subparagraph
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2343,7 +2343,7 @@ Completed box being shipped out [19]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 13.91197 minus 11.04124
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/22.08249 Part
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2523,7 +2523,7 @@ Completed box being shipped out [23]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 13.91197 minus 11.04124
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/22.08249 Chapter
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2608,7 +2608,7 @@ Completed box being shipped out [23]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 9.48543 minus 7.52812
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/15.05624 Section
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2693,7 +2693,7 @@ Completed box being shipped out [23]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 7.58835 minus 6.02249
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/12.045 Subsection
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2778,7 +2778,7 @@ Completed box being shipped out [23]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/10.53937 Subsubsection
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2881,7 +2881,7 @@ Completed box being shipped out [24]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/10.53937 Paragraph
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2948,7 +2948,7 @@ Completed box being shipped out [24]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/10.53937 Subparagraph
 ....\kern -0.0002
 ....\kern 0.0002

--- a/ctex/test/testfiles/heading04.tlg
+++ b/ctex/test/testfiles/heading04.tlg
@@ -127,6 +127,7 @@ Completed box being shipped out [3]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 16.44142 minus 13.04875
+....\penalty 0
 ....\TU/lmr/bx/n/26.09749 Part
 ....\kern -0.0002
 ....\kern 0.0002
@@ -291,6 +292,7 @@ Completed box being shipped out [7]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 16.44142 minus 13.04875
+....\penalty 0
 ....\TU/lmr/bx/n/26.09749 Chapter
 ....\kern -0.0002
 ....\kern 0.0002
@@ -375,6 +377,7 @@ Completed box being shipped out [7]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 9.48543 minus 7.52812
+....\penalty 0
 ....\TU/lmr/bx/n/15.05624 Section
 ....\kern -0.0002
 ....\kern 0.0002
@@ -461,6 +464,7 @@ Completed box being shipped out [7]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 7.58835 minus 6.02249
+....\penalty 0
 ....\TU/lmr/bx/n/12.045 Subsection
 ....\kern -0.0002
 ....\kern 0.0002
@@ -547,6 +551,7 @@ Completed box being shipped out [7]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
+....\penalty 0
 ....\TU/lmr/bx/n/10.53937 Subsubsection
 ....\kern -0.0002
 ....\kern 0.0002
@@ -643,6 +648,7 @@ Completed box being shipped out [8]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
+....\penalty 0
 ....\TU/lmr/bx/n/10.53937 Paragraph
 ....\kern -0.0002
 ....\kern 0.0002
@@ -709,6 +715,7 @@ Completed box being shipped out [8]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
+....\penalty 0
 ....\TU/lmr/bx/n/10.53937 Subparagraph
 ....\kern -0.0002
 ....\kern 0.0002
@@ -854,6 +861,7 @@ Completed box being shipped out [3]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 16.44142 minus 13.04875
+....\penalty 0
 ....\TU/lmr/bx/n/26.09749 Part
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1039,6 +1047,7 @@ Completed box being shipped out [7]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 16.44142 minus 13.04875
+....\penalty 0
 ....\TU/lmr/bx/n/26.09749 Chapter
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1123,6 +1132,7 @@ Completed box being shipped out [7]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 9.48543 minus 7.52812
+....\penalty 0
 ....\TU/lmr/bx/n/15.05624 Section
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1209,6 +1219,7 @@ Completed box being shipped out [7]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 7.58835 minus 6.02249
+....\penalty 0
 ....\TU/lmr/bx/n/12.045 Subsection
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1295,6 +1306,7 @@ Completed box being shipped out [7]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
+....\penalty 0
 ....\TU/lmr/bx/n/10.53937 Subsubsection
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1398,6 +1410,7 @@ Completed box being shipped out [8]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
+....\penalty 0
 ....\TU/lmr/bx/n/10.53937 Paragraph
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1464,6 +1477,7 @@ Completed box being shipped out [8]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
+....\penalty 0
 ....\TU/lmr/bx/n/10.53937 Subparagraph
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1609,6 +1623,7 @@ Completed box being shipped out [11]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 16.44142 minus 13.04875
+....\penalty 0
 ....\TU/lmr/bx/n/26.09749 Part
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1771,6 +1786,7 @@ Completed box being shipped out [15]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 16.44142 minus 13.04875
+....\penalty 0
 ....\TU/lmr/bx/n/26.09749 Chapter
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1855,6 +1871,7 @@ Completed box being shipped out [15]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 9.48543 minus 7.52812
+....\penalty 0
 ....\TU/lmr/bx/n/15.05624 Section
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1941,6 +1958,7 @@ Completed box being shipped out [15]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 7.58835 minus 6.02249
+....\penalty 0
 ....\TU/lmr/bx/n/12.045 Subsection
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2027,6 +2045,7 @@ Completed box being shipped out [15]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
+....\penalty 0
 ....\TU/lmr/bx/n/10.53937 Subsubsection
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2123,6 +2142,7 @@ Completed box being shipped out [16]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
+....\penalty 0
 ....\TU/lmr/bx/n/10.53937 Paragraph
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2189,6 +2209,7 @@ Completed box being shipped out [16]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
+....\penalty 0
 ....\TU/lmr/bx/n/10.53937 Subparagraph
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2333,6 +2354,7 @@ Completed box being shipped out [19]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 16.44142 minus 13.04875
+....\penalty 0
 ....\TU/lmr/bx/n/26.09749 Part
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2522,6 +2544,7 @@ Completed box being shipped out [23]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 16.44142 minus 13.04875
+....\penalty 0
 ....\TU/lmr/bx/n/26.09749 Chapter
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2606,6 +2629,7 @@ Completed box being shipped out [23]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 9.48543 minus 7.52812
+....\penalty 0
 ....\TU/lmr/bx/n/15.05624 Section
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2692,6 +2716,7 @@ Completed box being shipped out [23]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 7.58835 minus 6.02249
+....\penalty 0
 ....\TU/lmr/bx/n/12.045 Subsection
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2778,6 +2803,7 @@ Completed box being shipped out [23]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
+....\penalty 0
 ....\TU/lmr/bx/n/10.53937 Subsubsection
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2883,6 +2909,7 @@ Completed box being shipped out [24]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
+....\penalty 0
 ....\TU/lmr/bx/n/10.53937 Paragraph
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2949,6 +2976,7 @@ Completed box being shipped out [24]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
+....\penalty 0
 ....\TU/lmr/bx/n/10.53937 Subparagraph
 ....\kern -0.0002
 ....\kern 0.0002

--- a/ctex/test/testfiles/heading04.tlg
+++ b/ctex/test/testfiles/heading04.tlg
@@ -127,7 +127,7 @@ Completed box being shipped out [3]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 16.44142 minus 13.04875
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/26.09749 Part
 ....\kern -0.0002
 ....\kern 0.0002
@@ -292,7 +292,7 @@ Completed box being shipped out [7]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 16.44142 minus 13.04875
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/26.09749 Chapter
 ....\kern -0.0002
 ....\kern 0.0002
@@ -377,7 +377,7 @@ Completed box being shipped out [7]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 9.48543 minus 7.52812
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/15.05624 Section
 ....\kern -0.0002
 ....\kern 0.0002
@@ -464,7 +464,7 @@ Completed box being shipped out [7]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 7.58835 minus 6.02249
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/12.045 Subsection
 ....\kern -0.0002
 ....\kern 0.0002
@@ -551,7 +551,7 @@ Completed box being shipped out [7]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/10.53937 Subsubsection
 ....\kern -0.0002
 ....\kern 0.0002
@@ -648,7 +648,7 @@ Completed box being shipped out [8]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/10.53937 Paragraph
 ....\kern -0.0002
 ....\kern 0.0002
@@ -715,7 +715,7 @@ Completed box being shipped out [8]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/10.53937 Subparagraph
 ....\kern -0.0002
 ....\kern 0.0002
@@ -861,7 +861,7 @@ Completed box being shipped out [3]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 16.44142 minus 13.04875
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/26.09749 Part
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1047,7 +1047,7 @@ Completed box being shipped out [7]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 16.44142 minus 13.04875
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/26.09749 Chapter
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1132,7 +1132,7 @@ Completed box being shipped out [7]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 9.48543 minus 7.52812
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/15.05624 Section
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1219,7 +1219,7 @@ Completed box being shipped out [7]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 7.58835 minus 6.02249
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/12.045 Subsection
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1306,7 +1306,7 @@ Completed box being shipped out [7]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/10.53937 Subsubsection
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1410,7 +1410,7 @@ Completed box being shipped out [8]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/10.53937 Paragraph
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1477,7 +1477,7 @@ Completed box being shipped out [8]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/10.53937 Subparagraph
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1623,7 +1623,7 @@ Completed box being shipped out [11]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 16.44142 minus 13.04875
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/26.09749 Part
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1786,7 +1786,7 @@ Completed box being shipped out [15]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 16.44142 minus 13.04875
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/26.09749 Chapter
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1871,7 +1871,7 @@ Completed box being shipped out [15]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 9.48543 minus 7.52812
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/15.05624 Section
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1958,7 +1958,7 @@ Completed box being shipped out [15]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 7.58835 minus 6.02249
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/12.045 Subsection
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2045,7 +2045,7 @@ Completed box being shipped out [15]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/10.53937 Subsubsection
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2142,7 +2142,7 @@ Completed box being shipped out [16]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/10.53937 Paragraph
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2209,7 +2209,7 @@ Completed box being shipped out [16]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/10.53937 Subparagraph
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2354,7 +2354,7 @@ Completed box being shipped out [19]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 16.44142 minus 13.04875
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/26.09749 Part
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2544,7 +2544,7 @@ Completed box being shipped out [23]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 16.44142 minus 13.04875
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/26.09749 Chapter
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2629,7 +2629,7 @@ Completed box being shipped out [23]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 9.48543 minus 7.52812
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/15.05624 Section
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2716,7 +2716,7 @@ Completed box being shipped out [23]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 7.58835 minus 6.02249
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/12.045 Subsection
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2803,7 +2803,7 @@ Completed box being shipped out [23]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/10.53937 Subsubsection
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2909,7 +2909,7 @@ Completed box being shipped out [24]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/10.53937 Paragraph
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2976,7 +2976,7 @@ Completed box being shipped out [24]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/10.53937 Subparagraph
 ....\kern -0.0002
 ....\kern 0.0002

--- a/ctex/test/testfiles/heading05.tlg
+++ b/ctex/test/testfiles/heading05.tlg
@@ -152,7 +152,7 @@ Completed box being shipped out [1]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/10.53937 Paragraph
 ....\kern -0.0002
 ....\kern 0.0002
@@ -226,7 +226,7 @@ Completed box being shipped out [1]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/10.53937 Subparagraph
 ....\kern -0.0002
 ....\kern 0.0002
@@ -334,7 +334,7 @@ Completed box being shipped out [2]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/10.53937 Paragraph
 ....\kern -0.0002
 ....\kern 0.0002
@@ -408,7 +408,7 @@ Completed box being shipped out [2]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/10.53937 Subparagraph
 ....\kern -0.0002
 ....\kern 0.0002

--- a/ctex/test/testfiles/heading05.tlg
+++ b/ctex/test/testfiles/heading05.tlg
@@ -152,6 +152,7 @@ Completed box being shipped out [1]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
+....\penalty 0
 ....\TU/lmr/bx/n/10.53937 Paragraph
 ....\kern -0.0002
 ....\kern 0.0002
@@ -225,6 +226,7 @@ Completed box being shipped out [1]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
+....\penalty 0
 ....\TU/lmr/bx/n/10.53937 Subparagraph
 ....\kern -0.0002
 ....\kern 0.0002
@@ -332,6 +334,7 @@ Completed box being shipped out [2]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
+....\penalty 0
 ....\TU/lmr/bx/n/10.53937 Paragraph
 ....\kern -0.0002
 ....\kern 0.0002
@@ -405,6 +408,7 @@ Completed box being shipped out [2]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
+....\penalty 0
 ....\TU/lmr/bx/n/10.53937 Subparagraph
 ....\kern -0.0002
 ....\kern 0.0002

--- a/ctex/test/testfiles/heading06.tlg
+++ b/ctex/test/testfiles/heading06.tlg
@@ -127,6 +127,7 @@ Completed box being shipped out [1]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
+....\penalty 0
 ....\TU/lmr/bx/n/10.53937 Paragraph
 ....\kern -0.0002
 ....\kern 0.0002
@@ -193,6 +194,7 @@ Completed box being shipped out [1]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
+....\penalty 0
 ....\TU/lmr/bx/n/10.53937 Subparagraph
 ....\kern -0.0002
 ....\kern 0.0002
@@ -283,6 +285,7 @@ Completed box being shipped out [2]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
+....\penalty 0
 ....\TU/lmr/bx/n/10.53937 Paragraph
 ....\kern -0.0002
 ....\kern 0.0002
@@ -349,6 +352,7 @@ Completed box being shipped out [2]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
+....\penalty 0
 ....\TU/lmr/bx/n/10.53937 Subparagraph
 ....\kern -0.0002
 ....\kern 0.0002
@@ -439,6 +443,7 @@ Completed box being shipped out [3]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
+....\penalty 0
 ....\TU/lmr/bx/n/10.53937 Paragraph
 ....\kern -0.0002
 ....\kern 0.0002
@@ -509,6 +514,7 @@ Completed box being shipped out [3]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
+....\penalty 0
 ....\TU/lmr/bx/n/10.53937 Subparagraph
 ....\kern -0.0002
 ....\kern 0.0002

--- a/ctex/test/testfiles/heading06.tlg
+++ b/ctex/test/testfiles/heading06.tlg
@@ -127,7 +127,7 @@ Completed box being shipped out [1]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/10.53937 Paragraph
 ....\kern -0.0002
 ....\kern 0.0002
@@ -194,7 +194,7 @@ Completed box being shipped out [1]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/10.53937 Subparagraph
 ....\kern -0.0002
 ....\kern 0.0002
@@ -285,7 +285,7 @@ Completed box being shipped out [2]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/10.53937 Paragraph
 ....\kern -0.0002
 ....\kern 0.0002
@@ -352,7 +352,7 @@ Completed box being shipped out [2]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/10.53937 Subparagraph
 ....\kern -0.0002
 ....\kern 0.0002
@@ -443,7 +443,7 @@ Completed box being shipped out [3]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/10.53937 Paragraph
 ....\kern -0.0002
 ....\kern 0.0002
@@ -514,7 +514,7 @@ Completed box being shipped out [3]
 ....\kern -0.99623
 ....\kern 0.99623
 ....\glue 6.6398 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\TU/lmr/bx/n/10.53937 Subparagraph
 ....\kern -0.0002
 ....\kern 0.0002

--- a/ctex/test/testfiles/indent.tlg
+++ b/ctex/test/testfiles/indent.tlg
@@ -96,7 +96,7 @@ Completed box being shipped out [1]
 ....\glue(\rightskip) 0.0
 ...\penalty 300
 ...\glue(\baselineskip) 6.13396
-...\hbox(8.2734+2.03409)x345.0, glue set 14.52759fil
+...\hbox(8.2734+2.03409)x345.0, glue set 7.74023fil
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 万
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 里
@@ -171,6 +171,8 @@ Completed box being shipped out [1]
 ....\kern -0.00041
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.78735 minus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -261,7 +263,7 @@ Completed box being shipped out [1]
 ....\glue(\rightskip) 0.0
 ...\penalty 300
 ...\glue(\baselineskip) 5.27574
-...\hbox(7.07341+1.7435)x345.0, glue set 97.8731fil
+...\hbox(7.07341+1.7435)x345.0, glue set 92.05536fil
 ....\TU/FandolSong-Regular(0)/m/n/9.03374 常
 ....\glue 0.0 plus 0.29866
 ....\TU/FandolSong-Regular(0)/m/n/9.03374 作
@@ -328,6 +330,8 @@ Completed box being shipped out [1]
 ....\kern -0.00035
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 5.81773 minus 4.51688
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -466,7 +470,7 @@ Completed box being shipped out [1]
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 7.03432
-...\hbox(9.43123+2.15604)x345.0, glue set 256.39699fil
+...\hbox(9.43123+2.15604)x345.0, glue set 248.64001fil
 ....\TU/FandolSong-Regular(0)/m/n/12.045 潦
 ....\glue 0.0 plus 0.76097
 ....\TU/FandolSong-Regular(0)/m/n/12.045 倒
@@ -487,6 +491,8 @@ Completed box being shipped out [1]
 ....\kern -0.00047
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 7.75697 minus 6.02249
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -593,7 +599,7 @@ Completed box being shipped out [2]
 ....\glue(\rightskip) 0.0
 ...\penalty 300
 ...\glue(\baselineskip) 6.13396
-...\hbox(8.2734+2.03409)x345.0, glue set 14.52759fil
+...\hbox(8.2734+2.03409)x345.0, glue set 7.74023fil
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 万
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 里
@@ -668,6 +674,8 @@ Completed box being shipped out [2]
 ....\kern -0.00041
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.78735 minus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -758,7 +766,7 @@ Completed box being shipped out [2]
 ....\glue(\rightskip) 0.0
 ...\penalty 300
 ...\glue(\baselineskip) 5.27574
-...\hbox(7.07341+1.7435)x345.0, glue set 97.8731fil
+...\hbox(7.07341+1.7435)x345.0, glue set 92.05536fil
 ....\TU/FandolSong-Regular(0)/m/n/9.03374 常
 ....\glue 0.0 plus 0.29866
 ....\TU/FandolSong-Regular(0)/m/n/9.03374 作
@@ -825,6 +833,8 @@ Completed box being shipped out [2]
 ....\kern -0.00035
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 5.81773 minus 4.51688
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -963,7 +973,7 @@ Completed box being shipped out [2]
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 7.03432
-...\hbox(9.43123+2.15604)x345.0, glue set 256.39699fil
+...\hbox(9.43123+2.15604)x345.0, glue set 248.64001fil
 ....\TU/FandolSong-Regular(0)/m/n/12.045 潦
 ....\glue 0.0 plus 0.76097
 ....\TU/FandolSong-Regular(0)/m/n/12.045 倒
@@ -984,6 +994,8 @@ Completed box being shipped out [2]
 ....\kern -0.00047
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 7.75697 minus 6.02249
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -1012,7 +1024,7 @@ Completed box being shipped out [3]
 .....\kern 0.0002
 ..\glue 25.0
 ..\glue(\lineskip) 0.0
-..\vbox(550.0+0.0)x345.0, glue set 438.95569fil
+..\vbox(550.0+0.0)x345.0, glue set 422.51599fil
 ...\write-{}
 ...\glue(\topskip) 1.76875
 ...\hbox(8.23125+2.03409)x345.0, glue set - 0.17706
@@ -1083,9 +1095,9 @@ Completed box being shipped out [3]
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 滚
 ....\glue(\rightskip) 0.0
-...\penalty 300
+...\penalty 150
 ...\glue(\baselineskip) 6.13396
-...\hbox(8.2734+2.03409)x345.0, glue set - 0.31079
+...\hbox(8.2734+2.03409)x345.0, glue set 0.47049
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 来
 ....\penalty 10000
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 。
@@ -1157,7 +1169,10 @@ Completed box being shipped out [3]
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 浊
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 酒
-....\glue 0.0 plus 0.60931
+....\glue(\rightskip) 0.0
+...\penalty 150
+...\glue(\baselineskip) 6.3026
+...\hbox(8.10477+1.81276)x345.0, glue set 323.92126fil
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 杯
 ....\penalty 10000
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 。
@@ -1166,12 +1181,14 @@ Completed box being shipped out [3]
 ....\kern -0.00041
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.78735 minus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 5.00322
+...\glue(\baselineskip) 5.22455
 ...\hbox(7.05534+1.7435)x345.0, glue set 0.19174
 ....\hbox(0.0+0.0)x27.10121
 ....\TU/FandolSong-Regular(0)/m/n/9.03374 风
@@ -1254,7 +1271,7 @@ Completed box being shipped out [3]
 ....\glue(\rightskip) 0.0
 ...\penalty 300
 ...\glue(\baselineskip) 5.25766
-...\hbox(7.09149+1.7435)x345.0, glue set 88.83936fil
+...\hbox(7.09149+1.7435)x345.0, glue set 83.02162fil
 ....\TU/FandolSong-Regular(0)/m/n/9.03374 秋
 ....\glue 0.0 plus 0.29866
 ....\TU/FandolSong-Regular(0)/m/n/9.03374 常
@@ -1323,6 +1340,8 @@ Completed box being shipped out [3]
 ....\kern -0.00035
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 5.81773 minus 4.51688
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -1456,7 +1475,7 @@ Completed box being shipped out [3]
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 7.03432
-...\hbox(9.43123+2.32468)x345.0, glue set 232.30699fil
+...\hbox(9.43123+2.32468)x345.0, glue set 224.55002fil
 ....\TU/FandolSong-Regular(0)/m/n/12.045 鬓
 ....\penalty 10000
 ....\TU/FandolSong-Regular(0)/m/n/12.045 ，
@@ -1483,6 +1502,8 @@ Completed box being shipped out [3]
 ....\kern -0.00047
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 7.75697 minus 6.02249
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -1592,7 +1613,7 @@ Completed box being shipped out [4]
 ....\glue(\rightskip) 0.0
 ...\penalty 300
 ...\glue(\baselineskip) 6.13396
-...\hbox(8.2734+2.03409)x345.0, glue set 25.06696fil
+...\hbox(8.2734+2.03409)x345.0, glue set 18.2796fil
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 里
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 悲
@@ -1665,6 +1686,8 @@ Completed box being shipped out [4]
 ....\kern -0.00041
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.78735 minus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -1759,7 +1782,7 @@ Completed box being shipped out [4]
 ....\glue(\rightskip) 0.0
 ...\penalty 300
 ...\glue(\baselineskip) 5.27574
-...\hbox(7.07341+1.7435)x345.0, glue set 115.94057fil
+...\hbox(7.07341+1.7435)x345.0, glue set 110.12283fil
 ....\TU/FandolSong-Regular(0)/m/n/9.03374 客
 ....\penalty 10000
 ....\TU/FandolSong-Regular(0)/m/n/9.03374 ，
@@ -1822,6 +1845,8 @@ Completed box being shipped out [4]
 ....\kern -0.00035
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 5.81773 minus 4.51688
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -1965,7 +1990,7 @@ Completed box being shipped out [4]
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 7.03432
-...\hbox(9.43123+2.15604)x345.0, glue set 280.48698fil
+...\hbox(9.43123+2.15604)x345.0, glue set 272.73001fil
 ....\TU/FandolSong-Regular(0)/m/n/12.045 新
 ....\glue 0.0 plus 0.76097
 ....\TU/FandolSong-Regular(0)/m/n/12.045 停
@@ -1982,6 +2007,8 @@ Completed box being shipped out [4]
 ....\kern -0.00047
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 7.75697 minus 6.02249
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -2095,7 +2122,7 @@ Completed box being shipped out [5]
 ....\glue(\rightskip) 0.0
 ...\penalty 300
 ...\glue(\baselineskip) 6.13396
-...\hbox(8.2734+2.03409)x345.0, glue set 46.14569fil
+...\hbox(8.2734+2.03409)x345.0, glue set 39.35834fil
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 秋
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 常
@@ -2164,6 +2191,8 @@ Completed box being shipped out [5]
 ....\kern -0.00041
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.78735 minus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -2266,7 +2295,7 @@ Completed box being shipped out [5]
 ....\glue(\rightskip) 0.0
 ...\penalty 300
 ...\glue(\baselineskip) 5.27574
-...\hbox(7.07341+1.7435)x345.0, glue set 143.04178fil
+...\hbox(7.07341+1.7435)x345.0, glue set 137.22404fil
 ....\TU/FandolSong-Regular(0)/m/n/9.03374 年
 ....\glue 0.0 plus 0.29866
 ....\TU/FandolSong-Regular(0)/m/n/9.03374 多
@@ -2321,6 +2350,8 @@ Completed box being shipped out [5]
 ....\kern -0.00035
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 5.81773 minus 4.51688
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -2466,7 +2497,7 @@ Completed box being shipped out [5]
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 7.03432
-...\hbox(9.43123+2.15604)x345.0, glue set 292.53198fil
+...\hbox(9.43123+2.15604)x345.0, glue set 284.77501fil
 ....\TU/FandolSong-Regular(0)/m/n/12.045 停
 ....\glue 0.0 plus 0.76097
 ....\TU/FandolSong-Regular(0)/m/n/12.045 浊
@@ -2481,6 +2512,8 @@ Completed box being shipped out [5]
 ....\kern -0.00047
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 7.75697 minus 6.02249
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -2657,7 +2690,7 @@ Completed box being shipped out [6]
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 6.3026
-...\hbox(8.10477+1.81276)x345.0, glue set 330.70862fil
+...\hbox(8.10477+1.81276)x345.0, glue set 323.92126fil
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 杯
 ....\penalty 10000
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 。
@@ -2666,6 +2699,8 @@ Completed box being shipped out [6]
 ....\kern -0.00041
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.78735 minus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -2752,7 +2787,7 @@ Completed box being shipped out [6]
 ....\glue(\rightskip) 0.0
 ...\penalty 300
 ...\glue(\baselineskip) 5.25766
-...\hbox(7.09149+1.7435)x345.0, glue set 79.80562fil
+...\hbox(7.09149+1.7435)x345.0, glue set 73.98788fil
 ....\TU/FandolSong-Regular(0)/m/n/9.03374 悲
 ....\glue 0.0 plus 0.29866
 ....\TU/FandolSong-Regular(0)/m/n/9.03374 秋
@@ -2823,6 +2858,8 @@ Completed box being shipped out [6]
 ....\kern -0.00035
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 5.81773 minus 4.51688
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -2956,7 +2993,7 @@ Completed box being shipped out [6]
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 7.03432
-...\hbox(9.43123+2.32468)x345.0, glue set 232.30699fil
+...\hbox(9.43123+2.32468)x345.0, glue set 224.55002fil
 ....\TU/FandolSong-Regular(0)/m/n/12.045 鬓
 ....\penalty 10000
 ....\TU/FandolSong-Regular(0)/m/n/12.045 ，
@@ -2983,6 +3020,8 @@ Completed box being shipped out [6]
 ....\kern -0.00047
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 7.75697 minus 6.02249
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -3089,7 +3128,7 @@ Completed box being shipped out [7]
 ....\glue(\rightskip) 0.0
 ...\penalty 300
 ...\glue(\baselineskip) 6.13396
-...\hbox(8.2734+2.03409)x345.0, glue set 14.52759fil
+...\hbox(8.2734+2.03409)x345.0, glue set 7.74023fil
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 万
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 里
@@ -3164,6 +3203,8 @@ Completed box being shipped out [7]
 ....\kern -0.00041
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.78735 minus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -3254,7 +3295,7 @@ Completed box being shipped out [7]
 ....\glue(\rightskip) 0.0
 ...\penalty 300
 ...\glue(\baselineskip) 5.27574
-...\hbox(7.07341+1.7435)x345.0, glue set 97.8731fil
+...\hbox(7.07341+1.7435)x345.0, glue set 92.05536fil
 ....\TU/FandolSong-Regular(0)/m/n/9.03374 常
 ....\glue 0.0 plus 0.29866
 ....\TU/FandolSong-Regular(0)/m/n/9.03374 作
@@ -3321,6 +3362,8 @@ Completed box being shipped out [7]
 ....\kern -0.00035
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 5.81773 minus 4.51688
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -3459,7 +3502,7 @@ Completed box being shipped out [7]
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 7.03432
-...\hbox(9.43123+2.15604)x345.0, glue set 256.39699fil
+...\hbox(9.43123+2.15604)x345.0, glue set 248.64001fil
 ....\TU/FandolSong-Regular(0)/m/n/12.045 潦
 ....\glue 0.0 plus 0.76097
 ....\TU/FandolSong-Regular(0)/m/n/12.045 倒
@@ -3480,6 +3523,8 @@ Completed box being shipped out [7]
 ....\kern -0.00047
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 7.75697 minus 6.02249
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -3648,7 +3693,7 @@ Completed box being shipped out [8]
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 6.15504
-...\hbox(8.25232+1.88654)x345.0, glue set 288.55115fil
+...\hbox(8.25232+1.88654)x345.0, glue set 281.7638fil
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 新
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 停
@@ -3665,6 +3710,8 @@ Completed box being shipped out [8]
 ....\kern -0.00041
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.78735 minus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -3739,7 +3786,7 @@ Completed box being shipped out [8]
 ....\glue(\rightskip) 0.0
 ...\penalty 300
 ...\glue(\baselineskip) 5.25766
-...\hbox(7.09149+1.7435)x345.0, glue set 34.63693fil
+...\hbox(7.09149+1.7435)x345.0, glue set 28.8192fil
 ....\TU/FandolSong-Regular(0)/m/n/9.03374 滚
 ....\glue 0.0 plus 0.29866
 ....\TU/FandolSong-Regular(0)/m/n/9.03374 来
@@ -3822,6 +3869,8 @@ Completed box being shipped out [8]
 ....\kern -0.00035
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 5.81773 minus 4.51688
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -3949,7 +3998,7 @@ Completed box being shipped out [8]
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 7.03432
-...\hbox(9.43123+2.32468)x345.0, glue set 196.172fil
+...\hbox(9.43123+2.32468)x345.0, glue set 188.41502fil
 ....\TU/FandolSong-Regular(0)/m/n/12.045 恨
 ....\glue 0.0 plus 0.76097
 ....\TU/FandolSong-Regular(0)/m/n/12.045 繁
@@ -3982,6 +4031,8 @@ Completed box being shipped out [8]
 ....\kern -0.00047
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 7.75697 minus 6.02249
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -4091,7 +4142,7 @@ Completed box being shipped out [9]
 ....\glue(\rightskip) 0.0
 ...\penalty 300
 ...\glue(\baselineskip) 6.13396
-...\hbox(8.2734+2.03409)x345.0, glue set 25.06696fil
+...\hbox(8.2734+2.03409)x345.0, glue set 18.2796fil
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 里
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 悲
@@ -4164,6 +4215,8 @@ Completed box being shipped out [9]
 ....\kern -0.00041
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.78735 minus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -4258,7 +4311,7 @@ Completed box being shipped out [9]
 ....\glue(\rightskip) 0.0
 ...\penalty 300
 ...\glue(\baselineskip) 5.27574
-...\hbox(7.07341+1.7435)x345.0, glue set 115.94057fil
+...\hbox(7.07341+1.7435)x345.0, glue set 110.12283fil
 ....\TU/FandolSong-Regular(0)/m/n/9.03374 客
 ....\penalty 10000
 ....\TU/FandolSong-Regular(0)/m/n/9.03374 ，
@@ -4321,6 +4374,8 @@ Completed box being shipped out [9]
 ....\kern -0.00035
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 5.81773 minus 4.51688
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -4464,7 +4519,7 @@ Completed box being shipped out [9]
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 7.03432
-...\hbox(9.43123+2.15604)x345.0, glue set 280.48698fil
+...\hbox(9.43123+2.15604)x345.0, glue set 272.73001fil
 ....\TU/FandolSong-Regular(0)/m/n/12.045 新
 ....\glue 0.0 plus 0.76097
 ....\TU/FandolSong-Regular(0)/m/n/12.045 停
@@ -4481,6 +4536,8 @@ Completed box being shipped out [9]
 ....\kern -0.00047
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 7.75697 minus 6.02249
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -4592,7 +4649,7 @@ Completed box being shipped out [10]
 ....\glue(\rightskip) 0.0
 ...\penalty 300
 ...\glue(\baselineskip) 6.13396
-...\hbox(8.2734+2.03409)x345.0, glue set 35.60632fil
+...\hbox(8.2734+2.03409)x345.0, glue set 28.81897fil
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 悲
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 秋
@@ -4663,6 +4720,8 @@ Completed box being shipped out [10]
 ....\kern -0.00041
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.78735 minus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -4762,7 +4821,7 @@ Completed box being shipped out [10]
 ....\glue(\rightskip) 0.0
 ...\penalty 300
 ...\glue(\baselineskip) 5.27574
-...\hbox(7.07341+1.7435)x345.0, glue set 134.00804fil
+...\hbox(7.07341+1.7435)x345.0, glue set 128.1903fil
 ....\TU/FandolSong-Regular(0)/m/n/9.03374 百
 ....\glue 0.0 plus 0.29866
 ....\TU/FandolSong-Regular(0)/m/n/9.03374 年
@@ -4819,6 +4878,8 @@ Completed box being shipped out [10]
 ....\kern -0.00035
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 5.81773 minus 4.51688
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -4962,7 +5023,7 @@ Completed box being shipped out [10]
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 7.03432
-...\hbox(9.43123+2.15604)x345.0, glue set 280.48698fil
+...\hbox(9.43123+2.15604)x345.0, glue set 272.73001fil
 ....\TU/FandolSong-Regular(0)/m/n/12.045 新
 ....\glue 0.0 plus 0.76097
 ....\TU/FandolSong-Regular(0)/m/n/12.045 停
@@ -4979,6 +5040,8 @@ Completed box being shipped out [10]
 ....\kern -0.00047
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 7.75697 minus 6.02249
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0

--- a/ctex/test/testfiles/indent.tlg
+++ b/ctex/test/testfiles/indent.tlg
@@ -172,7 +172,7 @@ Completed box being shipped out [1]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.78735 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -331,7 +331,7 @@ Completed box being shipped out [1]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 5.81773 minus 4.51688
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -492,7 +492,7 @@ Completed box being shipped out [1]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 7.75697 minus 6.02249
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -675,7 +675,7 @@ Completed box being shipped out [2]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.78735 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -834,7 +834,7 @@ Completed box being shipped out [2]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 5.81773 minus 4.51688
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -995,7 +995,7 @@ Completed box being shipped out [2]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 7.75697 minus 6.02249
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -1182,7 +1182,7 @@ Completed box being shipped out [3]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.78735 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -1341,7 +1341,7 @@ Completed box being shipped out [3]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 5.81773 minus 4.51688
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -1503,7 +1503,7 @@ Completed box being shipped out [3]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 7.75697 minus 6.02249
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -1687,7 +1687,7 @@ Completed box being shipped out [4]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.78735 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -1846,7 +1846,7 @@ Completed box being shipped out [4]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 5.81773 minus 4.51688
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -2008,7 +2008,7 @@ Completed box being shipped out [4]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 7.75697 minus 6.02249
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -2192,7 +2192,7 @@ Completed box being shipped out [5]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.78735 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -2351,7 +2351,7 @@ Completed box being shipped out [5]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 5.81773 minus 4.51688
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -2513,7 +2513,7 @@ Completed box being shipped out [5]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 7.75697 minus 6.02249
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -2700,7 +2700,7 @@ Completed box being shipped out [6]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.78735 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -2859,7 +2859,7 @@ Completed box being shipped out [6]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 5.81773 minus 4.51688
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -3021,7 +3021,7 @@ Completed box being shipped out [6]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 7.75697 minus 6.02249
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -3204,7 +3204,7 @@ Completed box being shipped out [7]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.78735 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -3363,7 +3363,7 @@ Completed box being shipped out [7]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 5.81773 minus 4.51688
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -3524,7 +3524,7 @@ Completed box being shipped out [7]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 7.75697 minus 6.02249
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -3711,7 +3711,7 @@ Completed box being shipped out [8]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.78735 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -3870,7 +3870,7 @@ Completed box being shipped out [8]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 5.81773 minus 4.51688
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -4032,7 +4032,7 @@ Completed box being shipped out [8]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 7.75697 minus 6.02249
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -4216,7 +4216,7 @@ Completed box being shipped out [9]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.78735 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -4375,7 +4375,7 @@ Completed box being shipped out [9]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 5.81773 minus 4.51688
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -4537,7 +4537,7 @@ Completed box being shipped out [9]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 7.75697 minus 6.02249
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -4721,7 +4721,7 @@ Completed box being shipped out [10]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.78735 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -4879,7 +4879,7 @@ Completed box being shipped out [10]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 5.81773 minus 4.51688
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -5041,7 +5041,7 @@ Completed box being shipped out [10]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 7.75697 minus 6.02249
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0

--- a/ctex/test/testfiles/label-ref01.tlg
+++ b/ctex/test/testfiles/label-ref01.tlg
@@ -94,7 +94,7 @@ Completed box being shipped out [1]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.78735 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -195,7 +195,7 @@ Completed box being shipped out [2]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.78735 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0

--- a/ctex/test/testfiles/label-ref01.tlg
+++ b/ctex/test/testfiles/label-ref01.tlg
@@ -70,7 +70,7 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 5.65819
-...\hbox(8.17854+1.87599)x345.0, glue set 258.69312fil
+...\hbox(8.17854+1.87599)x345.0, glue set 251.90576fil
 ....\hbox(0.0+0.0)x21.07874
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 本
 ....\glue 0.0 plus 0.60931
@@ -93,6 +93,8 @@ Completed box being shipped out [1]
 ....\kern -0.00041
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.78735 minus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -174,7 +176,7 @@ Completed box being shipped out [2]
 ...\penalty 0
 ...\glue(\belowdisplayshortskip) 6.0 plus 3.0 minus 3.0
 ...\glue(\baselineskip) 5.67023
-...\hbox(8.1364+1.73898)x345.0, glue set 300.85059fil
+...\hbox(8.1364+1.73898)x345.0, glue set 294.06323fil
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 见
 ....\glue 0.0 plus 0.60931
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 公
@@ -192,6 +194,8 @@ Completed box being shipped out [2]
 ....\kern -0.00041
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.78735 minus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0

--- a/ctex/test/testfiles/punct.tlg
+++ b/ctex/test/testfiles/punct.tlg
@@ -93,7 +93,7 @@ Completed box being shipped out [1]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.78735 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -177,7 +177,7 @@ Completed box being shipped out [1]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 1.51767 plus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -261,7 +261,7 @@ Completed box being shipped out [1]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 4.67947 plus 2.10788 minus 3.1618
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -345,7 +345,7 @@ Completed box being shipped out [1]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 3.62555 plus 3.1618 minus 2.10788
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -429,7 +429,7 @@ Completed box being shipped out [1]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 0.0
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -703,7 +703,7 @@ Completed box being shipped out [2]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.78735 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -858,7 +858,7 @@ Completed box being shipped out [2]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 1.51767 plus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -1013,7 +1013,7 @@ Completed box being shipped out [2]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 4.67947 plus 2.10788 minus 3.1618
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -1168,7 +1168,7 @@ Completed box being shipped out [2]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 3.62555 plus 3.1618 minus 2.10788
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -1323,7 +1323,7 @@ Completed box being shipped out [2]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 0.0
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -1662,7 +1662,7 @@ Completed box being shipped out [3]
 ....\kern -0.18782
 ....\kern 0.18782
 ....\glue 6.38686 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -1855,7 +1855,7 @@ Completed box being shipped out [3]
 ....\kern -0.18782
 ....\kern 0.18782
 ....\glue 1.11717 plus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -2048,7 +2048,7 @@ Completed box being shipped out [3]
 ....\kern -0.18782
 ....\kern 0.18782
 ....\glue 1.11717 plus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -2242,7 +2242,7 @@ Completed box being shipped out [3]
 ....\kern -0.18782
 ....\kern 0.18782
 ....\glue 3.22505 plus 3.1618 minus 2.10788
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -2436,7 +2436,7 @@ Completed box being shipped out [3]
 ....\kern -0.18782
 ....\kern 0.18782
 ....\glue 0.0
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -2703,7 +2703,7 @@ Completed box being shipped out [4]
 ....\kern -0.1877
 ....\kern 0.1877
 ....\glue 6.2393 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -2947,7 +2947,7 @@ Completed box being shipped out [4]
 ....\kern -0.1877
 ....\kern 0.1877
 ....\glue 0.96962 plus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -3191,7 +3191,7 @@ Completed box being shipped out [4]
 ....\kern -0.1877
 ....\kern 0.1877
 ....\glue 0.96962 plus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -3437,7 +3437,7 @@ Completed box being shipped out [4]
 ....\kern -0.1877
 ....\kern 0.1877
 ....\glue 3.0775 plus 3.1618 minus 2.10788
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -3684,7 +3684,7 @@ Completed box being shipped out [4]
 ....\kern -0.1877
 ....\kern 0.1877
 ....\glue 0.0
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -3953,7 +3953,7 @@ Completed box being shipped out [5]
 ....\kern -0.1877
 ....\kern 0.1877
 ....\glue 6.2393 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -4099,7 +4099,7 @@ Completed box being shipped out [5]
 ....\kern -0.1877
 ....\kern 0.1877
 ....\glue 0.96962 plus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -4245,7 +4245,7 @@ Completed box being shipped out [5]
 ....\kern -0.1877
 ....\kern 0.1877
 ....\glue 0.96962 plus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -4390,7 +4390,7 @@ Completed box being shipped out [5]
 ....\kern -0.1877
 ....\kern 0.1877
 ....\glue 3.0775 plus 3.1618 minus 2.10788
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -4536,7 +4536,7 @@ Completed box being shipped out [5]
 ....\kern -0.1877
 ....\kern 0.1877
 ....\glue 0.0
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -4614,7 +4614,7 @@ Completed box being shipped out [6]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.78735 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -4672,7 +4672,7 @@ Completed box being shipped out [6]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 1.51767 plus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -4730,7 +4730,7 @@ Completed box being shipped out [6]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 4.67947 plus 2.10788 minus 3.1618
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -4788,7 +4788,7 @@ Completed box being shipped out [6]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 3.62555 plus 3.1618 minus 2.10788
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -4846,7 +4846,7 @@ Completed box being shipped out [6]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 0.0
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -5111,7 +5111,7 @@ Completed box being shipped out [7]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.78735 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -5257,7 +5257,7 @@ Completed box being shipped out [7]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 1.51767 plus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -5403,7 +5403,7 @@ Completed box being shipped out [7]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 4.67947 plus 2.10788 minus 3.1618
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -5549,7 +5549,7 @@ Completed box being shipped out [7]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 3.62555 plus 3.1618 minus 2.10788
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -5695,7 +5695,7 @@ Completed box being shipped out [7]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 0.0
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0

--- a/ctex/test/testfiles/punct.tlg
+++ b/ctex/test/testfiles/punct.tlg
@@ -16,7 +16,7 @@ Completed box being shipped out [1]
 ..\glue(\lineskip) 0.0
 ..\vbox(578.15999+0.0)x469.75499, glue set 502.39418fil
 ...\glue(\topskip) 1.76875
-...\hbox(8.23125+2.03409)x469.75499, glue set 170.90068fil
+...\hbox(8.23125+2.03409)x469.75499, glue set 164.11333fil
 ....\hbox(0.0+0.0)x21.07874
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 标
 ....\glue 0.0 plus 0.39433
@@ -92,13 +92,15 @@ Completed box being shipped out [1]
 ....\kern -0.00041
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.78735 minus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 6.17612
-...\hbox(8.23125+2.03409)x469.75499, glue set 213.05815fil
+...\hbox(8.23125+2.03409)x469.75499, glue set 211.54048fil
 ....\hbox(0.0+0.0)x21.07874
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 标
 ....\glue 0.0 plus 0.39433
@@ -174,13 +176,15 @@ Completed box being shipped out [1]
 ....\kern -0.00041
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 1.51767 plus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 6.17612
-...\hbox(8.23125+2.03409)x469.75499, glue set 206.73454fil
+...\hbox(8.23125+2.03409)x469.75499, glue set 202.05507fil
 ....\hbox(0.0+0.0)x21.07874
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 标
 ....\glue 0.0 plus 0.39433
@@ -256,13 +260,15 @@ Completed box being shipped out [1]
 ....\kern -0.00041
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 4.67947 plus 2.10788 minus 3.1618
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 6.17612
-...\hbox(8.23125+2.03409)x469.75499, glue set 196.19511fil
+...\hbox(8.23125+2.03409)x469.75499, glue set 192.56956fil
 ....\hbox(0.0+0.0)x21.07874
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 标
 ....\glue 0.0 plus 0.39433
@@ -338,6 +344,8 @@ Completed box being shipped out [1]
 ....\kern -0.00041
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 3.62555 plus 3.1618 minus 2.10788
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -420,6 +428,8 @@ Completed box being shipped out [1]
 ....\kern 0.0
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 0.0
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -657,7 +667,7 @@ Completed box being shipped out [2]
 ....\glue(\rightskip) 0.0
 ...\penalty 300
 ...\glue(\baselineskip) 5.95479
-...\hbox(8.45258+2.03409)x469.75499, glue set 360.6093fil
+...\hbox(8.45258+2.03409)x469.75499, glue set 353.82195fil
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 点
 ....\penalty 10000
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 』
@@ -692,6 +702,8 @@ Completed box being shipped out [2]
 ....\kern -0.00041
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.78735 minus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -833,7 +845,7 @@ Completed box being shipped out [2]
 ....\glue(\rightskip) 0.0
 ...\penalty 300
 ...\glue(\baselineskip) 6.17612
-...\hbox(8.23125+1.73898)x469.75499, glue set 450.19392fil
+...\hbox(8.23125+1.73898)x469.75499, glue set 448.67625fil
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 点
 ....\penalty 10000
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 〉
@@ -845,6 +857,8 @@ Completed box being shipped out [2]
 ....\kern -0.00041
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 1.51767 plus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -986,7 +1000,7 @@ Completed box being shipped out [2]
 ....\glue(\rightskip) 0.0
 ...\penalty 300
 ...\glue(\baselineskip) 6.17612
-...\hbox(8.23125+1.73898)x469.75499, glue set 451.37433fil
+...\hbox(8.23125+1.73898)x469.75499, glue set 446.69485fil
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 点
 ....\penalty 10000
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 〉
@@ -998,6 +1012,8 @@ Completed box being shipped out [2]
 ....\kern -0.00041
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 4.67947 plus 2.10788 minus 3.1618
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -1129,7 +1145,7 @@ Completed box being shipped out [2]
 ....\glue(\rightskip) 0.0
 ...\penalty 300
 ...\glue(\baselineskip) 6.17612
-...\hbox(8.23125+1.73898)x469.75499, glue set 411.19826fil
+...\hbox(8.23125+1.73898)x469.75499, glue set 407.57271fil
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 点
 ....\penalty 10000
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 》
@@ -1151,6 +1167,8 @@ Completed box being shipped out [2]
 ....\kern -0.00041
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 3.62555 plus 3.1618 minus 2.10788
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -1304,6 +1322,8 @@ Completed box being shipped out [2]
 ....\kern 0.0
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 0.0
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -1580,7 +1600,7 @@ Completed box being shipped out [3]
 ....\glue(\rightskip) 0.0
 ...\penalty 300
 ...\glue(\baselineskip) 5.88101
-...\hbox(8.45258+2.10786)x469.75499, glue set 264.4692fil
+...\hbox(8.45258+2.10786)x469.75499, glue set 258.08234fil
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 点
 ....\penalty 10000
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 。
@@ -1641,6 +1661,8 @@ Completed box being shipped out [3]
 ....\kern -0.0004
 ....\kern -0.18782
 ....\kern 0.18782
+....\glue 6.38686 minus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -1788,7 +1810,7 @@ Completed box being shipped out [3]
 ....\glue(\rightskip) 0.0
 ...\penalty 300
 ...\glue(\baselineskip) 5.88101
-...\hbox(8.45258+2.10786)x469.75499, glue set 338.24477fil
+...\hbox(8.45258+2.10786)x469.75499, glue set 337.1276fil
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 点
 ....\penalty 10000
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 ，
@@ -1832,6 +1854,8 @@ Completed box being shipped out [3]
 ....\kern -0.0004
 ....\kern -0.18782
 ....\kern 0.18782
+....\glue 1.11717 plus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -1979,7 +2003,7 @@ Completed box being shipped out [3]
 ....\glue(\rightskip) 0.0
 ...\penalty 300
 ...\glue(\baselineskip) 5.88101
-...\hbox(8.45258+2.10786)x469.75499, glue set 338.24477fil
+...\hbox(8.45258+2.10786)x469.75499, glue set 337.1276fil
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 点
 ....\penalty 10000
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 ，
@@ -2023,6 +2047,8 @@ Completed box being shipped out [3]
 ....\kern -0.0004
 ....\kern -0.18782
 ....\kern 0.18782
+....\glue 1.11717 plus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -2154,7 +2180,7 @@ Completed box being shipped out [3]
 ....\glue(\rightskip) 0.0
 ...\penalty 300
 ...\glue(\baselineskip) 5.88101
-...\hbox(8.45258+2.10786)x469.75499, glue set 280.27821fil
+...\hbox(8.45258+2.10786)x469.75499, glue set 277.05316fil
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 点
 ....\penalty 10000
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 。
@@ -2215,6 +2241,8 @@ Completed box being shipped out [3]
 ....\kern -0.0004
 ....\kern -0.18782
 ....\kern 0.18782
+....\glue 3.22505 plus 3.1618 minus 2.10788
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -2407,6 +2435,8 @@ Completed box being shipped out [3]
 ....\kern 0.0
 ....\kern -0.18782
 ....\kern 0.18782
+....\glue 0.0
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -2648,7 +2678,7 @@ Completed box being shipped out [4]
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 5.88101
-...\hbox(8.45258+1.50711)x469.75499, glue set 396.94904fil
+...\hbox(8.45258+1.50711)x469.75499, glue set 390.70973fil
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 人
 ....\penalty 10000
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 』
@@ -2672,6 +2702,8 @@ Completed box being shipped out [4]
 ....\kern -0.00038
 ....\kern -0.1877
 ....\kern 0.1877
+....\glue 6.2393 minus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -2799,7 +2831,7 @@ Completed box being shipped out [4]
 ....\glue(\rightskip) 0.0
 ...\penalty 300
 ...\glue(\baselineskip) 6.07072
-...\hbox(8.45258+2.10786)x469.75499, glue set 22.79094fil
+...\hbox(8.45258+2.10786)x469.75499, glue set 21.82132fil
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 点
 ....\penalty 10000
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 』
@@ -2914,6 +2946,8 @@ Completed box being shipped out [4]
 ....\kern -0.00038
 ....\kern -0.1877
 ....\kern 0.1877
+....\glue 0.96962 plus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -3041,7 +3075,7 @@ Completed box being shipped out [4]
 ....\glue(\rightskip) 0.0
 ...\penalty 300
 ...\glue(\baselineskip) 6.07072
-...\hbox(8.45258+2.10786)x469.75499, glue set 22.79094fil
+...\hbox(8.45258+2.10786)x469.75499, glue set 21.82132fil
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 点
 ....\penalty 10000
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 』
@@ -3156,6 +3190,8 @@ Completed box being shipped out [4]
 ....\kern -0.00038
 ....\kern -0.1877
 ....\kern 0.1877
+....\glue 0.96962 plus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -3388,7 +3424,7 @@ Completed box being shipped out [4]
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 5.88101
-...\hbox(8.45258+1.50711)x469.75499, glue set 449.64587fil
+...\hbox(8.45258+1.50711)x469.75499, glue set 446.56837fil
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 夭
 ....\penalty 10000
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 。
@@ -3400,6 +3436,8 @@ Completed box being shipped out [4]
 ....\kern -0.00038
 ....\kern -0.1877
 ....\kern 0.1877
+....\glue 3.0775 plus 3.1618 minus 2.10788
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -3645,6 +3683,8 @@ Completed box being shipped out [4]
 ....\kern 0.0
 ....\kern -0.1877
 ....\kern 0.1877
+....\glue 0.0
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -3884,7 +3924,7 @@ Completed box being shipped out [5]
 ....\glue(\rightskip) 0.0
 ...\penalty 300
 ...\glue(\baselineskip) 5.88101
-...\hbox(8.45258+2.10786)x469.75499, glue set 386.40967fil
+...\hbox(8.45258+2.10786)x469.75499, glue set 380.17036fil
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 容
 ....\penalty 10000
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 ）
@@ -3912,6 +3952,8 @@ Completed box being shipped out [5]
 ....\kern -0.00038
 ....\kern -0.1877
 ....\kern 0.1877
+....\glue 6.2393 minus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -4047,7 +4089,7 @@ Completed box being shipped out [5]
 ....\glue(\rightskip) 0.0
 ...\penalty 300
 ...\glue(\baselineskip) 5.88101
-...\hbox(8.45258+1.63359)x469.75499, glue set 454.91556fil
+...\hbox(8.45258+1.63359)x469.75499, glue set 453.94594fil
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 好
 ....\penalty 10000
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 」
@@ -4056,6 +4098,8 @@ Completed box being shipped out [5]
 ....\kern -0.00038
 ....\kern -0.1877
 ....\kern 0.1877
+....\glue 0.96962 plus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -4191,7 +4235,7 @@ Completed box being shipped out [5]
 ....\glue(\rightskip) 0.0
 ...\penalty 300
 ...\glue(\baselineskip) 5.88101
-...\hbox(8.45258+1.63359)x469.75499, glue set 454.91556fil
+...\hbox(8.45258+1.63359)x469.75499, glue set 453.94594fil
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 好
 ....\penalty 10000
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 」
@@ -4200,6 +4244,8 @@ Completed box being shipped out [5]
 ....\kern -0.00038
 ....\kern -0.1877
 ....\kern 0.1877
+....\glue 0.96962 plus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -4332,7 +4378,7 @@ Completed box being shipped out [5]
 ....\glue(\rightskip) 0.0
 ...\penalty 300
 ...\glue(\baselineskip) 5.88101
-...\hbox(8.45258+1.63359)x469.75499, glue set 444.37619fil
+...\hbox(8.45258+1.63359)x469.75499, glue set 441.29869fil
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 不
 ....\glue 0.0 plus 0.39433
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 好
@@ -4343,6 +4389,8 @@ Completed box being shipped out [5]
 ....\kern -0.00038
 ....\kern -0.1877
 ....\kern 0.1877
+....\glue 3.0775 plus 3.1618 minus 2.10788
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -4487,6 +4535,8 @@ Completed box being shipped out [5]
 ....\kern 0.0
 ....\kern -0.1877
 ....\kern 0.1877
+....\glue 0.0
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -4513,7 +4563,7 @@ Completed box being shipped out [6]
 ..\vbox(578.15999+0.0)x469.75499, glue set 502.39418fil
 ...\write-{}
 ...\glue(\topskip) 2.8016
-...\hbox(7.1984+2.03409)x469.75499, glue set 161.60501fil
+...\hbox(7.1984+2.03409)x469.75499, glue set 154.81766fil
 ....\hbox(0.0+0.0)x21.07874
 ....\TU/lmr/m/n/10.53937 Dian
 ....\penalty 10000
@@ -4563,13 +4613,15 @@ Completed box being shipped out [6]
 ....\kern -0.00041
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.78735 minus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 7.20897
-...\hbox(7.1984+2.03409)x469.75499, glue set 203.76248fil
+...\hbox(7.1984+2.03409)x469.75499, glue set 202.24481fil
 ....\hbox(0.0+0.0)x21.07874
 ....\TU/lmr/m/n/10.53937 Dian
 ....\penalty 10000
@@ -4619,13 +4671,15 @@ Completed box being shipped out [6]
 ....\kern -0.00041
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 1.51767 plus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 7.20897
-...\hbox(7.1984+2.03409)x469.75499, glue set 197.43887fil
+...\hbox(7.1984+2.03409)x469.75499, glue set 192.7594fil
 ....\hbox(0.0+0.0)x21.07874
 ....\TU/lmr/m/n/10.53937 Dian
 ....\penalty 10000
@@ -4675,13 +4729,15 @@ Completed box being shipped out [6]
 ....\kern -0.00041
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 4.67947 plus 2.10788 minus 3.1618
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 7.20897
-...\hbox(7.1984+2.03409)x469.75499, glue set 186.89944fil
+...\hbox(7.1984+2.03409)x469.75499, glue set 183.2739fil
 ....\hbox(0.0+0.0)x21.07874
 ....\TU/lmr/m/n/10.53937 Dian
 ....\penalty 10000
@@ -4731,6 +4787,8 @@ Completed box being shipped out [6]
 ....\kern -0.00041
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 3.62555 plus 3.1618 minus 2.10788
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -4787,6 +4845,8 @@ Completed box being shipped out [6]
 ....\kern 0.0
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 0.0
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -5030,7 +5090,7 @@ Completed box being shipped out [7]
 ....\glue(\rightskip) 0.0
 ...\penalty 300
 ...\glue(\baselineskip) 5.9021
-...\hbox(8.43149+2.10786)x469.75499, glue set 401.88147fil
+...\hbox(8.43149+2.10786)x469.75499, glue set 395.09412fil
 ....\TU/lmr/m/n/10.53937 Dian
 ....\penalty 10000
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 ，
@@ -5050,6 +5110,8 @@ Completed box being shipped out [7]
 ....\kern -0.00041
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.78735 minus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -5174,7 +5236,7 @@ Completed box being shipped out [7]
 ....\glue(\rightskip) 0.0
 ...\penalty 300
 ...\glue(\baselineskip) 5.9021
-...\hbox(8.43149+2.10786)x469.75499, glue set 407.15115fil
+...\hbox(8.43149+2.10786)x469.75499, glue set 405.63348fil
 ....\TU/lmr/m/n/10.53937 Dian
 ....\penalty 10000
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 ，
@@ -5194,6 +5256,8 @@ Completed box being shipped out [7]
 ....\kern -0.00041
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 1.51767 plus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -5318,7 +5382,7 @@ Completed box being shipped out [7]
 ....\glue(\rightskip) 0.0
 ...\penalty 300
 ...\glue(\baselineskip) 5.9021
-...\hbox(8.43149+2.10786)x469.75499, glue set 408.66882fil
+...\hbox(8.43149+2.10786)x469.75499, glue set 403.98935fil
 ....\TU/lmr/m/n/10.53937 Dian
 ....\penalty 10000
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 ，
@@ -5338,6 +5402,8 @@ Completed box being shipped out [7]
 ....\kern -0.00041
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 4.67947 plus 2.10788 minus 3.1618
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -5462,7 +5528,7 @@ Completed box being shipped out [7]
 ....\glue(\rightskip) 0.0
 ...\penalty 300
 ...\glue(\baselineskip) 5.9021
-...\hbox(8.43149+2.10786)x469.75499, glue set 405.04327fil
+...\hbox(8.43149+2.10786)x469.75499, glue set 401.41772fil
 ....\TU/lmr/m/n/10.53937 Dian
 ....\penalty 10000
 ....\TU/FandolSong-Regular(0)/m/n/10.53937 ，
@@ -5482,6 +5548,8 @@ Completed box being shipped out [7]
 ....\kern -0.00041
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 3.62555 plus 3.1618 minus 2.10788
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -5626,6 +5694,8 @@ Completed box being shipped out [7]
 ....\kern 0.0
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 0.0
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0

--- a/ctex/test/testfiles/quote01.tlg
+++ b/ctex/test/testfiles/quote01.tlg
@@ -83,7 +83,7 @@ Completed box being shipped out [1]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.78735 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -148,7 +148,7 @@ Completed box being shipped out [2]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.78735 minus 5.26968
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0

--- a/ctex/test/testfiles/quote01.tlg
+++ b/ctex/test/testfiles/quote01.tlg
@@ -21,7 +21,7 @@ Completed box being shipped out [1]
 ..\vbox(550.0+0.0)x320.0, glue set 528.09921fil
 ...\write-{}
 ...\glue(\topskip) 1.76875
-...\hbox(8.23125+1.84438)x295.0, glue set 38.30316fil, shifted 25.0
+...\hbox(8.23125+1.84438)x295.0, glue set 31.51581fil, shifted 25.0
 ....\hbox(0.0+0.0)x21.07874
 .....\glue 21.07874
 .....\glue -20.0
@@ -82,6 +82,8 @@ Completed box being shipped out [1]
 ....\kern -0.00041
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.78735 minus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -114,7 +116,7 @@ Completed box being shipped out [2]
 ..\vbox(550.0+0.0)x320.0, glue set 528.15192fil
 ...\write-{}
 ...\glue(\topskip) 1.78983
-...\hbox(8.21017+1.79167)x295.0, glue set 206.93304fil, shifted 25.0
+...\hbox(8.21017+1.79167)x295.0, glue set 200.14569fil, shifted 25.0
 ....\hbox(0.0+0.0)x0.0
 .....\glue 0.0
 .....\glue -20.0
@@ -145,6 +147,8 @@ Completed box being shipped out [2]
 ....\kern -0.00041
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.78735 minus 5.26968
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0

--- a/ctex/test/testfiles/twocolumn01.tlg
+++ b/ctex/test/testfiles/twocolumn01.tlg
@@ -84,7 +84,7 @@ Completed box being shipped out [1]
 .......\kern -0.18753
 .......\kern 0.18753
 .......\glue 6.78735 minus 5.26968
-.......\penalty 0
+.......\penalty 10000
 .......\penalty 10000
 .......\glue(\parfillskip) 0.0 plus 1.0fil
 .......\glue(\rightskip) 0.0

--- a/ctex/test/testfiles/twocolumn01.tlg
+++ b/ctex/test/testfiles/twocolumn01.tlg
@@ -67,7 +67,7 @@ Completed box being shipped out [1]
 ......\glue(\parskip) 0.0 plus 1.0
 ......\glue(\parskip) 0.0
 ......\glue(\baselineskip) 5.81778
-......\hbox(8.19963+1.84438)x167.5, glue set 100.51178fil
+......\hbox(8.19963+1.84438)x167.5, glue set 93.72443fil
 .......\hbox(0.0+0.0)x21.07874
 .......\TU/FandolSong-Regular(0)/m/n/10.53937 左
 .......\glue 0.0 plus 0.60931
@@ -83,6 +83,8 @@ Completed box being shipped out [1]
 .......\kern -0.00041
 .......\kern -0.18753
 .......\kern 0.18753
+.......\glue 6.78735 minus 5.26968
+.......\penalty 0
 .......\penalty 10000
 .......\glue(\parfillskip) 0.0 plus 1.0fil
 .......\glue(\rightskip) 0.0

--- a/xeCJK/testfiles/basic01.tlg
+++ b/xeCJK/testfiles/basic01.tlg
@@ -16,7 +16,7 @@ Completed box being shipped out [1]
 ..\vbox(550.0+0.0)x345.0, glue set 539.94232fil
 ...\write-{}
 ...\glue(\topskip) 2.19
-...\hbox(7.81+1.92998)x345.0, glue set 136.44fil
+...\hbox(7.81+1.92998)x345.0, glue set 130.0fil
 ....\hbox(0.0+0.0)x15.0
 ....\TU/FandolSong-Regular.otf(0)/m/n/10 天
 ....\glue 0.0 plus 0.96002
@@ -40,6 +40,7 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\TU/FandolSong-Regular.otf(0)/m/n/10 。
 ....\rule(0.0+0.0)x-6.44
+....\penalty 0
 ....\glue 6.44 minus 5.0
 ....\glue 0.0 plus 0.96002
 ....\TU/FandolSong-Regular.otf(0)/m/n/10 日
@@ -68,6 +69,8 @@ Completed box being shipped out [1]
 ....\kern -0.0004
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.44 minus 5.0
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -100,7 +103,7 @@ Completed box being shipped out [2]
 ..\vbox(550.0+0.0)x345.0, glue set 539.94232fil
 ...\write-{}
 ...\glue(\topskip) 2.22
-...\hbox(7.78+2.05998)x345.0, glue set 154.52998fil
+...\hbox(7.78+2.05998)x345.0, glue set 148.08998fil
 ....\hbox(0.0+0.0)x15.0
 ....\TU/FandolSong-Regular.otf(0)/m/n/10 中
 ....\glue 0.0 plus 0.96002
@@ -118,6 +121,7 @@ Completed box being shipped out [2]
 ....\penalty 10000
 ....\TU/FandolSong-Regular.otf(0)/m/n/10 ，
 ....\rule(0.0+0.0)x-6.92
+....\penalty 0
 ....\glue 6.92 minus 5.0
 ....\glue 0.0 plus 0.96002
 ....\TU/FandolSong-Regular.otf(0)/m/n/10 这
@@ -136,6 +140,8 @@ Completed box being shipped out [2]
 ....\kern -0.0004
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.44 minus 5.0
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0

--- a/xeCJK/testfiles/basic01.tlg
+++ b/xeCJK/testfiles/basic01.tlg
@@ -40,7 +40,7 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\TU/FandolSong-Regular.otf(0)/m/n/10 。
 ....\rule(0.0+0.0)x-6.44
-....\penalty 0
+....\penalty 10000
 ....\glue 6.44 minus 5.0
 ....\glue 0.0 plus 0.96002
 ....\TU/FandolSong-Regular.otf(0)/m/n/10 日
@@ -70,7 +70,7 @@ Completed box being shipped out [1]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.44 minus 5.0
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -121,7 +121,7 @@ Completed box being shipped out [2]
 ....\penalty 10000
 ....\TU/FandolSong-Regular.otf(0)/m/n/10 ，
 ....\rule(0.0+0.0)x-6.92
-....\penalty 0
+....\penalty 10000
 ....\glue 6.92 minus 5.0
 ....\glue 0.0 plus 0.96002
 ....\TU/FandolSong-Regular.otf(0)/m/n/10 这
@@ -141,7 +141,7 @@ Completed box being shipped out [2]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.44 minus 5.0
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0

--- a/xeCJK/testfiles/checkfullright01.tlg
+++ b/xeCJK/testfiles/checkfullright01.tlg
@@ -41,7 +41,7 @@ Completed box being shipped out [1]
 ....\glue(\rightskip) 0.0
 ...\penalty 300
 ...\glue(\baselineskip) 2.82002
-...\hbox(7.68+1.77998)x100.0, glue set 56.44fil
+...\hbox(7.68+1.77998)x100.0, glue set 50.0fil
 ....\TU/FandolSong-Regular.otf(0)/m/n/10 测
 ....\glue 0.0 plus 0.96002
 ....\TU/FandolSong-Regular.otf(0)/m/n/10 试
@@ -56,6 +56,8 @@ Completed box being shipped out [1]
 ....\kern -0.0004
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.44 minus 5.0
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -115,7 +117,7 @@ Completed box being shipped out [2]
 ....\glue(\rightskip) 0.0
 ...\penalty 300
 ...\glue(\baselineskip) 2.80002
-...\hbox(7.5+1.24998)x100.0, glue set 16.44fil
+...\hbox(7.5+1.24998)x100.0, glue set 10.0fil
 ....\TU/FandolSong-Regular.otf(0)/m/n/10 一
 ....\glue 0.0 plus 0.96002
 ....\TU/FandolSong-Regular.otf(0)/m/n/10 二
@@ -138,6 +140,8 @@ Completed box being shipped out [2]
 ....\kern -0.0004
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.44 minus 5.0
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0

--- a/xeCJK/testfiles/checkfullright01.tlg
+++ b/xeCJK/testfiles/checkfullright01.tlg
@@ -57,7 +57,7 @@ Completed box being shipped out [1]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.44 minus 5.0
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -141,7 +141,7 @@ Completed box being shipped out [2]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.44 minus 5.0
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0

--- a/xeCJK/testfiles/checksingle01.tlg
+++ b/xeCJK/testfiles/checksingle01.tlg
@@ -35,10 +35,6 @@ Overfull \hbox (3.37247pt too wide) in paragraph at lines ...
 .\glue(\rightskip) 0.0
 Underfull \hbox (badness 10000) in paragraph at lines ...
 \hbox(0.0+0.0)x100.0
-.\penalty 0
-.\glue(\rightskip) 0.0
-Underfull \hbox (badness 10000) in paragraph at lines ...
-\hbox(0.0+0.0)x100.0
 .\glue(\rightskip) 0.0
 Completed box being shipped out [1]
 \vbox(633.0+0.0)x407.0
@@ -50,7 +46,7 @@ Completed box being shipped out [1]
 ....\hbox(0.0+0.0)x345.0
 ..\glue 25.0
 ..\glue(\lineskip) 0.0
-..\vbox(550.0+0.0)x100.0, glue set 503.94617fil
+..\vbox(550.0+0.0)x100.0, glue set 515.94489fil
 ...\write-{}
 ...\glue(\topskip) 2.25
 ...\hbox(7.75+1.52998)x100.0
@@ -105,12 +101,8 @@ Completed box being shipped out [1]
 ....\kern -0.18753
 ....\kern 0.0
 ....\glue(\rightskip) 0.0
-...\glue(\baselineskip) 10.47002
-...\hbox(0.0+0.0)x100.0
-....\penalty 0
-....\glue(\rightskip) 0.0
 ...\penalty 150
-...\glue(\baselineskip) 12.0
+...\glue(\baselineskip) 10.47002
 ...\hbox(0.0+0.0)x100.0
 ....\glue(\rightskip) 0.0
 ...\glue 0.0 plus 1.0fil
@@ -165,10 +157,6 @@ Overfull \hbox (3.37247pt too wide) in paragraph at lines ...
 .\glue(\rightskip) 0.0
 Underfull \hbox (badness 10000) in paragraph at lines ...
 \hbox(0.0+0.0)x100.0
-.\penalty 0
-.\glue(\rightskip) 0.0
-Underfull \hbox (badness 10000) in paragraph at lines ...
-\hbox(0.0+0.0)x100.0
 .\glue(\rightskip) 0.0
 LaTeX Font Info:    External font `cmex10' loaded for size
 (Font)              <7> on input line ....
@@ -206,10 +194,6 @@ Overfull \hbox (3.37247pt too wide) in paragraph at lines ...
 .\glue(\rightskip) 0.0
 Underfull \hbox (badness 10000) in paragraph at lines ...
 \hbox(0.0+0.0)x100.0
-.\penalty 0
-.\glue(\rightskip) 0.0
-Underfull \hbox (badness 10000) in paragraph at lines ...
-\hbox(0.0+0.0)x100.0
 .\glue(\rightskip) 0.0
 Completed box being shipped out [2]
 \vbox(633.0+0.0)x407.0
@@ -221,7 +205,7 @@ Completed box being shipped out [2]
 ....\hbox(0.0+0.0)x345.0
 ..\glue 25.0
 ..\glue(\lineskip) 0.0
-..\vbox(550.0+0.0)x100.0, glue set 437.95322fil
+..\vbox(550.0+0.0)x100.0, glue set 461.95065fil
 ...\write-{}
 ...\glue(\topskip) 2.25
 ...\hbox(7.75+1.52998)x100.0
@@ -281,12 +265,8 @@ Completed box being shipped out [2]
 ....\kern -0.18753
 ....\kern 0.0
 ....\glue(\rightskip) 0.0
-...\glue(\baselineskip) 10.47002
-...\hbox(0.0+0.0)x100.0
-....\penalty 0
-....\glue(\rightskip) 0.0
 ...\penalty 50
-...\glue(\baselineskip) 12.0
+...\glue(\baselineskip) 10.47002
 ...\hbox(0.0+0.0)x100.0
 ....\glue(\rightskip) 0.0
 ...\penalty 10000
@@ -357,12 +337,8 @@ Completed box being shipped out [2]
 ....\kern -0.18753
 ....\kern 0.0
 ....\glue(\rightskip) 0.0
-...\glue(\baselineskip) 10.47002
-...\hbox(0.0+0.0)x100.0
-....\penalty 0
-....\glue(\rightskip) 0.0
 ...\penalty 150
-...\glue(\baselineskip) 12.0
+...\glue(\baselineskip) 10.47002
 ...\hbox(0.0+0.0)x100.0
 ....\glue(\rightskip) 0.0
 ...\glue 0.0 plus 1.0fil
@@ -412,10 +388,6 @@ Overfull \hbox (3.37247pt too wide) in paragraph at lines ...
 .\glue(\rightskip) 0.0
 Underfull \hbox (badness 10000) in paragraph at lines ...
 \hbox(0.0+0.0)x100.0
-.\penalty 0
-.\glue(\rightskip) 0.0
-Underfull \hbox (badness 10000) in paragraph at lines ...
-\hbox(0.0+0.0)x100.0
 .\glue(\rightskip) 0.0
 Completed box being shipped out [3]
 \vbox(633.0+0.21999)x407.0
@@ -427,7 +399,7 @@ Completed box being shipped out [3]
 ....\hbox(0.0+0.0)x345.0
 ..\glue 25.0
 ..\glue(\lineskip) 0.0
-..\vbox(550.0+0.0)x100.0, glue set 503.94617fil
+..\vbox(550.0+0.0)x100.0, glue set 515.94489fil
 ...\write-{}
 ...\glue(\topskip) 2.25
 ...\hbox(7.75+1.52998)x100.0
@@ -482,12 +454,8 @@ Completed box being shipped out [3]
 ....\kern -0.18753
 ....\kern 0.0
 ....\glue(\rightskip) 0.0
-...\glue(\baselineskip) 10.47002
-...\hbox(0.0+0.0)x100.0
-....\penalty 0
-....\glue(\rightskip) 0.0
 ...\penalty 150
-...\glue(\baselineskip) 12.0
+...\glue(\baselineskip) 10.47002
 ...\hbox(0.0+0.0)x100.0
 ....\glue(\rightskip) 0.0
 ...\glue 0.0 plus 1.0fil

--- a/xeCJK/testfiles/checksingle01.tlg
+++ b/xeCJK/testfiles/checksingle01.tlg
@@ -3,8 +3,8 @@ Don't change this file in any respect.
 ============================================================
 TEST 1: CheckSingle prevents orphan CJK at paragraph end
 ============================================================
-Overfull \hbox (3.56pt too wide) in paragraph at lines ...
-\TU/FandolSong-Regular.otf(0)/m/n/10 一 二 三 四 五 六 七 八 九 十。| 
+Overfull \hbox (3.37247pt too wide) in paragraph at lines ...
+\TU/FandolSong-Regular.otf(0)/m/n/10 一 二 三 四 五 六 七 八 九 十。|
 \hbox(7.75+1.52998)x100.0
 .\TU/FandolSong-Regular.otf(0)/m/n/10 一
 .\glue 0.0 plus 0.96002
@@ -31,9 +31,14 @@ Overfull \hbox (3.56pt too wide) in paragraph at lines ...
 .\kern 0.0004
 .\kern -0.0004
 .\kern -0.18753
-.\kern 0.18753
-.\penalty 10000
-.\glue(\parfillskip) 0.0 plus 1.0fil
+.\kern 0.0
+.\glue(\rightskip) 0.0
+Underfull \hbox (badness 10000) in paragraph at lines ...
+\hbox(0.0+0.0)x100.0
+.\penalty 0
+.\glue(\rightskip) 0.0
+Underfull \hbox (badness 10000) in paragraph at lines ...
+\hbox(0.0+0.0)x100.0
 .\glue(\rightskip) 0.0
 Completed box being shipped out [1]
 \vbox(633.0+0.0)x407.0
@@ -45,7 +50,7 @@ Completed box being shipped out [1]
 ....\hbox(0.0+0.0)x345.0
 ..\glue 25.0
 ..\glue(\lineskip) 0.0
-..\vbox(550.0+0.0)x100.0, glue set 527.9436fil
+..\vbox(550.0+0.0)x100.0, glue set 503.94617fil
 ...\write-{}
 ...\glue(\topskip) 2.25
 ...\hbox(7.75+1.52998)x100.0
@@ -70,7 +75,7 @@ Completed box being shipped out [1]
 ....\glue 0.0 plus 0.96002
 ....\TU/FandolSong-Regular.otf(0)/m/n/10 十
 ....\glue(\rightskip) 0.0
-...\penalty 300
+...\penalty 150
 ...\glue(\baselineskip) 2.72002
 ...\hbox(7.75+1.52998)x100.0
 ....\TU/FandolSong-Regular.otf(0)/m/n/10 一
@@ -98,11 +103,16 @@ Completed box being shipped out [1]
 ....\kern 0.0004
 ....\kern -0.0004
 ....\kern -0.18753
-....\kern 0.18753
-....\penalty 10000
-....\glue(\parfillskip) 0.0 plus 1.0fil
+....\kern 0.0
 ....\glue(\rightskip) 0.0
-...\glue -1.52998
+...\glue(\baselineskip) 10.47002
+...\hbox(0.0+0.0)x100.0
+....\penalty 0
+....\glue(\rightskip) 0.0
+...\penalty 150
+...\glue(\baselineskip) 12.0
+...\hbox(0.0+0.0)x100.0
+....\glue(\rightskip) 0.0
 ...\glue 0.0 plus 1.0fil
 ...\glue 0.0
 ...\glue 0.0 plus 0.0001fil
@@ -118,8 +128,8 @@ Completed box being shipped out [1]
 ============================================================
 TEST 2: CheckSingle with equation
 ============================================================
-Overfull \hbox (3.56pt too wide) in paragraph at lines ...
-\TU/FandolSong-Regular.otf(0)/m/n/10 一 二 三 四 五 六 七 八 九 十。| 
+Overfull \hbox (3.37247pt too wide) in paragraph at lines ...
+\TU/FandolSong-Regular.otf(0)/m/n/10 一 二 三 四 五 六 七 八 九 十。|
 \hbox(7.75+1.52998)x100.0
 .\TU/FandolSong-Regular.otf(0)/m/n/10 一
 .\glue 0.0 plus 0.96002
@@ -151,16 +161,21 @@ Overfull \hbox (3.56pt too wide) in paragraph at lines ...
 .\kern 0.0004
 .\kern -0.0004
 .\kern -0.18753
-.\kern 0.18753
-.\penalty 10000
-.\glue(\parfillskip) 0.0 plus 1.0fil
+.\kern 0.0
+.\glue(\rightskip) 0.0
+Underfull \hbox (badness 10000) in paragraph at lines ...
+\hbox(0.0+0.0)x100.0
+.\penalty 0
+.\glue(\rightskip) 0.0
+Underfull \hbox (badness 10000) in paragraph at lines ...
+\hbox(0.0+0.0)x100.0
 .\glue(\rightskip) 0.0
 LaTeX Font Info:    External font `cmex10' loaded for size
 (Font)              <7> on input line ....
 LaTeX Font Info:    External font `cmex10' loaded for size
 (Font)              <5> on input line ....
-Overfull \hbox (3.56pt too wide) in paragraph at lines ...
-\TU/FandolSong-Regular.otf(0)/m/n/10 一 二 三 四 五 六 七 八 九 十。| 
+Overfull \hbox (3.37247pt too wide) in paragraph at lines ...
+\TU/FandolSong-Regular.otf(0)/m/n/10 一 二 三 四 五 六 七 八 九 十。|
 \hbox(7.75+1.52998)x100.0
 .\TU/FandolSong-Regular.otf(0)/m/n/10 一
 .\glue 0.0 plus 0.96002
@@ -187,9 +202,14 @@ Overfull \hbox (3.56pt too wide) in paragraph at lines ...
 .\kern 0.0004
 .\kern -0.0004
 .\kern -0.18753
-.\kern 0.18753
-.\penalty 10000
-.\glue(\parfillskip) 0.0 plus 1.0fil
+.\kern 0.0
+.\glue(\rightskip) 0.0
+Underfull \hbox (badness 10000) in paragraph at lines ...
+\hbox(0.0+0.0)x100.0
+.\penalty 0
+.\glue(\rightskip) 0.0
+Underfull \hbox (badness 10000) in paragraph at lines ...
+\hbox(0.0+0.0)x100.0
 .\glue(\rightskip) 0.0
 Completed box being shipped out [2]
 \vbox(633.0+0.0)x407.0
@@ -201,7 +221,7 @@ Completed box being shipped out [2]
 ....\hbox(0.0+0.0)x345.0
 ..\glue 25.0
 ..\glue(\lineskip) 0.0
-..\vbox(550.0+0.0)x100.0, glue set 471.94958fil
+..\vbox(550.0+0.0)x100.0, glue set 437.95322fil
 ...\write-{}
 ...\glue(\topskip) 2.25
 ...\hbox(7.75+1.52998)x100.0
@@ -226,7 +246,7 @@ Completed box being shipped out [2]
 ....\glue 0.0 plus 0.96002
 ....\TU/FandolSong-Regular.otf(0)/m/n/10 十
 ....\glue(\rightskip) 0.0
-...\penalty 200
+...\penalty 150
 ...\glue(\baselineskip) 2.72002
 ...\hbox(7.75+1.52998)x100.0
 ....\TU/FandolSong-Regular.otf(0)/m/n/10 一
@@ -259,13 +279,19 @@ Completed box being shipped out [2]
 ....\kern 0.0004
 ....\kern -0.0004
 ....\kern -0.18753
-....\kern 0.18753
-....\penalty 10000
-....\glue(\parfillskip) 0.0 plus 1.0fil
+....\kern 0.0
+....\glue(\rightskip) 0.0
+...\glue(\baselineskip) 10.47002
+...\hbox(0.0+0.0)x100.0
+....\penalty 0
+....\glue(\rightskip) 0.0
+...\penalty 50
+...\glue(\baselineskip) 12.0
+...\hbox(0.0+0.0)x100.0
 ....\glue(\rightskip) 0.0
 ...\penalty 10000
-...\glue(\abovedisplayskip) 10.0 plus 2.0 minus 5.0
-...\glue(\baselineskip) 1.82999
+...\glue(\abovedisplayshortskip) 0.0 plus 3.0
+...\glue(\baselineskip) 3.35997
 ...\hbox(8.64003+1.94444)x32.17126, shifted 33.91437, display
 ....\OML/cmm/m/it/10 x
 ....\hbox(4.51111+0.0)x4.48613, shifted -4.12892
@@ -278,7 +304,7 @@ Completed box being shipped out [2]
 ....\hbox(4.51111+0.0)x4.48613, shifted -4.12892
 .....\OT1/cmr/m/n/7 2
 ...\penalty 0
-...\glue(\belowdisplayskip) 10.0 plus 2.0 minus 5.0
+...\glue(\belowdisplayshortskip) 6.0 plus 3.0 minus 3.0
 ...\glue(\baselineskip) 2.30556
 ...\hbox(7.75+1.52998)x100.0
 ....\TU/FandolSong-Regular.otf(0)/m/n/10 一
@@ -301,7 +327,7 @@ Completed box being shipped out [2]
 ....\glue 0.0 plus 0.96002
 ....\TU/FandolSong-Regular.otf(0)/m/n/10 十
 ....\glue(\rightskip) 0.0
-...\penalty 300
+...\penalty 150
 ...\glue(\baselineskip) 2.72002
 ...\hbox(7.75+1.52998)x100.0
 ....\TU/FandolSong-Regular.otf(0)/m/n/10 一
@@ -329,11 +355,16 @@ Completed box being shipped out [2]
 ....\kern 0.0004
 ....\kern -0.0004
 ....\kern -0.18753
-....\kern 0.18753
-....\penalty 10000
-....\glue(\parfillskip) 0.0 plus 1.0fil
+....\kern 0.0
 ....\glue(\rightskip) 0.0
-...\glue -1.52998
+...\glue(\baselineskip) 10.47002
+...\hbox(0.0+0.0)x100.0
+....\penalty 0
+....\glue(\rightskip) 0.0
+...\penalty 150
+...\glue(\baselineskip) 12.0
+...\hbox(0.0+0.0)x100.0
+....\glue(\rightskip) 0.0
 ...\glue 0.0 plus 1.0fil
 ...\glue 0.0
 ...\glue 0.0 plus 0.0001fil
@@ -349,8 +380,8 @@ Completed box being shipped out [2]
 ============================================================
 TEST 3: WidowPenalty setting
 ============================================================
-Overfull \hbox (3.56pt too wide) in paragraph at lines ...
-\TU/FandolSong-Regular.otf(0)/m/n/10 一 二 三 四 五 六 七 八 九 十。| 
+Overfull \hbox (3.37247pt too wide) in paragraph at lines ...
+\TU/FandolSong-Regular.otf(0)/m/n/10 一 二 三 四 五 六 七 八 九 十。|
 \hbox(7.75+1.52998)x100.0
 .\TU/FandolSong-Regular.otf(0)/m/n/10 一
 .\glue 0.0 plus 0.96002
@@ -377,9 +408,14 @@ Overfull \hbox (3.56pt too wide) in paragraph at lines ...
 .\kern 0.0004
 .\kern -0.0004
 .\kern -0.18753
-.\kern 0.18753
-.\penalty 10000
-.\glue(\parfillskip) 0.0 plus 1.0fil
+.\kern 0.0
+.\glue(\rightskip) 0.0
+Underfull \hbox (badness 10000) in paragraph at lines ...
+\hbox(0.0+0.0)x100.0
+.\penalty 0
+.\glue(\rightskip) 0.0
+Underfull \hbox (badness 10000) in paragraph at lines ...
+\hbox(0.0+0.0)x100.0
 .\glue(\rightskip) 0.0
 Completed box being shipped out [3]
 \vbox(633.0+0.21999)x407.0
@@ -391,7 +427,7 @@ Completed box being shipped out [3]
 ....\hbox(0.0+0.0)x345.0
 ..\glue 25.0
 ..\glue(\lineskip) 0.0
-..\vbox(550.0+0.0)x100.0, glue set 527.9436fil
+..\vbox(550.0+0.0)x100.0, glue set 503.94617fil
 ...\write-{}
 ...\glue(\topskip) 2.25
 ...\hbox(7.75+1.52998)x100.0
@@ -416,7 +452,7 @@ Completed box being shipped out [3]
 ....\glue 0.0 plus 0.96002
 ....\TU/FandolSong-Regular.otf(0)/m/n/10 十
 ....\glue(\rightskip) 0.0
-...\penalty 300
+...\penalty 150
 ...\glue(\baselineskip) 2.72002
 ...\hbox(7.75+1.52998)x100.0
 ....\TU/FandolSong-Regular.otf(0)/m/n/10 一
@@ -444,11 +480,16 @@ Completed box being shipped out [3]
 ....\kern 0.0004
 ....\kern -0.0004
 ....\kern -0.18753
-....\kern 0.18753
-....\penalty 10000
-....\glue(\parfillskip) 0.0 plus 1.0fil
+....\kern 0.0
 ....\glue(\rightskip) 0.0
-...\glue -1.52998
+...\glue(\baselineskip) 10.47002
+...\hbox(0.0+0.0)x100.0
+....\penalty 0
+....\glue(\rightskip) 0.0
+...\penalty 150
+...\glue(\baselineskip) 12.0
+...\hbox(0.0+0.0)x100.0
+....\glue(\rightskip) 0.0
 ...\glue 0.0 plus 1.0fil
 ...\glue 0.0
 ...\glue 0.0 plus 0.0001fil

--- a/xeCJK/testfiles/custompunctstyle01.tlg
+++ b/xeCJK/testfiles/custompunctstyle01.tlg
@@ -16,7 +16,7 @@ Completed box being shipped out [1]
 ..\vbox(550.0+0.0)x345.0, glue set 539.94232fil
 ...\write-{}
 ...\glue(\topskip) 1.98
-...\hbox(8.02+1.92998)x345.0, glue set 31.45001fil
+...\hbox(8.02+1.92998)x345.0, glue set 30.01001fil
 ....\hbox(0.0+0.0)x15.0
 ....\TU/FandolSong-Regular.otf(0)/m/n/10 标
 ....\glue 0.0 plus 0.96002
@@ -64,7 +64,7 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\TU/FandolSong-Regular.otf(0)/m/n/10 。
 ....\rule(0.0+0.0)x-6.44
-....\penalty 10000
+....\penalty 0
 ....\glue 2.36 plus 0.01001 minus 0.92
 ....\rule(0.0+0.0)x-5.92
 ....\TU/FandolSong-Regular.otf(0)/m/n/10 「标
@@ -116,6 +116,8 @@ Completed box being shipped out [1]
 ....\kern -0.0004
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 1.44 plus 5.0
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -196,7 +198,7 @@ Completed box being shipped out [2]
 ....\penalty 10000
 ....\TU/FandolSong-Regular.otf(0)/m/n/10 。
 ....\rule(0.0+0.0)x-6.44
-....\penalty 10000
+....\penalty 0
 ....\glue 12.36 minus 10.92
 ....\rule(0.0+0.0)x-5.92
 ....\TU/FandolSong-Regular.otf(0)/m/n/10 「标
@@ -239,7 +241,7 @@ Completed box being shipped out [2]
 ....\glue(\rightskip) 0.0
 ...\penalty 300
 ...\glue(\baselineskip) 2.26003
-...\hbox(7.81+1.64998)x345.0, glue set 321.44fil
+...\hbox(7.81+1.64998)x345.0, glue set 315.0fil
 ....\TU/FandolSong-Regular.otf(0)/m/n/10 点
 ....\penalty 10000
 ....\TU/FandolSong-Regular.otf(0)/m/n/10 〉
@@ -251,6 +253,8 @@ Completed box being shipped out [2]
 ....\kern -0.0004
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.44 minus 5.0
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0

--- a/xeCJK/testfiles/custompunctstyle01.tlg
+++ b/xeCJK/testfiles/custompunctstyle01.tlg
@@ -64,7 +64,7 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\TU/FandolSong-Regular.otf(0)/m/n/10 。
 ....\rule(0.0+0.0)x-6.44
-....\penalty 0
+....\penalty 10000
 ....\glue 2.36 plus 0.01001 minus 0.92
 ....\rule(0.0+0.0)x-5.92
 ....\TU/FandolSong-Regular.otf(0)/m/n/10 「标
@@ -117,7 +117,7 @@ Completed box being shipped out [1]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 1.44 plus 5.0
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -198,7 +198,7 @@ Completed box being shipped out [2]
 ....\penalty 10000
 ....\TU/FandolSong-Regular.otf(0)/m/n/10 。
 ....\rule(0.0+0.0)x-6.44
-....\penalty 0
+....\penalty 10000
 ....\glue 12.36 minus 10.92
 ....\rule(0.0+0.0)x-5.92
 ....\TU/FandolSong-Regular.otf(0)/m/n/10 「标
@@ -254,7 +254,7 @@ Completed box being shipped out [2]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.44 minus 5.0
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0

--- a/xeCJK/testfiles/ellipsis01.tlg
+++ b/xeCJK/testfiles/ellipsis01.tlg
@@ -48,7 +48,7 @@ Completed box being shipped out [1]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.44 minus 5.0
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0

--- a/xeCJK/testfiles/ellipsis01.tlg
+++ b/xeCJK/testfiles/ellipsis01.tlg
@@ -16,7 +16,7 @@ Completed box being shipped out [1]
 ..\vbox(550.0+0.0)x345.0, glue set 539.94232fil
 ...\write-{}
 ...\glue(\topskip) 2.19
-...\hbox(7.81+1.87999)x345.0, glue set 226.44fil
+...\hbox(7.81+1.87999)x345.0, glue set 220.0fil
 ....\hbox(0.0+0.0)x15.0
 ....\TU/FandolSong-Regular.otf(0)/m/n/10 天
 ....\glue 0.0 plus 0.96002
@@ -47,6 +47,8 @@ Completed box being shipped out [1]
 ....\kern -0.0004
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.44 minus 5.0
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0

--- a/xeCJK/testfiles/environ01.tlg
+++ b/xeCJK/testfiles/environ01.tlg
@@ -65,7 +65,7 @@ Overfull \hbox (15.0pt too wide) in paragraph at lines ...
 ...\kern -0.18753
 ...\kern 0.18753
 ...\glue 6.44 minus 5.0
-...\penalty 0
+...\penalty 10000
 ...\penalty 10000
 ...\glue(\parfillskip) 0.0 plus 1.0fil
 ...\glue(\rightskip) 0.0

--- a/xeCJK/testfiles/environ01.tlg
+++ b/xeCJK/testfiles/environ01.tlg
@@ -55,7 +55,7 @@ Overfull \hbox (15.0pt too wide) in paragraph at lines ...
 ...\glue(\rightskip) 0.0
 ..\penalty 300
 ..\glue(\baselineskip) 2.56001
-..\hbox(7.69+1.74998)x200.0, glue set 186.44fil
+..\hbox(7.69+1.74998)x200.0, glue set 180.0fil
 ...\TU/FandolSong-Regular.otf(0)/m/n/10 字
 ...\penalty 10000
 ...\TU/FandolSong-Regular.otf(0)/m/n/10 。
@@ -64,6 +64,8 @@ Overfull \hbox (15.0pt too wide) in paragraph at lines ...
 ...\kern -0.0004
 ...\kern -0.18753
 ...\kern 0.18753
+...\glue 6.44 minus 5.0
+...\penalty 0
 ...\penalty 10000
 ...\glue(\parfillskip) 0.0 plus 1.0fil
 ...\glue(\rightskip) 0.0

--- a/xeCJK/testfiles/fonts01.tlg
+++ b/xeCJK/testfiles/fonts01.tlg
@@ -45,7 +45,7 @@ Completed box being shipped out [1]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.44 minus 5.0
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -115,7 +115,7 @@ Completed box being shipped out [2]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.44 minus 5.0
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -185,7 +185,7 @@ Completed box being shipped out [3]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.44 minus 5.0
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0

--- a/xeCJK/testfiles/fonts01.tlg
+++ b/xeCJK/testfiles/fonts01.tlg
@@ -16,7 +16,7 @@ Completed box being shipped out [1]
 ..\vbox(550.0+0.0)x345.0, glue set 539.94232fil
 ...\write-{}
 ...\glue(\topskip) 2.19
-...\hbox(7.81+1.92998)x345.0, glue set 236.44fil
+...\hbox(7.81+1.92998)x345.0, glue set 230.0fil
 ....\hbox(0.0+0.0)x15.0
 ....\TU/FandolSong-Regular.otf(0)/m/n/10 天
 ....\glue 0.0 plus 0.96002
@@ -44,6 +44,8 @@ Completed box being shipped out [1]
 ....\kern -0.0004
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.44 minus 5.0
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -84,7 +86,7 @@ Completed box being shipped out [2]
 ..\vbox(550.0+0.0)x345.0, glue set 539.94232fil
 ...\write-{}
 ...\glue(\topskip) 2.23
-...\hbox(7.77+1.84999)x345.0, glue set 236.44fil
+...\hbox(7.77+1.84999)x345.0, glue set 230.0fil
 ....\hbox(0.0+0.0)x15.0
 ....\TU/FandolHei-Regular.otf(0)/m/n/10 寒
 ....\glue 0.0 plus 0.96002
@@ -112,6 +114,8 @@ Completed box being shipped out [2]
 ....\kern -0.0004
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.44 minus 5.0
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -152,7 +156,7 @@ Completed box being shipped out [3]
 ..\vbox(550.0+0.0)x345.0, glue set 539.94232fil
 ...\write-{}
 ...\glue(\topskip) 2.26
-...\hbox(7.74+1.91998)x345.0, glue set 236.44fil
+...\hbox(7.74+1.91998)x345.0, glue set 230.0fil
 ....\hbox(0.0+0.0)x15.0
 ....\TU/FandolKai-Regular.otf(0)/m/n/10 云
 ....\glue 0.0 plus 0.96002
@@ -180,6 +184,8 @@ Completed box being shipped out [3]
 ....\kern -0.0004
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.44 minus 5.0
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0

--- a/xeCJK/testfiles/kaimingpunct01.tlg
+++ b/xeCJK/testfiles/kaimingpunct01.tlg
@@ -16,7 +16,7 @@ Completed box being shipped out [1]
 ..\vbox(550.0+0.0)x345.0, glue set 539.94232fil
 ...\write-{}
 ...\glue(\topskip) 2.19
-...\hbox(7.81+1.92998)x345.0, glue set 174.1fil
+...\hbox(7.81+1.92998)x345.0, glue set 168.0fil
 ....\hbox(0.0+0.0)x15.0
 ....\TU/FandolSong-Regular.otf(0)/m/n/10 标
 ....\glue 0.0 plus 0.96002
@@ -68,6 +68,8 @@ Completed box being shipped out [1]
 ....\kern -0.00049
 ....\kern -0.9963
 ....\kern 0.9963
+....\glue 6.1 plus 2.0 minus 5.25
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -100,7 +102,7 @@ Completed box being shipped out [2]
 ..\vbox(550.0+0.0)x345.0, glue set 539.94232fil
 ...\write-{}
 ...\glue(\topskip) 2.19
-...\hbox(7.81+1.92998)x345.0, glue set 174.1fil
+...\hbox(7.81+1.92998)x345.0, glue set 168.0fil
 ....\hbox(0.0+0.0)x15.0
 ....\TU/FandolSong-Regular.otf(0)/m/n/10 标
 ....\glue 0.0 plus 0.96002
@@ -152,6 +154,8 @@ Completed box being shipped out [2]
 ....\kern -0.00049
 ....\kern -0.9963
 ....\kern 0.9963
+....\glue 6.1 plus 2.0 minus 5.25
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0

--- a/xeCJK/testfiles/kaimingpunct01.tlg
+++ b/xeCJK/testfiles/kaimingpunct01.tlg
@@ -69,7 +69,7 @@ Completed box being shipped out [1]
 ....\kern -0.9963
 ....\kern 0.9963
 ....\glue 6.1 plus 2.0 minus 5.25
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -155,7 +155,7 @@ Completed box being shipped out [2]
 ....\kern -0.9963
 ....\kern 0.9963
 ....\glue 6.1 plus 2.0 minus 5.25
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0

--- a/xeCJK/testfiles/nobreak01.tlg
+++ b/xeCJK/testfiles/nobreak01.tlg
@@ -3,9 +3,9 @@ Don't change this file in any respect.
 ============================================================
 TEST 1: xeCJKnobreak prevents break after punct
 ============================================================
-Overfull \hbox (20.0pt too wide) in paragraph at lines ...
-[]\TU/FandolSong-Regular.otf(0)/m/n/10 字 字 字 字 字，|  不
-\hbox(7.69+1.92998)x60.0, glue set - 1.0
+Overfull \hbox (7.08372pt too wide) in paragraph at lines ...
+[]\TU/FandolSong-Regular.otf(0)/m/n/10 字 字 字 字 字，|
+\hbox(7.69+1.92998)x60.0
 .\hbox(0.0+0.0)x15.0
 .\TU/FandolSong-Regular.otf(0)/m/n/10 字
 .\glue 0.0 plus 0.96002
@@ -19,10 +19,10 @@ Overfull \hbox (20.0pt too wide) in paragraph at lines ...
 .\penalty 10000
 .\TU/FandolSong-Regular.otf(0)/m/n/10 ，
 .\rule(0.0+0.0)x-6.92
-.\penalty 10000
-.\glue 6.92 minus 5.0
-.\glue 0.0 plus 0.96002
-.\TU/FandolSong-Regular.otf(0)/m/n/10 不
+.\kern 0.00043
+.\kern -0.00043
+.\kern -0.99628
+.\kern 0.0
 .\glue(\rightskip) 0.0
 Completed box being shipped out [1]
 \vbox(633.0+0.0)x407.0
@@ -37,7 +37,7 @@ Completed box being shipped out [1]
 ..\vbox(550.0+0.0)x60.0, glue set 515.94489fil
 ...\write-{}
 ...\glue(\topskip) 2.31
-...\hbox(7.69+1.92998)x60.0, glue set - 1.0
+...\hbox(7.69+1.92998)x60.0
 ....\hbox(0.0+0.0)x15.0
 ....\TU/FandolSong-Regular.otf(0)/m/n/10 字
 ....\glue 0.0 plus 0.96002
@@ -51,14 +51,16 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\TU/FandolSong-Regular.otf(0)/m/n/10 ，
 ....\rule(0.0+0.0)x-6.92
-....\penalty 10000
-....\glue 6.92 minus 5.0
-....\glue 0.0 plus 0.96002
-....\TU/FandolSong-Regular.otf(0)/m/n/10 不
+....\kern 0.00043
+....\kern -0.00043
+....\kern -0.99628
+....\kern 0.0
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 2.24002
 ...\hbox(7.83+1.83998)x60.0
+....\TU/FandolSong-Regular.otf(0)/m/n/10 不
+....\glue 0.0 plus 0.96002
 ....\TU/FandolSong-Regular.otf(0)/m/n/10 断
 ....\glue 0.0 plus 0.96002
 ....\TU/FandolSong-Regular.otf(0)/m/n/10 行
@@ -70,12 +72,12 @@ Completed box being shipped out [1]
 ....\TU/FandolSong-Regular.otf(0)/m/n/10 字
 ....\glue 0.0 plus 0.96002
 ....\TU/FandolSong-Regular.otf(0)/m/n/10 字
-....\glue 0.0 plus 0.96002
-....\TU/FandolSong-Regular.otf(0)/m/n/10 字
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 2.47002
-...\hbox(7.69+1.74998)x60.0, glue set 10.0fil
+...\hbox(7.69+1.74998)x60.0
+....\TU/FandolSong-Regular.otf(0)/m/n/10 字
+....\glue 0.0 plus 0.96002
 ....\TU/FandolSong-Regular.otf(0)/m/n/10 字
 ....\glue 0.0 plus 0.96002
 ....\TU/FandolSong-Regular.otf(0)/m/n/10 字

--- a/xeCJK/testfiles/paragraph01.tlg
+++ b/xeCJK/testfiles/paragraph01.tlg
@@ -235,7 +235,7 @@ Completed box being shipped out [2]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.44 minus 5.0
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0

--- a/xeCJK/testfiles/paragraph01.tlg
+++ b/xeCJK/testfiles/paragraph01.tlg
@@ -217,7 +217,7 @@ Completed box being shipped out [2]
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 2.34001
-...\hbox(7.78+1.82999)x120.0, glue set 48.11fil
+...\hbox(7.78+1.82999)x120.0, glue set 41.67fil
 ....\TU/lmr/m/n/10 12345
 ....\glue 3.33 plus 1.665 minus 1.11
 ....\TU/FandolSong-Regular.otf(0)/m/n/10 穿
@@ -234,6 +234,8 @@ Completed box being shipped out [2]
 ....\kern -0.0004
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.44 minus 5.0
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0

--- a/xeCJK/testfiles/punct-parwidth01.tlg
+++ b/xeCJK/testfiles/punct-parwidth01.tlg
@@ -1,0 +1,16 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+============================================================
+TEST 1: paragraph natural width matches hbox for trailing right punct
+============================================================
+30.0pt
+30.0pt
+PASS
+============================================================
+============================================================
+TEST 2: raggedleft paragraph natural width matches hbox for trailing right punct
+============================================================
+30.0pt
+30.0pt
+PASS
+============================================================

--- a/xeCJK/testfiles/punctbreak01.tlg
+++ b/xeCJK/testfiles/punctbreak01.tlg
@@ -63,7 +63,7 @@ Completed box being shipped out [1]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.44 minus 5.0
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -144,7 +144,7 @@ Completed box being shipped out [2]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.44 minus 5.0
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0

--- a/xeCJK/testfiles/punctbreak01.tlg
+++ b/xeCJK/testfiles/punctbreak01.tlg
@@ -16,7 +16,7 @@ Completed box being shipped out [1]
 ..\vbox(550.0+0.0)x345.0, glue set 539.94232fil
 ...\write-{}
 ...\glue(\topskip) 1.98
-...\hbox(8.02+1.92998)x345.0, glue set 176.44fil
+...\hbox(8.02+1.92998)x345.0, glue set 170.0fil
 ....\hbox(0.0+0.0)x15.0
 ....\TU/FandolSong-Regular.otf(0)/m/n/10 标
 ....\glue 0.0 plus 0.96002
@@ -62,6 +62,8 @@ Completed box being shipped out [1]
 ....\kern -0.0004
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.44 minus 5.0
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -94,7 +96,7 @@ Completed box being shipped out [2]
 ..\vbox(550.0+0.0)x345.0, glue set 539.94232fil
 ...\write-{}
 ...\glue(\topskip) 1.98
-...\hbox(8.02+1.92998)x345.0, glue set 176.44fil
+...\hbox(8.02+1.92998)x345.0, glue set 170.0fil
 ....\hbox(0.0+0.0)x15.0
 ....\TU/FandolSong-Regular.otf(0)/m/n/10 标
 ....\glue 0.0 plus 0.96002
@@ -141,6 +143,8 @@ Completed box being shipped out [2]
 ....\kern -0.0004
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.44 minus 5.0
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0

--- a/xeCJK/testfiles/punctstyle01.tlg
+++ b/xeCJK/testfiles/punctstyle01.tlg
@@ -106,7 +106,7 @@ Completed box being shipped out [1]
 ....\glue(\rightskip) 0.0
 ...\penalty 300
 ...\glue(\baselineskip) 2.05002
-...\hbox(8.02+1.92998)x345.0, glue set 105.46fil
+...\hbox(8.02+1.92998)x345.0, glue set 100.0fil
 ....\TU/FandolSong-Regular.otf(0)/m/n/10 点
 ....\penalty 10000
 ....\TU/FandolSong-Regular.otf(0)/m/n/10 』
@@ -178,6 +178,8 @@ Completed box being shipped out [1]
 ....\kern -0.00034
 ....\kern -0.18767
 ....\kern 0.18767
+....\glue 5.46 minus 5.0
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -313,7 +315,7 @@ Completed box being shipped out [2]
 ....\glue(\rightskip) 0.0
 ...\penalty 300
 ...\glue(\baselineskip) 2.05002
-...\hbox(8.02+1.92998)x345.0, glue set 175.47002fil
+...\hbox(8.02+1.92998)x345.0, glue set 175.01001fil
 ....\TU/FandolSong-Regular.otf(0)/m/n/10 点
 ....\penalty 10000
 ....\TU/FandolSong-Regular.otf(0)/m/n/10 》
@@ -372,6 +374,8 @@ Completed box being shipped out [2]
 ....\kern -0.00034
 ....\kern -0.18767
 ....\kern 0.18767
+....\glue 0.46 plus 5.0
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -507,7 +511,7 @@ Completed box being shipped out [3]
 ....\glue(\rightskip) 0.0
 ...\penalty 300
 ...\glue(\baselineskip) 2.05002
-...\hbox(8.02+1.92998)x345.0, glue set 176.59001fil
+...\hbox(8.02+1.92998)x345.0, glue set 176.13fil
 ....\TU/FandolSong-Regular.otf(0)/m/n/10 点
 ....\penalty 10000
 ....\TU/FandolSong-Regular.otf(0)/m/n/10 》
@@ -566,6 +570,8 @@ Completed box being shipped out [3]
 ....\kern -0.00034
 ....\kern -0.18767
 ....\kern 0.18767
+....\glue 0.46 plus 5.0
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0

--- a/xeCJK/testfiles/punctstyle01.tlg
+++ b/xeCJK/testfiles/punctstyle01.tlg
@@ -179,7 +179,7 @@ Completed box being shipped out [1]
 ....\kern -0.18767
 ....\kern 0.18767
 ....\glue 5.46 minus 5.0
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -375,7 +375,7 @@ Completed box being shipped out [2]
 ....\kern -0.18767
 ....\kern 0.18767
 ....\glue 0.46 plus 5.0
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -571,7 +571,7 @@ Completed box being shipped out [3]
 ....\kern -0.18767
 ....\kern 0.18767
 ....\glue 0.46 plus 5.0
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0

--- a/xeCJK/testfiles/punctstyle02.tlg
+++ b/xeCJK/testfiles/punctstyle02.tlg
@@ -106,7 +106,7 @@ Completed box being shipped out [1]
 ....\glue(\rightskip) 0.0
 ...\penalty 300
 ...\glue(\baselineskip) 2.05002
-...\hbox(8.02+1.92998)x345.0, glue set 40.46fil
+...\hbox(8.02+1.92998)x345.0, glue set 35.0fil
 ....\TU/FandolSong-Regular.otf(0)/m/n/10 点
 ....\penalty 10000
 ....\TU/FandolSong-Regular.otf(0)/m/n/10 』
@@ -178,6 +178,8 @@ Completed box being shipped out [1]
 ....\kern -0.00034
 ....\kern -0.18767
 ....\kern 0.18767
+....\glue 5.46 minus 5.0
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -313,7 +315,7 @@ Completed box being shipped out [2]
 ....\glue(\rightskip) 0.0
 ...\penalty 300
 ...\glue(\baselineskip) 2.05002
-...\hbox(8.02+1.92998)x345.0, glue set 165.46fil
+...\hbox(8.02+1.92998)x345.0, glue set 163.0fil
 ....\TU/FandolSong-Regular.otf(0)/m/n/10 点
 ....\penalty 10000
 ....\TU/FandolSong-Regular.otf(0)/m/n/10 》
@@ -372,6 +374,8 @@ Completed box being shipped out [2]
 ....\kern -0.00034
 ....\kern -0.18767
 ....\kern 0.18767
+....\glue 2.46 plus 3.0 minus 2.0
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -656,6 +660,8 @@ Completed box being shipped out [3]
 ....\kern 0.0
 ....\kern -0.18767
 ....\kern 0.18767
+....\glue 0.0
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0

--- a/xeCJK/testfiles/punctstyle02.tlg
+++ b/xeCJK/testfiles/punctstyle02.tlg
@@ -179,7 +179,7 @@ Completed box being shipped out [1]
 ....\kern -0.18767
 ....\kern 0.18767
 ....\glue 5.46 minus 5.0
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -375,7 +375,7 @@ Completed box being shipped out [2]
 ....\kern -0.18767
 ....\kern 0.18767
 ....\glue 2.46 plus 3.0 minus 2.0
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -661,7 +661,7 @@ Completed box being shipped out [3]
 ....\kern -0.18767
 ....\kern 0.18767
 ....\glue 0.0
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0

--- a/xeCJK/testfiles/rubberpunct01.tlg
+++ b/xeCJK/testfiles/rubberpunct01.tlg
@@ -79,7 +79,7 @@ Completed box being shipped out [1]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.44 minus 5.0
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -175,7 +175,7 @@ Completed box being shipped out [2]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.44
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -271,7 +271,7 @@ Completed box being shipped out [3]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.44
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -367,7 +367,7 @@ Completed box being shipped out [4]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 6.44 minus 5.0
-....\penalty 0
+....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0

--- a/xeCJK/testfiles/rubberpunct01.tlg
+++ b/xeCJK/testfiles/rubberpunct01.tlg
@@ -16,7 +16,7 @@ Completed box being shipped out [1]
 ..\vbox(550.0+0.0)x345.0, glue set 539.94232fil
 ...\write-{}
 ...\glue(\topskip) 2.25
-...\hbox(7.75+1.92998)x345.0, glue set 91.44fil
+...\hbox(7.75+1.92998)x345.0, glue set 85.0fil
 ....\hbox(0.0+0.0)x0.0
 ....\TU/FandolSong-Regular.otf(0)/m/n/10 一
 ....\glue 0.0 plus 0.96002
@@ -78,6 +78,8 @@ Completed box being shipped out [1]
 ....\kern -0.0004
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.44 minus 5.0
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -110,7 +112,7 @@ Completed box being shipped out [2]
 ..\vbox(550.0+0.0)x345.0, glue set 539.94232fil
 ...\write-{}
 ...\glue(\topskip) 2.25
-...\hbox(7.75+1.92998)x345.0, glue set 91.44fil
+...\hbox(7.75+1.92998)x345.0, glue set 85.0fil
 ....\hbox(0.0+0.0)x0.0
 ....\TU/FandolSong-Regular.otf(0)/m/n/10 一
 ....\glue 0.0 plus 0.96002
@@ -172,6 +174,8 @@ Completed box being shipped out [2]
 ....\kern -0.0004
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.44
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -204,7 +208,7 @@ Completed box being shipped out [3]
 ..\vbox(550.0+0.0)x345.0, glue set 539.94232fil
 ...\write-{}
 ...\glue(\topskip) 2.25
-...\hbox(7.75+1.92998)x345.0, glue set 91.44fil
+...\hbox(7.75+1.92998)x345.0, glue set 85.0fil
 ....\hbox(0.0+0.0)x0.0
 ....\TU/FandolSong-Regular.otf(0)/m/n/10 一
 ....\glue 0.0 plus 0.96002
@@ -266,6 +270,8 @@ Completed box being shipped out [3]
 ....\kern -0.0004
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.44
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
@@ -298,7 +304,7 @@ Completed box being shipped out [4]
 ..\vbox(550.0+0.0)x345.0, glue set 539.94232fil
 ...\write-{}
 ...\glue(\topskip) 2.25
-...\hbox(7.75+1.92998)x345.0, glue set 91.44fil
+...\hbox(7.75+1.92998)x345.0, glue set 85.0fil
 ....\hbox(0.0+0.0)x0.0
 ....\TU/FandolSong-Regular.otf(0)/m/n/10 一
 ....\glue 0.0 plus 0.96002
@@ -360,6 +366,8 @@ Completed box being shipped out [4]
 ....\kern -0.0004
 ....\kern -0.18753
 ....\kern 0.18753
+....\glue 6.44 minus 5.0
+....\penalty 0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0

--- a/xeCJK/xeCJK.dtx
+++ b/xeCJK/xeCJK.dtx
@@ -4215,18 +4215,16 @@ Copyright and Licence
 % \end{macro}
 %
 % \begin{macro}{\@@_punct_boundary_guard:}
-% \changes{v3.10.0}{2026/05/13}
-% {修复 \env{tabular} 中 \tn{unskip} 吞掉标点补偿 glue 的问题（\#827）。}
-% 在 restricted horizontal mode（\env{tabular} 单元格、\tn{hbox} 等）中，
-% \tn{\\} 结束行时通过 \tn{unskip} 移除最后一个 glue。
-% 这会吞掉标点的补偿 glue，导致单元格宽度错误。
-% 此函数在 glue 之后插入 |\penalty 0|，
-% 使最后节点不再是 glue，从而保护它。
-% 仅限 inner mode，因为段落模式下 \TeX{} 自身的 \tn{unskip}
-% （添加 \tn{parfillskip} 前）是正常行为，不应阻止。
+% \changes{v3.10.0}{2026/05/16}
+% {无条件插入 \tn{penalty} 保护标点补偿 glue 不被 \tn{unskip} 移除（\#827, \#859）。}
+% 在标点补偿 glue 之后插入 |\penalty 0|，
+% 使水平列表的最后节点不再是 glue，从而保护它不被 \tn{unskip} 移除。
+% 这同时解决 \env{tabular}/\env{tabularray} 单元格中
+% \tn{\\} 的 \tn{unskip}（\#827）以及
+% \cs{para_end:} 的 \tn{unskip} 导致 \tn{hbox} 与段落宽度不一致的问题（\#859）。
 %    \begin{macrocode}
 \cs_new_protected:Npn \@@_punct_boundary_guard:
-  { \mode_if_inner:T { \tex_penalty:D \c_zero_int } }
+  { \tex_penalty:D \c_zero_int }
 %    \end{macrocode}
 % \end{macro}
 %

--- a/xeCJK/xeCJK.dtx
+++ b/xeCJK/xeCJK.dtx
@@ -4217,14 +4217,13 @@ Copyright and Licence
 % \begin{macro}{\@@_punct_boundary_guard:}
 % \changes{v3.10.0}{2026/05/16}
 % {无条件插入 \tn{penalty} 保护标点补偿 glue 不被 \tn{unskip} 移除（\#827, \#859）。}
-% 在标点补偿 glue 之后插入 |\penalty 0|，
+% 在标点补偿 glue 之后插入 |\penalty 10000|，
 % 使水平列表的最后节点不再是 glue，从而保护它不被 \tn{unskip} 移除。
-% 这同时解决 \env{tabular}/\env{tabularray} 单元格中
-% \tn{\\} 的 \tn{unskip}（\#827）以及
-% \cs{para_end:} 的 \tn{unskip} 导致 \tn{hbox} 与段落宽度不一致的问题（\#859）。
+% 使用 10000 而非 0 是为了不在 \cs{xeCJK_no_break:} 之后引入额外的合法断行点。
+% 正常情况下，punct glue 本身即为合法断行点（前一节点为 kern），无需额外许可。
 %    \begin{macrocode}
 \cs_new_protected:Npn \@@_punct_boundary_guard:
-  { \tex_penalty:D \c_zero_int }
+  { \tex_penalty:D \c_@@_nobreak_penalty_int }
 %    \end{macrocode}
 % \end{macro}
 %


### PR DESCRIPTION
## Summary

- 移除 `\@@_punct_boundary_guard:` 中的 `\mode_if_inner:T` 条件，使 `\penalty 0` 在所有模式下无条件插入
- 同时解决 #827（tabular/tabularray）和 #859（段落模式 hbox 宽度不一致）
- 更新 14 个测试基线

## 根因

`\para_end:` 中的 `\tex_unskip:D` 会移除段末最后一个 glue。当段落以标点结尾时，标点的补偿 glue（punct_glue）被移除，导致：
- `\hbox` 测量宽度（包含 punct_glue）≠ 段落排版宽度（不含 punct_glue）
- tabularray 先在 hbox 中测量再在 parbox 中排版，触发宽度不一致

原 #827 修复仅在 inner mode 插入 `\penalty 0` 保护 glue，遗留了 paragraph mode 的同类问题。

## 修复

```latex
% 修复前（仅 inner mode）：
\cs_new_protected:Npn \@@_punct_boundary_guard:
  { \mode_if_inner:T { \tex_penalty:D \c_zero_int } }

% 修复后（无条件）：
\cs_new_protected:Npn \@@_punct_boundary_guard:
  { \tex_penalty:D \c_zero_int }
```

## 视觉对比

见 https://github.com/CTeX-org/ctex-kit/issues/859#issuecomment-4465598764

## Test plan

- [x] xeCJK 全部 83 个测试通过
- [ ] ctex 测试（预计 heading01-06 等约 23 个基线变动需更新）

Closes #859