### PR TITLE
fix(ci): upload-ctan job 不 checkout inputs.tag

### DIFF
--- a/.github/workflows/release-ctan-upload.yml
+++ b/.github/workflows/release-ctan-upload.yml
@@ -255,7 +255,11 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-          ref: ${{ inputs.tag }}
+          # 这里**故意不 checkout inputs.tag**: upload-ctan job 需要
+          # build.lua / support/build-config.lua 的最新版本 (含 uploadconfig
+          # builder), 而 tag 指向的历史 commit 可能早于 release pipeline 接入,
+          # 那时 build.lua 还没 uploadconfig, l3build 会拿到空 author 而 abort.
+          # 实际的 zip 资产由下面 gh release download 拉, 与本次 checkout 无关.
 
       - name: Install TeX Live (minimal for l3build)
         timeout-minutes: 15

--- a/.github/workflows/release-ctan-upload.yml
+++ b/.github/workflows/release-ctan-upload.yml
@@ -314,12 +314,22 @@ jobs:
           ARGS+=(--email "${{ inputs.email }}")
           if [ "${{ inputs.dry_run }}" = "true" ]; then
             ARGS+=(--dry-run)
+            ANSWER=n   # 见下方注释
             echo "::notice::DRY-RUN mode: 不会真投递到 CTAN."
           else
+            ANSWER=y
             echo "::warning::LIVE mode: 正在投递到 CTAN."
           fi
           echo "l3build upload ${ARGS[*]}"
-          l3build upload "${ARGS[@]}"
+          # l3build 在 validate 成功后总会问 "Do you want to upload? [y/n]" —
+          # 即便带 --dry-run. 这是 l3build (TL 2026) 的设计 bug:
+          # l3build-upload.lua 顶层 `if options["dry-run"] then ctanupload = false end`
+          # 把 ctanupload 设为 false, 但随后 l3build-variables.lua 又跑
+          # `ctanupload = ctanupload or "ask"`, 用 `or` 会把 false 覆盖成
+          # "ask" — 没区分 nil 与 false. 结果 --dry-run 仍会等 stdin.
+          # 我们用 stdin 喂答案: dry-run 喂 n (走到 validate 后停止);
+          # live 模式喂 y (validate + 真上传).
+          printf '%s\n' "$ANSWER" | l3build upload "${ARGS[@]}"
 
       - name: Mark GH Release as latest (live mode only)
         if: inputs.dry_run == false


### PR DESCRIPTION
## Bug

[Run 28230099006](https://github.com/CTeX-org/ctex-kit/actions/runs/28230099006) 触发了 `release-ctan-upload.yml` 投递 `xeCJK-v3.10.0`, 在 `Run l3build upload` step 报错:

```
ctan-upload | author: ??
> .../l3build-upload.lua:322: The field author must contain Author name
```

l3build 拿到的 `uploadconfig.author` 是 nil, 但 `xeCJK/build.lua` 里明明写了:

```lua
uploadconfig = ctex_kit_uploadconfig {
  ...
  author = "Leo Liu; Qing Lee; Liam Huang",
  ...
}
```

## 根因

`upload-ctan` job 用 `ref: \${{ inputs.tag }}` checkout 到 GH Release tag 对应的历史 commit. 但 `xeCJK-v3.10.0` 指向 `a9866f0b`, 是 **#888 之后但 #894 之前** 的位置 —— 那时 `build.lua` 还没接入 `ctex_kit_uploadconfig` builder, 所以 l3build 加载到的 `uploadconfig` 是默认空表, author 字段不存在, 触发 mandatory missing error.

简言之: workflow 想用 master 上的 release pipeline 去发历史 tag 的产物, 但 checkout 到了不含 pipeline 接入的旧 commit.

## 修法

`upload-ctan` job 不再 checkout `inputs.tag`. 改为 checkout default branch (workflow_dispatch 默认 ref, 即 master). 这样:

- `build.lua` / `support/build-config.lua` 总是最新版 (含 builder 和 uploadconfig)
- zip 资产由 `gh release download` 拉取, 与 checkout 内容无关 —— 保持 \"公测 zip = CTAN zip\" 字节级一致的承诺
- 未来无论何时新加包到 release pipeline, 历史 tag 都能正常上 CTAN, 无需重打 tag

`prepare-announcement` job **仍 checkout inputs.tag**, 因为它要从那个版本的 `.dtx` 抽 `\\changes` 块作 LLM 输入材料. 这条不变.

## Test plan

- [ ] Merge 后重跑 [Run 28230099006](https://github.com/CTeX-org/ctex-kit/actions/runs/28230099006) 的同等触发: \`xeCJK-v3.10.0\` + dry_run=true
- [ ] \`upload-ctan\` job 跑通到 \`l3build upload --dry-run\` 完成, author 字段非空
- [ ] (可选) \`ctex-v2.6.0\` 也 dry-run 一遍验证
- [ ] PR #892 (zhlineskip 接入) 合并后第一个 zhlineskip-v\* tag 发布, 验证 release pipeline 端到端跑通