### PR TITLE
docs(ctex): 在字号表附近提示 experiment/font-size-system 的影响

### DIFF
--- a/ctex/ctex.dtx
+++ b/ctex/ctex.dtx
@@ -1132,10 +1132,12 @@ Copyright and Licence
 %   \begin{optdesc}[itemsep=\medskipamount]
 %     \item[word] 默认值。源自 Microsoft Word / Adobe 等桌面排版软件的字号定义，
 %       亦与 GB/T~40070---2021 国家标准一致。这是 \CTeX{} 历史以来使用的字号体系。
-%     \item[letterpress] 金属活字排印字号体系，基于严格的倍数关系。
+%     \item[letterpress] 金属活字排印字号体系的一种，基于严格的倍数关系。
 %       初号/二号/五号/七号形成 $\times 2$ 等比序列（$42:21:10.5:5.25$），
 %       一号/四号形成 $\times 2$ 序列（$28:14$），
 %       三号/六号/八号形成 $\times 2$ 序列（$16:8:4$）。
+%       历史上金属活字字号曾存在多种命名与点数约定，本预设仅为其中一种，
+%       并非唯一定义。
 %   \end{optdesc}
 %
 % 两种字号系统仅在以下六个字号上存在差异：
@@ -1228,6 +1230,11 @@ Copyright and Licence
 % \bottomrule
 % \end{tabular}
 %\end{table}
+%
+% 表~\ref{tab:fontsize} 中字体命令对应的字号大小（\si{bp}）基于默认的
+% |word| 字号系统。当启用 \opt{experiment/font-size-system = letterpress}
+% 时，一号、二号、六号、小六、七号、八号这六个字号的 \si{bp} 数值会发生变化，
+% 其余字号保持不变。具体差异见 \ref{subs:options-class}~节。
 %
 % \begin{function}[rEXP]{10pt, 11pt, 12pt}
 %   \CTeX{} 文档类是在 \LaTeX{} 标准文档类之上开发的。因此，除了可以使用 \CTeX{}
@@ -2794,6 +2801,10 @@ Copyright and Licence
 % \end{tabular}
 % \end{table}
 %
+% 表~\ref{tab:zihao} 中的字号大小基于默认的 |word| 字号系统。当启用
+% \opt{experiment/font-size-system = letterpress} 或用户自定义字号系统时，
+% 部分字号的 \si{bp} 数值会发生变化，详见 \ref{subs:options-class}~节。
+%
 % \begin{function}[updated=2014-03-28]{\ziju}
 %   \begin{syntax}
 %     \tn{ziju} \Arg{中文字符宽度的倍数}
@@ -3820,6 +3831,9 @@ Copyright and Licence
 %   \opt{experiment/font-size-system} 选项（\#543）。}
 % \changes{v2.6.0}{2026/05/04}{将 \opt{experiment/font-size-system}
 %   的 \opt{traditional} 选项更名为 \opt{letterpress}（\#813）。}
+% \changes{v2.6.0}{2026/06/23}{文档：在标准字体命令、中文字号表附近提示
+%   \opt{experiment/font-size-system} 的影响；说明
+%   \opt{letterpress} 只是金属活字排印字号体系之一（\#871）。}
 %
 % \begin{macro}{experiment/font-size-system}
 % 选择字号系统。预设有 |word| 和 |letterpress| 两种字号系统，用户也可以自定义。


### PR DESCRIPTION
## 背景

#871 指出:

1. `ctex.pdf` 中的表 4（标准字体命令与字号的对应）和表 25（中文字号）所列数值都基于默认的 `word` 字号系统,文档没有提示读者: 一旦启用 `experiment/font-size-system=letterpress`,其中六个字号的 bp 值会改变。
2. 评论 https://github.com/CTeX-org/ctex-kit/issues/543#issuecomment-4470195871 提议: `letterpress` 文档应说明它只是金属活字排印字号体系的「一种」,而非唯一。

## 修改

`ctex/ctex.dtx`:

- `experiment/font-size-system` 的 `letterpress` 描述补充一句限定语,明确这只是金属活字排印字号体系的一种,历史上存在多种命名与点数约定。
- 表 4 (`tab:fontsize`) 之后新增一段说明: 表中数值基于默认的 `word` 系统,启用 `letterpress` 时一号、二号、六号、小六、七号、八号会发生变化,具体差异见 `\ref{subs:options-class}`。
- 表 25 (`tab:zihao`) 之后新增类似说明: 表中数值基于默认 `word`,启用 `letterpress` 或用户自定义字号系统时部分字号会变化,引导读者查阅 `\ref{subs:options-class}`。
- 新增 `\changes` 条目 (v2.6.0, 2026/06/23)。

不改变 `letterpress` 现有字号数据,也不重排现有表格,只是补充指向 `experiment/font-size-system` 一节的注记。

## 测试

- `l3build doc` 通过(188 页),无 `! ... Error`。

Closes #871

Refs #543