### PR TITLE
fix(ctex): 修复文档编译失败

### DIFF
--- a/ctex/ctex.dtx
+++ b/ctex/ctex.dtx
@@ -10837,7 +10837,7 @@ Copyright and Licence
 %<tt&jt2>\DeclareKanjiFamily{JT2}{zhtt}{}
 %    \end{macrocode}
 %
-% \changes{v2.6.0}{2026/05/16}{补全 \upLaTeX\ 字体编码 |JY2| 和 |JT2| 的
+% \changes{v2.6.0}{2026/05/16}{补全 \upLaTeX\ 字体编码 JY2 和 JT2 的
 % Fallback 机制。}
 % 在 \upLaTeX\ 字体族 |zhrm| 下采用如下 Fallback 机制：
 % 形状 |sl| 优先保留加粗字重，形状 |it| 优先保留楷书字形。


### PR DESCRIPTION
## Summary
- `\changes` 是移动参数，不能使用 `|...|` verbatim 语法，改为纯文本

## Test plan
- [x] `l3build doc` 编译成功（188 pages）