### PR TITLE
chore(ci): release-ctan-upload artifact actions 升 v4 → v7

### DIFF
--- a/.github/workflows/release-ctan-upload.yml
+++ b/.github/workflows/release-ctan-upload.yml
@@ -232,7 +232,7 @@ jobs:
           echo '```' >> $GITHUB_STEP_SUMMARY
 
       - name: Upload announcement artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: announcement
           path: announcement.md
@@ -273,7 +273,7 @@ jobs:
           repository: https://ctan.math.illinois.edu/systems/texlive/tlnet
 
       - name: Download announcement artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: announcement
           path: .


### PR DESCRIPTION
## 背景

[Run 28231833487](https://github.com/CTeX-org/ctex-kit/actions/runs/28231833487) 跑完 dry-run 验证后, 发现两条 step 触发 Node.js 20 deprecation warning:

```
##[warning]Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/upload-artifact@v4.
```

`actions/upload-artifact@v4` 和 `actions/download-artifact@v4` 都是 Node 20 时代的版本. GH 已经把默认 runtime 换成 Node 24, 仍能跑但有 warning, 后面会 EOL.

## 改动

`release-ctan-upload.yml` 的两个 artifact action 升到 v7:

- `actions/upload-artifact@v4` → `@v7` (latest v7.0.1)
- `actions/download-artifact@v4` → `@v7` (latest v7.0.0)

主版本号对齐, 与 `test.yml` 已使用的 `upload-artifact@v7` 风格一致.

## 风险面

v4 → v7 跨了多个主版本, 但我们用的功能 (打 zip + 读 zip) 不在 breaking 范围:

- v5 开始引入 immutable artifact (每条上传是独立 entry, 不能 append) — 我们一个 job 上传, 另一个 job 下载, 不 append, 无影响
- v6 切 Node 24
- v7 新增 direct upload (\`archive: false\`) — 我们没启用, 仍走默认 zip 路径
- download v8 配合 direct upload, 默认严格 hash check — 我们用 v7 避开

不升 `TeX-Live/setup-texlive-action@v4`: 它跑 Docker 不依赖 Node 20, 没 warning.

## Test plan

- [ ] Merge 后再跑一次 \`release-ctan-upload\` (xeCJK-v3.10.0 + dry_run=true), 确认 Node 20 warning 消失, artifact 上下传仍正常