### PR TITLE
fix(githooks): tag 更新也需 force-with-lease (pre-push inner push)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -78,13 +78,25 @@ while read -r local_ref local_sha remote_ref remote_sha; do
   else
     refspecs+=("${local_ref}:${remote_ref}")
     have_update=1
-    # 非快进 (远端有本地没有的 commit) ⟹ 普通 push 会被拒, 用户必然用了
-    # --force. INNER push 用 `--force-with-lease=<ref>:<remote_sha>` 精确镜像,
-    # 避免被拒.
-    if [ "$remote_sha" != "$zero" ] \
-       && ! git merge-base --is-ancestor "$remote_sha" "$local_sha" 2>/dev/null; then
-      force_lease_args+=("--force-with-lease=${remote_ref}:${remote_sha}")
-    fi
+    # 何时给 INNER push 加 `--force-with-lease=<ref>:<remote_sha>`:
+    #   • 分支 ref: 远端有本地没有的 commit (非快进) ⟹ outer 必然用了 --force.
+    #   • tag  ref: 远端 sha 与本地不同 ⟹ git 默认拒绝任何同名 tag 更新
+    #               ("already exists"), 不论能否 ff. outer 必然用了 --force.
+    # 用精确 lease (而非裸 --force-with-lease) 镜像 git 在 stdin 看到的远端 sha,
+    # 避免裸 lease 依赖 stale 跟踪引用造成误判.
+    case "$remote_ref" in
+      refs/tags/*)
+        if [ "$remote_sha" != "$zero" ] && [ "$remote_sha" != "$local_sha" ]; then
+          force_lease_args+=("--force-with-lease=${remote_ref}:${remote_sha}")
+        fi
+        ;;
+      *)
+        if [ "$remote_sha" != "$zero" ] \
+           && ! git merge-base --is-ancestor "$remote_sha" "$local_sha" 2>/dev/null; then
+          force_lease_args+=("--force-with-lease=${remote_ref}:${remote_sha}")
+        fi
+        ;;
+    esac
     # 当前 HEAD 分支被推送 ⟹ 候选 -u 目标
     if [ -n "$head_ref" ] && [ "$local_ref" = "$head_ref" ]; then
       head_branch_pushed=1


### PR DESCRIPTION
## 背景

PR #888 引入的 self-wrapping \`pre-push\` 在 INNER push 时,只对**分支 ref 非快进**的情况加 \`--force-with-lease=<ref>:<remote_sha>\`。tag refspec 不进这条 if。

但 git 对 tag 的语义是「默认拒绝任何同名 tag 更新」(不论能否 ff 都拒 \`already exists\`)。当 OUTER \`git push --force origin refs/tags/<tag>\` 起一次 force-push 移动 tag 时, INNER push 由于未带 force 标志, 直接被远端拒掉:

\`\`\`
! [rejected]          xeCJK-v3.10.0 -> xeCJK-v3.10.0 (already exists)
post-push: inner push failed (rc=1) — not watching CI.
\`\`\`

实测在尝试移动 \`xeCJK-v3.10.0\` tag 到当前 master HEAD (\`a9866f0b\`) 时撞上, 当时只能用 \`git push --force --no-verify\` 绕开。

## 改动

\`.githooks/pre-push\` 的「加 lease」逻辑按 \`remote_ref\` 拆成两路:

- **\`refs/tags/*\`**: 远端 sha 与本地 sha 不同 ⟹ 加 \`--force-with-lease=<ref>:<remote_sha>\`
- **其他 (分支)**: 远端非快进 ⟹ 加 lease (原行为不变)

注释同步说明两条路径的判定依据。

## Test plan

- [x] \`bash -n\` 语法校验通过
- [x] 本分支自身 push 跑通完整 self-wrap (这次 PR 创建即一次实战)
- [ ] 后续移动其他 tag 时验证: 直接 \`git push --force origin <tag>\` 不再需要 \`--no-verify\`