### PR TITLE
`.choices:nn` 中用 `#1` 替代 `\l_keys_choice_str`

### DIFF
--- a/ctex/ctex.dtx
+++ b/ctex/ctex.dtx
@@ -4000,10 +4000,7 @@ Copyright and Licence
 %   \begin{macrocode}
     space .choices:nn =
       { true , auto , false }
-      {
-        \exp_args:Ne \ctex_at_end:n
-          { \ctex_set:n { space = \l_keys_choice_str } }
-      } ,
+      { \ctex_at_end:n { \ctex_set:n { space = #1 } } } ,
     space  .default:n = { true } ,
     nospace   .code:n = { \ctex_deprecated_option:nn { space = false } } ,
     nospace   .value_forbidden:n = true ,

--- a/jiazhu/jiazhu.dtx
+++ b/jiazhu/jiazhu.dtx
@@ -1442,10 +1442,10 @@ Copyright and Licence
     shortcut-              .code:n = \@@_remove_shortcuts:n {#1} ,
     halign             .choices:nn =
       { justified , left , right , centered , distributed }
-      { \@@_set_halign:n { \l_keys_choice_str } } ,
+      { \@@_set_halign:n {#1} } ,
     valign             .choices:nn =
       { middle , top , bottom }
-      { \@@_set_valign:n { \l_keys_choice_str } } ,
+      { \@@_set_valign:n {#1} } ,
     lines        .value_required:n = true ,
     halign       .value_required:n = true ,
     valign       .value_required:n = true ,

--- a/xeCJK/xeCJK.dtx
+++ b/xeCJK/xeCJK.dtx
@@ -6996,7 +6996,7 @@ Copyright and Licence
 \keys_define:nn { xeCJK / options }
   {
     AutoFakeBold .choices:nn = { true , false }
-      { \use:c { bool_gset_ \l_keys_choice_str :N } \g_@@_auto_fake_bold_bool } ,
+      { \use:c { bool_gset_ #1 :N } \g_@@_auto_fake_bold_bool } ,
     AutoFakeBold / unknown .code:n =
       {
         \bool_gset_true:N  \g_@@_auto_fake_bold_bool
@@ -7004,7 +7004,7 @@ Copyright and Licence
       } ,
     AutoFakeBold  .default:n  = { true } ,
     AutoFakeSlant .choices:nn = { true , false }
-      { \use:c { bool_gset_ \l_keys_choice_str :N } \g_@@_auto_fake_slant_bool } ,
+      { \use:c { bool_gset_ #1 :N } \g_@@_auto_fake_slant_bool } ,
     AutoFakeSlant / unknown  .code:n =
       {
         \bool_gset_true:N  \g_@@_auto_fake_slant_bool

--- a/zhnumber/zhnumber.dtx
+++ b/zhnumber/zhnumber.dtx
@@ -1998,7 +1998,7 @@ Copyright and Licence
   {
     encoding         .choices:nn =
       { UTF8 , GBK , Big5 }
-      { \exp_args:No \zhnum_set_encoding:n { \l_keys_choice_str } } ,
+      { \zhnum_set_encoding:n {#1} } ,
     encoding          .default:n = { GBK } ,
     encoding / Bg5       .meta:n = { encoding = Big5 } ,
     encoding / unknown   .code:n =


### PR DESCRIPTION
我对 #806 <https://github.com/CTeX-org/ctex-kit/commit/8c84490a74af39fda73278520e88d16dca9b1c15> 的改动有一点建议。原始提交中只是单纯做了全局的 `tl` 到 `str` 替换。而 `\l_keys_choice_str` 是给 `.choice:` 设计的，在 `.choices:nn` 里面天然地有一个 `#1` 来传递选项，这样的话也不用额外做展开了。

涉及: `ctex`, `xeCJK`, `jiazhu`, `zhnumber`

需要在 PR 里更新 llmdoc 咩？