### PR TITLE
fix(xeCJK): 修复 \HD@target / \url 之后 CJKecglue 丢失 (#873, #880)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,10 +1,5 @@
 {
   "permissions": {
-    "defaultMode": "auto",
-    "deny": [
-      "Bash(xxd -r *>*)",
-      "Bash(xxd -r *tee *)"
-    ],
     "allow": [
       "Skill(llmdoc:llmdoc-init)",
       "Bash(git *)",
@@ -40,6 +35,14 @@
       "WebFetch(domain:github.com)",
       "WebFetch(domain:raw.githubusercontent.com)",
       "WebFetch(domain:www.unicode.org)"
-    ]
+    ],
+    "deny": [
+      "Bash(xxd -r *>*)",
+      "Bash(xxd -r *tee *)"
+    ],
+    "defaultMode": "auto"
+  },
+  "enabledPlugins": {
+    "llmdoc@llmdoc-cc-plugin": true
   }
 }

--- a/llmdoc/architecture/xecjk-architecture.md
+++ b/llmdoc/architecture/xecjk-architecture.md
@@ -191,6 +191,28 @@ Boundary → CJK 时：
 2. **ecglue 缓存在 CJK→Boundary 时机**：`\l_@@_ecglue_skip` 在离开 CJK 上下文前测量并缓存，后续恢复不重新展开 `\CJKecglue`
 3. **宏路径不提前输出 glue**：`\@@_boundary_reserve_space:` 只保留标记 kern，不抢先输出空格 glue
 
+### 边界恢复修复点选择矩阵
+
+修复 marker 失效问题时，**修复位置由“被遮蔽的节点类型”决定，不由 marker 类型决定**。已实际落地的四类对照：
+
+| 遮蔽类型 | 案例 | 修复位置 | 修复模式 |
+|---------|------|---------|---------|
+| hbox 节点（marker 仍在但 `\lastkern` 回看不到） | #873 `\HD@target` 的 `\raisebox` 0x0 hbox | 调用方入口（fixed-point patch） | **save/replay**：入口保存 `\g_@@_last_node_tl` 到本地 tl，调用结束后 `\xeCJK_make_node:n` 重发 marker |
+| math 模式（marker 被 math 节点吞掉） | #880 `\Url@FormatString` 的 `$ \fam\z@ ... $` | 调用方入口（fixed-point patch） | **drain**：入口 `\xeCJK_remove_node:` 拔掉 marker，直接补 `\l_@@_ecglue_skip` |
+| whatsit 节点（color / hyperref annot 等） | #807 / #809 / #810 / #831 | `\@@_recover_glue_whatsit:` 或调用方入口 | **whatsit 恢复链**，必要时配合**专用 pending boolean**（如 `\g_@@_reset_color_pending_bool`） |
+| 用户显式分组（catcode 2 `}`） | #831 catcode 2 路径 | CJK→Boundary handler 内 | **brace 路径状态保存**：在 handler 内部识别 catcode 2，设置 `\g_@@_ulem_pending_bool` 让下游 glue-skip 接管 |
+
+#### 选择 drain 还是 save/replay 的判断
+
+- 如果遮蔽点之后**始终是西文**（如 `\url` 内容必然是西文），CJK→西文方向边界永远是 ecglue，无需保留 marker 类型，用 drain。
+- 如果遮蔽点之后可能既是 CJK 又是西文（如 `\HD@target` 后面什么都可能），必须保留 marker 类型让下游状态机判断，用 save/replay。
+
+#### 与“收窄 `\@@_recover_glue_whatsit:` default 分支”思路的边界
+
+PR #831 在 whatsit 路径上用 `\g_@@_reset_color_pending_bool` 实现了“只在已知调用方显式置位时才允许 fallback 分支吐 ecglue”的门控。这一思路理论上可继续推广到 `\@@_recover_glue_whatsit:` 的 default 分支以收窄“任意 whatsit 误触发”的攻击面，但与 #873 / #880 无关——hbox 走 else 分支、math 直接吃 marker，都不进入 `recover_glue_whatsit`。是否做这一收窄是独立 PR 范畴。
+
+详见反思 [[873-880-meta-url-hbox-math-boundary]]。落地点：`xeCJK/xeCJK.dtx` 中 `\@@_patch_hd_target:` / `\@@_patch_url_format:` 段（commit `7c3a2c2e`），与回归测试 `xeCJK/testfiles/hypdoc-ecglue01.lvt` / `url-ecglue01.lvt`。
+
 ## 字体管理
 
 ### 分层设计
@@ -278,7 +300,8 @@ xeCJK 通过 `\@@_package_hook:nn` 为第三方包注册延迟加载的兼容补
 | `ulem` | 临时关闭 interchar (`\makexeCJKinactive`) |
 | `pifont` | 输出前先进入水平模式，防止 interchartokenstate 泄漏 |
 | `listings` | 用 `\scantokens` 替代 `\lowercase` 字符转换 |
-| `url` | 确保 CJK 字体在 URL 数学模式中正确切换 |
+| `url` | `\Url@FormatString` 入口 drain marker kern 并补 ecglue（#880） |
+| `hypdoc` | `\HD@target` 入口 save/replay `\g_@@_last_node_tl`，保证 hbox 节点不遮蔽 marker（#873） |
 
 ### 补丁模式
 

--- a/llmdoc/index.md
+++ b/llmdoc/index.md
@@ -7,13 +7,13 @@
 ## architecture
 
 - `llmdoc/architecture/package-architecture.md` — `ctex` 与 `xeCJK` 的主干架构、引擎适配策略、第三方包补丁子系统与包间依赖图；现含 xeCJK 对 #407/#800 的 `\xeCJKchar` + 定点补丁策略，以及边界恢复链中 `\lastkern` 标记 kern、whatsit 定点重放（含 `\set@color` / `\reset@color` / `\Hy@BeginAnnot` / `l3color` 后端四类）、#324 宏路径多余 glue 遮蔽、#826 fntef 右侧 glue-on-kern-pair 遮蔽、#831 显式 `}` / `\textcolor` color-pop / `\mbox` hlist 三种变体、#832 l3color `\__color_select:N`/`\__color_backend_reset:` kern 对保护、ecglue 缓存取值四层约束的统一心智模型；fntef 双向 `\g_@@_last_node_tl` 全局状态隔离模式（`\xeCJK_fntef_sbox:n` hbox 隔离 + #830 ulem save/restore 隔离）；以及 #859 `experiment/punct-measure-fix` 段落模式下 `\unskip` 吞掉段末标点补偿 glue 的 `para/end` 钩子补偿机制。
-- `llmdoc/architecture/xecjk-architecture.md` — xeCJK 独立架构详解：interchar token 机制、字符分类体系、类别转换矩阵（含 CJK→Boundary handler 对 catcode 2 的处理）、边界恢复状态机三层模型（含 `\@@_check_for_glue_skip:` kern 路径 + 非 kern 三分支：hlist / whatsit（`\g_@@_reset_color_pending_bool` 门控）/ fallback；`\g_@@_ulem_pending_bool` 三 set 点）、`\reset@color` 与 `l3color` 后端定点补丁（#832 `\__color_select:N`/`\__color_backend_reset:` kern 对保护）、字体管理、标点压缩系统（含 `\@@_punct_boundary_guard:` inner mode penalty 保护与 #859 `experiment/punct-measure-fix` 段落模式 `para/end` 钩子补偿）、间距系统、兼容性补丁模式、`\char` 约束与扩展子包（含 xeCJKfntef 双向全局状态隔离 + xunicode-symbols.tex 五级逐字符字体回退链 #878）。
+- `llmdoc/architecture/xecjk-architecture.md` — xeCJK 独立架构详解：interchar token 机制、字符分类体系、类别转换矩阵（含 CJK→Boundary handler 对 catcode 2 的处理）、边界恢复状态机三层模型（含 `\@@_check_for_glue_skip:` kern 路径 + 非 kern 三分支：hlist / whatsit（`\g_@@_reset_color_pending_bool` 门控）/ fallback；`\g_@@_ulem_pending_bool` 三 set 点）、`\reset@color` 与 `l3color` 后端定点补丁（#832 `\__color_select:N`/`\__color_backend_reset:` kern 对保护）、字体管理、标点压缩系统（含 `\@@_punct_boundary_guard:` inner mode penalty 保护与 #859 `experiment/punct-measure-fix` 段落模式 `para/end` 钩子补偿）、间距系统、兼容性补丁模式、`\char` 约束与扩展子包（含 xeCJKfntef 双向全局状态隔离 + xunicode-symbols.tex 五级逐字符字体回退链 #878）；#873/#880 边界恢复修复点选择矩阵。
 - `llmdoc/architecture/ctex-architecture.md` — ctex 独立架构详解：分层加载、键值选项、引擎适配（含 pdfTeX UTF-8 `\DeclareUnicodeCharacter` 优先查找）、字号系统（含 #871 `letterpress` 仅为金属活字字号体系**之一**的勘误说明）、方案/标题/字体集、命令补丁与实验性接口。
 - `llmdoc/architecture/cleveref-patch.md` — cleveref 兼容补丁机制、挂钩链、`patch/cleveref` 开关与 Issue #725 根因分析。
 
 ## reference
 
-- `llmdoc/reference/build-and-test.md` — `l3build`、共享构建配置、`ctex` 180 个主回归测试的覆盖簇、多引擎基线策略、LuaTeX 预热、CI/CD、CI 字体策略（含 #878 `xunicode-symbols.tex` 五级逐字符字体回退链最低保证）、agentic 工作流来源与频率约束（#874/#876）、LaTeX2e 2026-06-01 格式依赖声明（#883）。
+- `llmdoc/reference/build-and-test.md` — `l3build`、共享构建配置、`ctex` 180 个主回归测试的覆盖簇、多引擎基线策略、LuaTeX 预热、CI/CD、CI 字体策略（含 #878 `xunicode-symbols.tex` 五级逐字符字体回退链最低保证）、agentic 工作流来源与频率约束（#874/#876）、LaTeX2e 2026-06-01 格式依赖声明（#883）、本地 TL usertree 同步双步流程（#873/#880）。
 - `llmdoc/reference/coding-conventions.md` — expl3 命名、e-type 优先约定、`@@` 私有空间、`.choices:nn` 用 `#1` 替代 `\l_keys_choice_str`（#806 / #881）、作用域语义、docstrip 标签、`\CTEX@` 遗留接口与文档排版基础设施。
 - `llmdoc/reference/ctex-fontset-mac.md` — `ctex` 中 `fontset=mac` / `macnew` / `macold` 的选择逻辑、macOS 15+ 检测后备、XeTeX/LuaTeX 字体探测差异与回退语义。
 
@@ -38,6 +38,7 @@
 - `llmdoc/memory/decisions/826-fntef-color-global-state.md` — 决策: fntef+textcolor 组合时 `\xeCJK_fntef_sbox:n` 的 `\hbox_set:Nn` 内 interchar toks 全局修改 `\g_@@_last_node_tl` 导致 `\set@color` 补丁用错误节点类型重建 kern pair；修复为 hbox 前后保存/恢复该状态。
 - `llmdoc/memory/decisions/830-color-wraps-ulem-last-node-tl.md` — 决策: textcolor 包裹 ulem 类 fntef 命令时，ulem `\UL@end` 的 `*` 字符触发 Default→Boundary interchar 转换污染 `\g_@@_last_node_tl`；修复为 `\xeCJK_ulem_right:` / `\__xeCJK_ulem_end:` 前后 save/restore，与 #826 fntef(color) 方向互补。
 - `llmdoc/memory/decisions/831-boundary-explicit-brace-ecglue.md` — 决策: #831 显式 `}` / `\mbox` / `\textcolor` 右侧多余 inter-word glue 的三阶段修复：CJK→Boundary handler catcode 2 set 点、`\reset@color` 设置专用 `\g_@@_reset_color_pending_bool`、`\@@_check_for_glue_skip:` 非 kern 三分支（hlist / whatsit 门控 / fallback）。
+- `llmdoc/memory/decisions/873-880-fixed-point-vs-default-narrowing.md` — 决策: #873 / #880 选 input-side fixed-point patch（#873 save/replay、#880 drain），不选收窄 `\@@_recover_glue_whatsit:` default 分支——修复位置由被遮蔽的节点类型决定，与 marker 类型无关。
 - `llmdoc/memory/doc-gaps.md` — 已知文档与实现缺口追踪。
 - `llmdoc/memory/reflections/717-experiment-cjkecglue.md` — 反思: #717 用 `ctex / experiment` 子路径统一暴露实验性 `CJKecglue` 接口，并记录 xeCJK 参数桥接、xkanjiskip 缓存同步与四引擎基线策略。
 - `llmdoc/memory/reflections/715-hyperref-driverfallback.md` — 反思: TYPE 展开陷阱、l3build 命令拦截测试技巧。
@@ -58,6 +59,7 @@
 - `llmdoc/memory/reflections/324-boundary-reserve-space-glue.md` — 反思: xeCJK #324 中宏路径提前输出空格 glue 遮蔽 `CJK-space` 标记 kern，破坏 `\lastkern` 边界恢复；修复同时揭示 xeCJK→ctex 的广泛基线联动。
 - `llmdoc/memory/reflections/826-fntef-boolean-flag-iteration.md` — 反思: xeCJK #826 fntef glue-on-kern-pair 初始修复后的迭代——`\l_@@_last_skip` 状态污染、`\quad` 误处理、fallback 路径错误的根因与三层过滤收敛过程。
 - `llmdoc/memory/reflections/831-reset-color-pending-bool.md` — 反思: #831 colorbox/textcolor 右侧间距修复四轮迭代——从 `\reset@color` 直接插入 kern 对到 `\g_@@_reset_color_pending_bool` 专用布尔延迟处理的收敛过程，核心教训为共享全局布尔的语义过载风险。
+- `llmdoc/memory/reflections/873-880-meta-url-hbox-math-boundary.md` — 反思: xeCJK #873 / #880 中 `\HD@target` 的 0x0 hbox 与 `\Url@FormatString` 的 math 模式分别遮蔽边界 marker；混合修复（save/replay vs drain），以及本地 TeX Live usertree 与 CI 漂移导致 7 个 false-positive 测试失败的诊断教训（双步同步 + fmt 重生成）。
 - `llmdoc/memory/reflections/878-xunicode-symbols-multilevel-fallback.md` — 反思: xeCJK #878 `xunicode-symbols.tex` 驱动从“整段单字体 if-else”升级为 `FreeSerif → Noto Sans Symbols 2 → Symbola → Segoe UI Symbol → DejaVu Sans` 五级逐字符 `\iffontchar` + `\cs_if_exist_use:N` 链；只适用于演示性符号目录驱动文件，不应推广到正文 / CJK 字体路径。
 - `llmdoc/memory/reflections/874-876-agentic-fork-shielding-cron.md` — 反思: #875 / #874 `agentic-*.yml` 同时存在两条边界约束——job 级 `if: github.repository == ...` 把 fork 调度挡在 runner 分配之前，`schedule` 频率回退到每天一次北京时间 08:00；未来新增 agentic 工作流时这两条都应作为默认。
 - `llmdoc/memory/reflections/ctex-architecture-doc.md` — 反思: ctex 架构独立文档的创建过程、源码阅读方法与已知文档缺口。

--- a/llmdoc/memory/decisions/873-880-fixed-point-vs-default-narrowing.md
+++ b/llmdoc/memory/decisions/873-880-fixed-point-vs-default-narrowing.md
@@ -1,0 +1,42 @@
+---
+name: "873-880-fixed-point-vs-default-narrowing"
+description: "决策: #873 / #880 选 input-side fixed-point patch（save/replay 与 drain），不选收窄 \\@@_recover_glue_whatsit: default 分支——修复位置由被遮蔽的节点类型决定，与 marker 类型无关"
+metadata:
+  type: decision
+---
+
+# 决策：#873 / #880 选 input-side fixed-point patch 而非“收窄 default 分支”
+
+## 背景
+
+#873（`\meta` 后 CJK 丢 ecglue）与 #880（`\url` 后 CJK 丢 ecglue）根因相同：xeCJK 边界恢复链通过 `\tex_lastkern:D` 判断 marker，但被中间节点遮蔽（#873 是 `\HD@target` 的 0x0 hbox，#880 是 `\Url@FormatString` 的 math 模式）。曾考虑两条修复路径。
+
+## 候选方案
+
+**方案 A（采纳）**：在调用方入口下 fixed-point patch。
+
+- #873 → save/replay `\g_@@_last_node_tl`
+- #880 → drain marker + 直接补 ecglue
+
+**方案 B（未采纳）**：仿 PR #831 给 `\@@_recover_glue_whatsit:` 的 default 兜底分支加 pending boolean gate，只在已知调用方（`\set@color` / `\HD@target` / `\Url@FormatString`）显式置位时才允许 default 分支吐 ecglue。
+
+## 决策
+
+采纳方案 A。
+
+## 理由
+
+- #873 走的是 boundary check 的 hbox else 分支，根本不进 `\@@_recover_glue_whatsit:`。
+- #880 在 math 模式下 marker 已被吃掉，更进不去 whatsit 恢复链。
+- 收窄 default 分支是另一类问题——“防御任意第三方 whatsit 误触发”。它与 #873 / #880 的根因正交。
+- **核心规律**：修复位置取决于“被遮蔽的节点类型”，不取决于 marker 类型。详见 [[../../architecture/xecjk-architecture]] 中“边界恢复修复点选择矩阵”。
+
+## 后续
+
+若未来要落“收窄 `\@@_recover_glue_whatsit:` default 分支”的独立 PR，动机应是“防御任意 whatsit 误触发”而非“修 #873 / #880 副作用”——两个目标完全不同。
+
+## 落地引用
+
+- 实现：`xeCJK/xeCJK.dtx` `\@@_patch_hd_target:` / `\@@_patch_url_format:`（commit `7c3a2c2e`）。
+- 回归测试：`xeCJK/testfiles/hypdoc-ecglue01.lvt` / `url-ecglue01.lvt`。
+- 反思：[[../reflections/873-880-meta-url-hbox-math-boundary]]。

--- a/llmdoc/memory/reflections/873-880-meta-url-hbox-math-boundary.md
+++ b/llmdoc/memory/reflections/873-880-meta-url-hbox-math-boundary.md
@@ -1,0 +1,159 @@
+---
+name: 873-880-meta-url-hbox-math-boundary
+description: 反思 #873 / #880 修复中"边界 marker 被 hbox 节点或 math 模式遮蔽"的两条修复模式（save/replay vs drain），以及本地 TeX Live usertree 与 CI 漂移导致 7 个 false-positive 测试失败的诊断教训
+metadata:
+  type: feedback
+---
+
+# [Task Reflection]
+
+## Task
+
+为 xeCJK 修复两个边界恢复缺陷并补回归测试：
+
+- **#873**：l3doc 的 `\meta` / `\cs` 在 CJK 之后丢失 ecglue。`\HD@target`
+  (hypdoc.sty) 通过 `\raisebox` 产生一个 0x0 hbox 节点。xeCJK 边界恢复链靠
+  `\tex_lastkern:D` 判断之前是否插过 marker kern；hbox 节点夹在中间会让
+  `\lastkern` 读到 0pt（或非 marker 值），状态机判断失败、左侧 ecglue 丢失。
+- **#880**：`\url` 后 CJK 之间也丢 ecglue。url.sty 的 `\Url@FormatString` 把
+  内容包在 `$\fam\z@ ... $` 里进入 math 模式，整段 hbox 化的同时 marker kern
+  直接被 math 模式吃掉，`\lastkern` 连原 marker 都读不到。
+
+实施方案为**混合修复**：
+
+1. **#873 save/replay**：在 `\HD@target` 入口用 `\xeCJK_if_last_node:` 检测并
+   把 `\g_@@_last_node_tl` 暂存到 `\g_@@_hd_saved_node_tl`，调用结束后用
+   `\xeCJK_make_node:n` 重新发射 marker，让下游边界检查仍能命中。
+2. **#880 drain**：在 `\Url@FormatString` 入口直接 `\xeCJK_remove_node:` 拔掉
+   marker 并补 `\l_@@_ecglue_skip`；`\url` 内容必为西文，CJK→西文方向边界总是
+   ecglue，不需要区分 marker 类型。
+
+两处都通过 `\@@_package_hook:nn` 在对应包加载后 patch。新增两个回归测试
+`xeCJK/testfiles/hypdoc-ecglue01.lvt`、`url-ecglue01.lvt`，已落到
+commit `7c3a2c2e`。
+
+## Expected vs Actual
+
+- 预期：修复完应当直接通过本地 `l3build check`，因为补丁面收得很窄、新增测试也都通过。
+- 实际：本地多出 7 个看似无关的失败——xeCJK 的 `environ01` / `loading01` /
+  `punct-measure-fix01` / `tabular01`，以及 ctex contrib 的 `elegantbook` /
+  `pkuthss` / `thuthesis`。我**最初草率判定**为"预存问题、与本次 patch 无关"，
+  被用户当场反驳："线上最新 action 是没问题的，要分析清楚再解决"。
+  反驳之后才查清楚根因并修通。
+
+## What Went Wrong
+
+1. **错误归因**：把本地一组看起来"跟 patch 不相关"的失败直接打包成"预存问题"，
+   没有先比对 CI 现状。CI 是已知良好基线，本地与 CI 的差异应是**第一信号**而不是
+   被忽略的背景噪声。
+2. **忘了一个关键步骤——重生成 fmt**：发现是 TL 版本漂移后，第一反应是
+   `tlmgr --usermode update --all`，但**只更新 `.ltx` / `.sty` 文件不够**。
+   xelatex 启动时加载的是预编译的 fmt 文件，里面 dump 的还是老内核。必须
+   `fmtutil-user --byfmt xelatex` 才能把 `~/.texlive2026/texmf-var/web2c/xetex/xelatex.fmt`
+   同步到新内核。
+3. **没在第一时间用 CI 状态作交叉验证**。线上最新 action 是干净的，这条
+   信号本来够分辨"是 patch 副作用 vs 本地环境漂移"，但被我跳过。
+
+## Root Cause
+
+- **直接根因（环境）**：本地是 Homebrew 安装的 TeX Live 2026，`tlmgr revision 77655`，
+  自 2026-02-07 后没再拉过 TLnet；CI 用 `setup-texlive-action@v4` 每次拉 TLnet
+  最新版，包括最新 LaTeX 内核（`fmtversion=2026-06-01`）。commit `06ca4680`
+  已经把仓库声明的最低 LaTeX2e 拉到 `2026-06-01`，本地老内核加载时触发 release
+  warning，把 `loading01` 的日志第 3 行错开；另 6 个失败则是新版 LaTeX / hyperref /
+  graphics 改了 `\showbox` 输出格式（开始打印 `\mathon` / `\mathoff` 节点和
+  `$[]$` 风格 Overfull 标记），与本地老内核不一致。
+- **思维定式（人）**：本地失败"看起来跟 patch 无关"就归为环境问题——这是一种
+  懒分析。正确做法是看 diff 内容找根因（release warning 字样、mathon/mathoff
+  节点、`\showbox` 输出差异都是清晰的环境指纹），不是看用例名是否落在改动文件附近。
+- **诊断 checklist 缺位**：项目缺少一份"本地 TL usermode 维护与 CI 漂移检测"
+  小流程，导致即使遇到典型症状也得每次手动重推一遍。
+
+## Missing Docs or Signals
+
+- **缺少"本地 TL usermode 同步" guide / reference 小节**。`tlmgr --usermode update --all`
+  与 `fmtutil-user --byfmt xelatex` 的**双步**流程不写下来就极易忘 fmt 一步。
+  附带还要写清楚 `tlmgr --usermode` 不能更新 `tlmgr` 自身、不能更新引擎包
+  （xetex / luaotfload / latex-bin 会显示 "mentioned, but neither new nor
+  forcibly removed"，这是预期行为而非错误）。
+- **缺少"本地失败 vs CI 失败"的诊断 checklist**。判定指纹：
+  - `LaTeX2e <YYYY-MM-DD>` 的 release warning 出现在前几行 → 本地内核低于仓库声明。
+  - `.tlg` diff 出现 `\mathon` / `\mathoff` / `$[]$` / `pre-display` 等新增节点 →
+    本地 LaTeX / hyperref / graphics 包级 `\showbox` 实现旧版。
+  - 引擎 banner（如 `XeTeX 0.99996`）一致但包级 diff 大 → 不是引擎差异，
+    是包差异（如本轮 6/7 个失败的真实情况）。
+- **边界恢复架构文档里没有显式记录"修复点选择矩阵"**：当一个 marker 被某种
+  下游节点遮蔽时，应在哪里下补丁是有规律可寻的。本轮把这种规律实际**实践**了
+  一次，但 `architecture/xecjk-architecture.md` 里没体现。
+
+## Promotion Candidates
+
+适合提升到 **`architecture/xecjk-architecture.md`**（由 recorder 落地）：
+
+- **边界恢复修复点矩阵**——按"marker 被什么遮蔽"分类，给出对应修复模式：
+
+  | 遮蔽类型                     | 案例                          | 修复位置                                  | 修复模式                                                                  |
+  | ---------------------------- | ----------------------------- | ----------------------------------------- | ------------------------------------------------------------------------- |
+  | hbox 节点（marker 仍在但回看不到） | #873 `\HD@target` 的 `\raisebox` 0x0 hbox | 调用方入口                                | **save/replay**：入口保存 `\g_@@_last_node_tl`，调用结束后 `\xeCJK_make_node:n` 重发 |
+  | math 模式（marker 被吃掉）         | #880 `\Url@FormatString` 的 `$...$` | 调用方入口                                | **drain**：入口 `\xeCJK_remove_node:` + 直接补 `\l_@@_ecglue_skip`                |
+  | whatsit 节点（color / annot 等）   | #807 / #809 / #810 / #831      | `\@@_recover_glue_whatsit:` 或调用方入口      | **whatsit 恢复链**，必要时配合 **专用 pending boolean**（如 `\g_@@_reset_color_pending_bool`） |
+  | 用户 brace / 显式分组               | #831 catcode 2 路径             | 状态机内部                                | **brace 路径状态保存**                                                       |
+
+  这张表的核心规律是：**修复位置由"被遮蔽的节点类型"决定，而不是由 marker 本身的
+  类型决定**。本轮 #873 / #880 的修复并不经过 `\@@_recover_glue_whatsit:`
+  （hbox 走 else 分支，math 直接吃 marker），所以与 PR #831 的 "default 分支
+  boolean gate" 思路是正交的。
+
+适合提升到 **`reference/build-and-test.md`**（由 recorder 落地）：
+
+- 新增"本地 TL usertree 同步"小节，记录双步流程：
+
+  ```bash
+  # 1. 同步包到 usertree（已 init 过 ~/texmf + ~/.texlive2026/）
+  tlmgr --usermode update --all
+  # 2. 重生成 xelatex fmt（必须，否则启动时仍用老内核）
+  fmtutil-user --byfmt xelatex
+  ```
+
+  以及"本地失败 diff 指纹检查表"——release warning / mathon-mathoff / 引擎
+  banner 的判读规则。
+
+适合放到 **`memory/decisions/`** 一条新决策（由 recorder 落地）：
+
+- **#873 / #880：选 input-side fixed-point patch 而非"收窄 default 分支"的理由**。
+  备选方案曾考虑仿 PR #831 给 `\@@_recover_glue_whatsit:` 的 default 分支加
+  pending boolean gate（仅在 `\set@color` / `\HD@target` / `\Url@FormatString`
+  等已知调用方显式置位时才允许 default 分支吐 ecglue）。**未采纳**，因为：
+  - #873 走的是 hbox else 分支，根本不进 `recover_glue_whatsit`；
+  - #880 在 math 模式里 marker 已被吃掉，更进不去；
+  - 收窄 default 分支是另一类问题（防止任意 whatsit 误触发），应作独立 PR 处理。
+  一句话总结：**修复位置取决于被遮蔽的节点类型，不取决于 marker 类型**。
+
+仅保留在本反思（不上推）：
+
+- 本轮 7 个本地失败的具体清单与诊断细节、`tlmgr --usermode update` 输出里那 9 个
+  被升级的包（amsmath/babel/firstaid/graphics/hyperref/l3kernel/latex/thuthesis/tools，
+  rev 76xxx → 79xxx）。
+- "误归因为预存问题"这条人因教训本身——值得记住，但属于 reflection 范畴。
+
+## Follow-up
+
+- 下次主助手起手就该**先 check 本地 fmt 时间戳与仓库声明的最低 LaTeX2e
+  日期**，把 TL 漂移挡在分析前面，而不是出现一堆 `.tlg` diff 才去排查。
+- 等用户确认后，由 recorder 把上面三处 Promotion Candidates 落到稳定文档
+  （architecture/reference/decisions），本反思保持不变。
+- 如果未来真要落"收窄 `\@@_recover_glue_whatsit:` default 分支"的独立 PR，
+  应明确动机是"防御任意 whatsit 误触发"，而不是"修 #873 / #880 的副作用"——
+  两者目标完全不同。
+
+## 相关引用
+
+- 实现位置：`xeCJK/xeCJK.dtx` 中 `\HD@target` 与 `\Url@FormatString` 的
+  `\@@_package_hook:nn` patch 段（commit `7c3a2c2e`）。
+- 回归测试：`xeCJK/testfiles/hypdoc-ecglue01.lvt` / `.tlg`，
+  `xeCJK/testfiles/url-ecglue01.lvt` / `.tlg`。
+- 同方向但不同修复模式的对照反思：
+  [[807-set-color-stale-state]]、[[809-810-hyperref-annot-ecglue]]、
+  [[831-reset-color-pending-bool]]。
+- 仓库 LaTeX2e 依赖声明上调：commit `06ca4680`（ctex/xeCJK/zhlineskip 声明依赖
+  LaTeX2e 2026-06-01）。

--- a/llmdoc/reference/build-and-test.md
+++ b/llmdoc/reference/build-and-test.md
@@ -325,3 +325,38 @@ CTAN 打包现已完全由 `.github/workflows/release.yml` 自动化驱动。原
 - `.dtx` 中声明的公开版本号
 - `\changes` 中的人类可读变更记录
 - 打包阶段自动注入的 git 标识
+
+## 本地 TeX Live usertree 同步
+
+仓库在 PR #883 中声明了 LaTeX2e 2026-06-01 作为最低依赖。CI 通过 `setup-texlive-action@v4 + update-all-packages: true` 每次拉 TLnet 最新版（含最新 LaTeX2e 内核与 hyperref / graphics 等包），所以 CI 始终对齐。本地若用冻结发行版（如 Homebrew TeX Live），需要靠 `tlmgr` 的 **usermode** 维护一个用户树跟进。
+
+### 双步同步流程
+
+```bash
+# 1. 同步包到 usertree（前提：已 init 过 ~/texmf + ~/.texlive2026/）
+tlmgr --usermode update --all
+
+# 2. 重生成 xelatex fmt（必须，否则启动时仍加载老内核）
+fmtutil-user --byfmt xelatex
+```
+
+仅做第 1 步是常见坑：xelatex 启动加载的是预编译 `xelatex.fmt`，里面 dump 的 `latex.ltx` 是包升级**前**的版本，新 `.ltx` / `.sty` 文件即使已落盘也不会生效。
+
+`tlmgr --usermode` 的边界：
+
+- 不能更新 `tlmgr` 自身、不能更新引擎包（`xetex` / `luaotfload` / `latex-bin` 会显示 `mentioned, but neither new nor forcibly removed`，这是预期行为）。
+- 引擎相关包要等冻结发行版（Homebrew 等）的 formula 升级，或者另装一份官方 install-tl。
+
+### 本地测试失败的环境指纹检查表
+
+当本地 `l3build check` 失败而最新 master CI 全绿时，先看 `.tlg` diff 的指纹：
+
+| 指纹 | 含义 |
+|------|------|
+| 前几行出现 `LaTeX Warning: You have requested release '<日期>' of LaTeX` | 本地 LaTeX2e 内核 < 仓库声明的最低日期（通常即 #883 的 2026-06-01）|
+| diff 出现 `\mathon` / `\mathoff` 节点 或 `$[]$` 风格 Overfull 标记 | 本地 LaTeX / hyperref / graphics 的 `\showbox` 实现旧版 |
+| 引擎 banner 一致（如 `XeTeX 3.141592653-2.6-0.999998`）但包级 diff 大 | 不是引擎差异，是 LaTeX / hyperref / graphics 等包差异 |
+
+出现以上任一指纹应优先按“本地 usertree 同步”流程修，而不是当作业务回归排查。
+
+详见反思 [[873-880-meta-url-hbox-math-boundary]]。

--- a/xeCJK/testfiles/hypdoc-ecglue01.lvt
+++ b/xeCJK/testfiles/hypdoc-ecglue01.lvt
@@ -1,0 +1,44 @@
+\input{regression-test}
+
+\documentclass{article}
+
+\usepackage{xeCJK}
+\usepackage{hypdoc}
+\setCJKmainfont{FandolSong-Regular.otf}
+
+\makeatletter
+
+\begin{document}
+
+\START
+
+% #873: \HD@target produces an empty hbox via \raisebox that shadows the
+% xeCJK marker kern. The boundary check fails and the ecglue is lost.
+
+\TEST{ecglue across HD@target hbox (873)}{
+  \setbox0=\hbox{用 abc 设置}
+  \setbox1=\hbox{用 \HD@target abc 设置}
+  % With the fix, the second box should keep both ecglues; widths should match
+  % the no-target baseline.
+  \ifdim\wd0=\wd1
+    \TYPE{PASS:~HD@target~hbox~does~not~swallow~ecglue}
+  \else
+    \TYPE{FAIL:~\the\wd0\space vs~\the\wd1}
+  \fi
+}
+
+\TEST{HD@target between CJK preserves width (873)}{
+  \setbox0=\hbox{用设置}
+  \setbox1=\hbox{用\HD@target 设置}
+  % source space between two CJK is absorbed; HD@target inserts a 0-width hbox
+  % but should not alter spacing. Widths should match.
+  \ifdim\wd0=\wd1
+    \TYPE{PASS:~CJK~HD@target~CJK~width~preserved}
+  \else
+    \TYPE{FAIL:~\the\wd0\space vs~\the\wd1}
+  \fi
+}
+
+\END
+
+\end{document}

--- a/xeCJK/testfiles/hypdoc-ecglue01.tlg
+++ b/xeCJK/testfiles/hypdoc-ecglue01.tlg
@@ -1,0 +1,12 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+============================================================
+TEST 1: ecglue across HD@target hbox (873)
+============================================================
+PASS:~HD@target~hbox~does~not~swallow~ecglue
+============================================================
+============================================================
+TEST 2: HD@target between CJK preserves width (873)
+============================================================
+PASS:~CJK~HD@target~CJK~width~preserved
+============================================================

--- a/xeCJK/testfiles/url-ecglue01.lvt
+++ b/xeCJK/testfiles/url-ecglue01.lvt
@@ -1,0 +1,52 @@
+\input{regression-test}
+
+\documentclass{article}
+
+\usepackage{xeCJK}
+\usepackage{url}
+\setCJKmainfont{FandolSong-Regular.otf}
+
+\begin{document}
+
+\START
+
+% #880: CJK followed by \url should have ecglue inserted on the left side.
+% Without the fix, the boundary marker kern is shadowed by the math node,
+% so the left ecglue is lost and the box becomes ~3.33pt narrower.
+
+\TEST{ecglue between CJK and url (880)}{
+  \setbox0=\hbox{测\url{X}无}
+  \setbox2=\hbox{测\hbox{}\url{X}无}
+  % \hbox{} provides a baseline: no CJK marker kern, hence no left ecglue.
+  % With the fix in place, box0 (which keeps its marker kern -> drained
+  % into ecglue) should be wider than box2 by exactly one ecglue (~3.33pt).
+  \dimen0=\wd0 \advance\dimen0 by -\wd2
+  \ifdim\dimen0>2pt
+    \TYPE{PASS:~left~ecglue~present:~\the\dimen0}
+  \else
+    \TYPE{FAIL:~left~ecglue~missing:~\the\dimen0}
+  \fi
+}
+
+\TEST{explicit space before url absorbed (880)}{
+  \setbox0=\hbox{测试 \url{X}无}
+  \setbox1=\hbox{测试\url{X}无}
+  \ifdim\wd0=\wd1
+    \TYPE{PASS:~explicit~space~absorbed}
+  \else
+    \TYPE{FAIL:~\the\wd0\space vs~\the\wd1}
+  \fi
+}
+
+\TEST{ascii context url unchanged (non-regression)}{
+  % Sanity check: patch should be a no-op when no CJK marker exists.
+  % Compare \url{X} surrounded by ASCII before/after loading the patch
+  % vs the same expression in a pure-ASCII document (no xeCJK at all):
+  % unfeasible inside one .lvt, so settle for a stable width assertion.
+  \setbox0=\hbox{abc\url{X}def}
+  \TYPE{INFO:~ASCII~url~width:~\the\wd0}
+}
+
+\END
+
+\end{document}

--- a/xeCJK/testfiles/url-ecglue01.tlg
+++ b/xeCJK/testfiles/url-ecglue01.tlg
@@ -1,0 +1,24 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+============================================================
+TEST 1: ecglue between CJK and url (880)
+============================================================
+Package xeCJK Warning: Unknown CJK family `\CJKttdefault' is being ignored.
+(xeCJK)                
+(xeCJK)                Try to use `\setCJKmonofont[<...>]{<...>}' to define it.
+LaTeX Font Info:    External font `cmex10' loaded for size
+(Font)              <7> on input line ....
+LaTeX Font Info:    External font `cmex10' loaded for size
+(Font)              <5> on input line ....
+PASS:~left~ecglue~present:~3.33pt
+============================================================
+============================================================
+TEST 2: explicit space before url absorbed (880)
+============================================================
+PASS:~explicit~space~absorbed
+============================================================
+============================================================
+TEST 3: ascii context url unchanged (non-regression)
+============================================================
+INFO:~ASCII~url~width:~36.92pt
+============================================================

--- a/xeCJK/xeCJK.dtx
+++ b/xeCJK/xeCJK.dtx
@@ -9849,6 +9849,84 @@ Copyright and Licence
 \@@_patch_l3color:
 %    \end{macrocode}
 %
+% \changes{v3.10.0}{2026/06/23}{为 \pkg{hypdoc} 的 \tn{HD@target} 添加补丁，
+%   在它产生的 hbox 之后重放 xeCJK 节点标记，
+%   修复 \pkg{l3doc} 中 \cs{cs}、\cs{meta} 等命令后 \texttt{CJKecglue}
+%   丢失或保留为原始空格的问题（\#873）。}
+%
+% \pkg{hypdoc} 的 \tn{HD@target} 通过 \tn{raisebox} 产生 \texttt{hbox(0+0)x0}
+% 用于放置 \tn{special\{pdf:dest...\}}。该 hbox 隔在 xeCJK 标记 kern
+% 对和后续字符之间，使 |\tex_lastkern:D| 探测失败，导致
+% Boundary→\{Default,CJK\} 路径中 |\xeCJK_if_last_node:n| / |\@@_if_last_kern:|
+% 检查返回 false，间距因此丢失。
+% 此处保存 |\g_@@_last_node_tl|、清除现有标记 kern、调用原始
+% \tn{HD@target}、然后根据保存的状态重放节点标记，
+% 使后续触发路径能正确识别前方上下文。
+%    \begin{macrocode}
+\tl_new:N \g_@@_hd_saved_node_tl
+\cs_new_protected:Npn \@@_patch_hd_target:
+  {
+    \cs_if_exist:NF \@@_orig_HD_target:
+      {
+        \cs_set_eq:NN \@@_orig_HD_target: \HD@target
+        \cs_gset_protected:Npn \HD@target
+          {
+            \xeCJK_if_last_node:TF
+              { \tl_gset_eq:NN \g_@@_hd_saved_node_tl \g_@@_last_node_tl }
+              { \tl_gclear:N \g_@@_hd_saved_node_tl }
+            \tl_gclear:N \g_@@_last_node_tl
+            \@@_orig_HD_target:
+            \tl_if_empty:NF \g_@@_hd_saved_node_tl
+              { \exp_args:No \xeCJK_make_node:n { \g_@@_hd_saved_node_tl } }
+          }
+      }
+  }
+\@@_package_hook:nn { hypdoc } { \@@_patch_hd_target: }
+%    \end{macrocode}
+%
+% \changes{v3.10.0}{2026/06/23}{为 \pkg{url} 的 \tn{Url@FormatString} 添加补丁，
+%   在进入数学模式前 drain 缓存的 \texttt{CJKecglue}，
+%   修复 CJK 文字与 \tn{url} 命令之间间距丢失的问题（\#880）。}
+%
+% \pkg{url} 的 \tn{url} 命令通过 \tn{Url@FormatString} 进入数学模式
+% 排版 URL 字符串。
+% 数学模式 node 隔在 xeCJK 标记 kern 对和数学公式之间，
+% 又因 \XeTeX{} 在数学模式中不触发 interchar class 转换，
+% 标记 kern 对永远等不到匹配的 Boundary→\{CJK,Default\} 触发，
+% 缓存的 \texttt{CJKecglue} 因此在 CJK 与 \tn{url} 之间丢失。
+% 此处在进入数学模式前直接 drain 缓存间距：\tn{url} 排版的内容
+% 必然是西文，前方上下文为 CJK / CJK-space / CJK-widow / default
+% 中任意一种时均应使用 \texttt{CJKecglue}（西文边界间距）。
+% \tn{url} 数学模式结束至 CJK 文字之间的右侧间距由
+% \cs{xeCJK_check_for_glue:} 的 \cs{@@_if_last_math:} 路径自然处理。
+%    \begin{macrocode}
+\cs_new_protected:Npn \@@_drain_ecglue:
+  {
+    \xeCJK_if_last_node:TF
+      {
+        \tl_if_empty:NF \g_@@_last_node_tl
+          {
+            \xeCJK_remove_node:
+            \skip_horizontal:N \l_@@_ecglue_skip
+          }
+      }
+      { \tl_gclear:N \g_@@_last_node_tl }
+  }
+\cs_new_protected:Npn \@@_patch_url_format:
+  {
+    \cs_if_exist:NF \@@_orig_Url_FormatString:
+      {
+        \cs_set_eq:NN \@@_orig_Url_FormatString: \Url@FormatString
+        \cs_gset_protected:Npn \Url@FormatString
+          {
+            \@@_drain_ecglue:
+            \@@_orig_Url_FormatString:
+          }
+      }
+  }
+\@@_package_hook:nn { url } { \@@_patch_url_format: }
+%    \end{macrocode}
+%
 % \changes{v3.1.0}{2012/11/13}{取消 \tn{cprotect} 的外部宏限制。}
 % 当探测到 \pkg{cprotect} 宏包被引入时，则取消 \tn{cprotect} 宏的 \tn{outer} 定义。
 %    \begin{macrocode}


### PR DESCRIPTION
## Summary

- **#873** l3doc `\meta` / `\cs` 在 CJK 之后丢失 ecglue。根因：`\HD@target`（hypdoc.sty）通过 `\raisebox` 产出 0x0 hbox，遮蔽 `\tex_lastkern:D`，边界恢复链判定失败。修复：在 `\HD@target` 入口 save `\g_@@_last_node_tl`，调用结束后用 `\xeCJK_make_node:n` **replay** marker。
- **#880** `\url` 后 CJK 之间丢失 ecglue。根因：`\Url@FormatString` 用 `$\fam\z@ ... $` 进入 math 模式，marker kern 被整体吃掉。修复：在 `\Url@FormatString` 入口 **drain** marker 并直接补 `\l_@@_ecglue_skip`（`\url` 内容必为西文，CJK→西文方向边界总应是 ecglue，无需保留 marker 类型）。
- 同步更新 llmdoc：新增"边界恢复修复点选择矩阵"（按遮蔽节点类型决定修复位置）、"本地 TL usertree 同步"双步流程指南，与决策文档 `873-880-fixed-point-vs-default-narrowing.md`。

## 方案对比

曾考虑收窄 `\@@_recover_glue_whatsit:` 的 default 分支（仿 #831 的 `\g_@@_reset_color_pending_bool` 模式加 pending boolean gate），未采纳：

- #873 走 hbox else 分支，根本不进 `\@@_recover_glue_whatsit:`
- #880 在 math 模式里 marker 已被吃掉，更进不去
- **修复位置由"被遮蔽的节点类型"决定，不由 marker 类型决定**

收窄 default 分支是独立的"防御任意 whatsit 误触发"问题，应作单独 PR。

## Test plan

- [x] 新增回归测试 `xeCJK/testfiles/hypdoc-ecglue01.lvt`（2 用例，验证 `\HD@target` hbox 不吞 ecglue）
- [x] 新增回归测试 `xeCJK/testfiles/url-ecglue01.lvt`（3 用例，验证 `\url` 左侧 ecglue 存在 + 显式空格被吸收 + ASCII 上下文不回归）
- [x] 本地 `l3build check` 全过（在 `tlmgr --usermode update --all` + `fmtutil-user --byfmt xelatex` 同步后；详见 `llmdoc/reference/build-and-test.md` 的"本地 TL usertree 同步"节）
- [ ] CI 验证

## chore

closes #873 
closes #880 