### PR TITLE
fix(ci): 仅在主仓库运行 agentic 定时任务 (#875)

### DIFF
--- a/.github/workflows/agentic-llmdoc-updater.yml
+++ b/.github/workflows/agentic-llmdoc-updater.yml
@@ -20,6 +20,7 @@ permissions:
 
 jobs:
   prepare-llmdoc:
+    if: github.repository == 'CTeX-org/ctex-kit'
     runs-on: ubuntu-latest
     outputs:
       since_period: ${{ steps.check.outputs.since_period }}

--- a/.github/workflows/agentic-patrol.yml
+++ b/.github/workflows/agentic-patrol.yml
@@ -17,6 +17,7 @@ permissions:
 
 jobs:
   patrol:
+    if: github.repository == 'CTeX-org/ctex-kit'
     runs-on: ubuntu-latest
     env:
       diffext: .diff


### PR DESCRIPTION
## Summary
- 在 `agentic-patrol.yml` 和 `agentic-llmdoc-updater.yml` 的 job 层级添加 `if: github.repository == 'CTeX-org/ctex-kit'`
- fork 仓库无 `ANTHROPIC_API_KEY` 等 secrets，定时任务会持续失败并向 contributor 发送邮件
- 添加判断后 fork 中的定时任务会被直接跳过（显示为 skipped），不再产生 error
- `agentic-pr-review.yml` 使用 `pull_request_target`，仅在 base repo 触发，无需修改

Fixes #875

## Test plan
- [x] YAML 语法检查
- [ ] 合并后验证 fork 中下次定时触发不再失败