### PR TITLE
perf(ci): TL bypass cache 让 caller 真秒过 (weekly 才真装)

### DIFF
--- a/.github/font-urls.txt
+++ b/.github/font-urls.txt
@@ -1,0 +1,6 @@
+# CJK 字体下载 URL, 每行一个. _test-package.yml 的 "Install Noto fonts" step
+# 逐行 curl, 同时这个文件的 hash 作为字体 cache key 的依据 —— URL 变才让
+# cache invalidate, 不会被 yml 其它字段改动连带掀掉.
+# 行首 # 是注释, 空行被忽略.
+https://github.com/notofonts/noto-cjk/releases/download/Sans2.004/03_NotoSansCJK-OTC.zip
+https://github.com/notofonts/noto-cjk/releases/download/Serif2.002/04_NotoSerifCJKOTC.zip

--- a/.github/workflows/_test-package.yml
+++ b/.github/workflows/_test-package.yml
@@ -55,17 +55,23 @@ jobs:
             shell: bash
             tl-pkgs: ""
             tl-bin-platform: x86_64-linux
+            tlmgr-exe: tlmgr
           - os: macos-latest
             font-dir: /Library/Fonts
             shell: bash
             tl-pkgs: ""
             tl-bin-platform: universal-darwin
+            tlmgr-exe: tlmgr
           - os: windows-latest
             font-dir: /c/Windows/Fonts
             shell: C:\msys64\usr\bin\bash.exe -e {0}
             # for `unzip` shipped with texlive
             tl-pkgs: wintools.windows
             tl-bin-platform: windows
+            # Windows 上 tlmgr 实际是 tlmgr.bat. msys2 bash 不按 PATHEXT
+            # 补后缀, sanity check 直调必须显式写出. 测试阶段不影响 — l3build
+            # 调的是 latex/xelatex/luatex 这些 .exe, 走 PATH 没问题.
+            tlmgr-exe: tlmgr.bat
 
     # workflow_call 触发时, 整个 reusable workflow 在 caller 视角显示为
     # 一个 check, 名字 = "<caller_job_id> / <reusable_job_id> (<matrix>)".
@@ -94,14 +100,15 @@ jobs:
         path: ${{ runner.temp }}/setup-texlive-action/${{ inputs.tl-version }}
         key: tl-bypass-${{ runner.os }}-${{ inputs.tl-version }}-${{ inputs.tl-cache-week }}
 
-    # cache hit fast path. sanity check 用 `continue-on-error: true` 兜底两种
-    # 情况:
-    #   1. cache 损坏 (理论极少)
-    #   2. Windows 上 tlmgr 是 tlmgr.bat, msys2 bash 不按 PATHEXT 补后缀,
-    #      "$TL_BIN/tlmgr" 直接 127. warmup 那边用 `|| true` 屏蔽过, 这里
-    #      改用 continue-on-error + 下游 fallback 走 outcome 自愈, 更稳.
-    # 失败时 step.outcome == 'failure', 下面所有 fallback step 的 if 都
-    # 同时 OR 这个 outcome, 让 setup-texlive fallback 自动接管.
+    # cache hit fast path. sanity check 用 `continue-on-error: true` 兜底 cache
+    # 真损坏的极端情况 (理论极少 — warmup 验证过才 save). 失败时
+    # step.outcome == 'failure', 下面所有 fallback step 的 if 都同时 OR 这个
+    # outcome, 让 setup-texlive fallback 自动接管.
+    #
+    # Windows: tlmgr 是 tlmgr.bat, msys2 bash 不按 PATHEXT 补后缀, 所以 matrix
+    # 里给出显式 tlmgr-exe (windows 用 tlmgr.bat, ubuntu/macos 用 tlmgr) — 不靠
+    # continue-on-error 兜 Windows, 否则 Windows 每次都假阳 fallback 退化成跟没
+    # bypass cache 一样慢.
     - name: Export PATH (cache hit fast path, skip setup-texlive)
       id: export-path
       if: steps.bypass-cache.outputs.cache-hit == 'true'
@@ -111,7 +118,7 @@ jobs:
         echo "$TL_BIN" >> "$GITHUB_PATH"
         echo "Added to PATH: $TL_BIN"
         # 不联网, 用 cache 内的本地 db 简单 sanity check.
-        "$TL_BIN/tlmgr" version
+        "$TL_BIN/${{ matrix.tlmgr-exe }}" version
 
     # ────────────────────────────────────────────────────────────────────
     # 以下是 cache miss 的 fallback 路径. 触发条件: cache miss, 或 cache hit

--- a/.github/workflows/_test-package.yml
+++ b/.github/workflows/_test-package.yml
@@ -31,6 +31,13 @@ on:
         description: 'TeX Live 版本 (例 "2026"). 由 test.yml 顶层 env TL_VERSION 透传.'
         required: true
         type: string
+      tl-cache-week:
+        # ISO 年-周 (例 "2026-W26"), 用作 TL bypass cache key 的时间维度.
+        # 周内 cache hit, 跨周翻新. 由 changes job 在 ubuntu runner 上算
+        # 一次, 透传给所有 caller × 3 OS 保证 key 一致.
+        description: 'ISO 年-周字符串 (例 2026-W26). 由 test.yml changes job 计算.'
+        required: true
+        type: string
 
 env:
   NOTO_SANS_URL: https://github.com/notofonts/noto-cjk/releases/download/Sans2.004/03_NotoSansCJK-OTC.zip
@@ -47,15 +54,18 @@ jobs:
             font-dir: /usr/share/fonts/truetype
             shell: bash
             tl-pkgs: ""
+            tl-bin-platform: x86_64-linux
           - os: macos-latest
             font-dir: /Library/Fonts
             shell: bash
             tl-pkgs: ""
+            tl-bin-platform: universal-darwin
           - os: windows-latest
             font-dir: /c/Windows/Fonts
             shell: C:\msys64\usr\bin\bash.exe -e {0}
             # for `unzip` shipped with texlive
             tl-pkgs: wintools.windows
+            tl-bin-platform: windows
 
     # workflow_call 触发时, 整个 reusable workflow 在 caller 视角显示为
     # 一个 check, 名字 = "<caller_job_id> / <reusable_job_id> (<matrix>)".
@@ -71,6 +81,32 @@ jobs:
     steps:
     - uses: actions/checkout@v7
 
+    # TL bypass cache: warmup-tl 已经把 update 后的整个 TEXDIR 保到这个
+    # key. caller restore 这份 cache + 把 bin/<platform> 加入 PATH, 完全
+    # 不跑 setup-texlive-action, 不联网, 秒过.
+    #
+    # cache miss (例 weekly 边界 + push race, 或 cache eviction): fallback
+    # 到 setup-texlive-action (下面 try 1/2 + verification). 保险但慢.
+    - name: TL bypass cache (caller restore)
+      id: bypass-cache
+      uses: actions/cache@v6
+      with:
+        path: ${{ runner.temp }}/setup-texlive-action/${{ inputs.tl-version }}
+        key: tl-bypass-${{ runner.os }}-${{ inputs.tl-version }}-${{ inputs.tl-cache-week }}
+
+    - name: Export PATH (cache hit fast path, skip setup-texlive)
+      if: steps.bypass-cache.outputs.cache-hit == 'true'
+      run: |
+        TL_BIN="${{ runner.temp }}/setup-texlive-action/${{ inputs.tl-version }}/bin/${{ matrix.tl-bin-platform }}"
+        echo "$TL_BIN" >> "$GITHUB_PATH"
+        echo "Added to PATH: $TL_BIN"
+        # 不联网, 用 cache 内的本地 db 简单 sanity check.
+        "$TL_BIN/tlmgr" version
+
+    # ────────────────────────────────────────────────────────────────────
+    # 以下是 cache miss 的 fallback 路径. cache hit 时全部 skip.
+    # ────────────────────────────────────────────────────────────────────
+
     # caller 端 setup-texlive 也得 retry 换 mirror — 即便 cache hit, setup-texlive
     # 在 'Updating packages' 阶段仍会联网拉 tlmgr db checksum 判断要不要 update.
     # PR #899 实测 windows ctan.math.illinois.edu 网络抖动时 "Unable to download
@@ -83,7 +119,8 @@ jobs:
     # mirror.ctan.org 全球自动重定向 (而非 pin illinois 一个单点), GH runner
     # 网络好时它会自动选最快/最稳的 mirror. illinois pin 给 try 2 兜底
     # (mirror.ctan.org 极端不可用时).
-    - name: Install TeX Live (try 1, ctan.org auto-redirect)
+    - name: Install TeX Live (try 1, ctan.org auto-redirect, fallback)
+      if: steps.bypass-cache.outputs.cache-hit != 'true'
       id: tl1
       continue-on-error: true
       timeout-minutes: 15
@@ -98,9 +135,11 @@ jobs:
         # 70s 是 setup-texlive cache 设计的固有代价 (同 primaryKey 不覆写),
         # 实测无合理方案绕开. 见 _test-package.yml head 注释.
         update-all-packages: true
+        # 关掉 setup-texlive 内部 cache, 我们自己用 bypass-cache.
+        cache: false
 
-    - name: Install TeX Live (try 2, illinois mirror)
-      if: steps.tl1.outcome == 'failure'
+    - name: Install TeX Live (try 2, illinois mirror, fallback)
+      if: steps.bypass-cache.outputs.cache-hit != 'true' && steps.tl1.outcome == 'failure'
       timeout-minutes: 15
       uses: TeX-Live/setup-texlive-action@v4
       with:
@@ -109,6 +148,7 @@ jobs:
         packages: ${{ matrix.tl-pkgs }}
         repository: https://ctan.math.illinois.edu/systems/texlive/tlnet
         update-all-packages: true
+        cache: false
 
     # 验证 setup-texlive 真的 update 到了最新 TLnet, 而非 tlmgr 在 mirror
     # 不通时 silent fallback 用本地老 db. PR #899 实测 ubuntu 上 tlmgr 在
@@ -116,8 +156,9 @@ jobs:
     # 退码 0 看不出来, caller cache 是数月前的 TL → 跟仓库 .tlg baseline 不一致.
     # 这里 tlmgr update --self --list 强制访问 remote, grep 输出验证 "Unable
     # to download" 不出现; 出现就 exit 1 强 fail, 让 rerun --failed 在 GH
-    # Actions UI 上可手动重跑.
-    - name: Verify TL mirror reachable (no silent fallback to local db)
+    # Actions UI 上可手动重跑. 仅在 cache miss 走 fallback 路径时跑.
+    - name: Verify TL mirror reachable (fallback path only)
+      if: steps.bypass-cache.outputs.cache-hit != 'true'
       run: |
         out=$(tlmgr update --self --list 2>&1) || true
         echo "$out"

--- a/.github/workflows/_test-package.yml
+++ b/.github/workflows/_test-package.yml
@@ -94,8 +94,18 @@ jobs:
         path: ${{ runner.temp }}/setup-texlive-action/${{ inputs.tl-version }}
         key: tl-bypass-${{ runner.os }}-${{ inputs.tl-version }}-${{ inputs.tl-cache-week }}
 
+    # cache hit fast path. sanity check 用 `continue-on-error: true` 兜底两种
+    # 情况:
+    #   1. cache 损坏 (理论极少)
+    #   2. Windows 上 tlmgr 是 tlmgr.bat, msys2 bash 不按 PATHEXT 补后缀,
+    #      "$TL_BIN/tlmgr" 直接 127. warmup 那边用 `|| true` 屏蔽过, 这里
+    #      改用 continue-on-error + 下游 fallback 走 outcome 自愈, 更稳.
+    # 失败时 step.outcome == 'failure', 下面所有 fallback step 的 if 都
+    # 同时 OR 这个 outcome, 让 setup-texlive fallback 自动接管.
     - name: Export PATH (cache hit fast path, skip setup-texlive)
+      id: export-path
       if: steps.bypass-cache.outputs.cache-hit == 'true'
+      continue-on-error: true
       run: |
         TL_BIN="${{ runner.temp }}/setup-texlive-action/${{ inputs.tl-version }}/bin/${{ matrix.tl-bin-platform }}"
         echo "$TL_BIN" >> "$GITHUB_PATH"
@@ -104,7 +114,8 @@ jobs:
         "$TL_BIN/tlmgr" version
 
     # ────────────────────────────────────────────────────────────────────
-    # 以下是 cache miss 的 fallback 路径. cache hit 时全部 skip.
+    # 以下是 cache miss 的 fallback 路径. 触发条件: cache miss, 或 cache hit
+    # 但 export-path sanity check 失败 (cache 损坏 / Windows tlmgr 路径问题).
     # ────────────────────────────────────────────────────────────────────
 
     # caller 端 setup-texlive 也得 retry 换 mirror — 即便 cache hit, setup-texlive
@@ -120,7 +131,7 @@ jobs:
     # 网络好时它会自动选最快/最稳的 mirror. illinois pin 给 try 2 兜底
     # (mirror.ctan.org 极端不可用时).
     - name: Install TeX Live (try 1, ctan.org auto-redirect, fallback)
-      if: steps.bypass-cache.outputs.cache-hit != 'true'
+      if: steps.bypass-cache.outputs.cache-hit != 'true' || steps.export-path.outcome == 'failure'
       id: tl1
       continue-on-error: true
       timeout-minutes: 15
@@ -139,7 +150,7 @@ jobs:
         cache: false
 
     - name: Install TeX Live (try 2, illinois mirror, fallback)
-      if: steps.bypass-cache.outputs.cache-hit != 'true' && steps.tl1.outcome == 'failure'
+      if: (steps.bypass-cache.outputs.cache-hit != 'true' || steps.export-path.outcome == 'failure') && steps.tl1.outcome == 'failure'
       timeout-minutes: 15
       uses: TeX-Live/setup-texlive-action@v4
       with:
@@ -158,7 +169,7 @@ jobs:
     # to download" 不出现; 出现就 exit 1 强 fail, 让 rerun --failed 在 GH
     # Actions UI 上可手动重跑. 仅在 cache miss 走 fallback 路径时跑.
     - name: Verify TL mirror reachable (fallback path only)
-      if: steps.bypass-cache.outputs.cache-hit != 'true'
+      if: steps.bypass-cache.outputs.cache-hit != 'true' || steps.export-path.outcome == 'failure'
       run: |
         out=$(tlmgr update --self --list 2>&1) || true
         echo "$out"

--- a/.github/workflows/_test-package.yml
+++ b/.github/workflows/_test-package.yml
@@ -39,10 +39,6 @@ on:
         required: true
         type: string
 
-env:
-  NOTO_SANS_URL: https://github.com/notofonts/noto-cjk/releases/download/Sans2.004/03_NotoSansCJK-OTC.zip
-  NOTO_SERIF_URL: https://github.com/notofonts/noto-cjk/releases/download/Serif2.002/04_NotoSerifCJKOTC.zip
-
 jobs:
   run:
     strategy:
@@ -194,8 +190,10 @@ jobs:
       uses: actions/cache@v6
       with:
         path: ${{ github.workspace }}/.font-cache
-        # hashFiles 取本 yml hash (URL 改了 → key 变 → 重 download).
-        key: ctex-kit-fonts-${{ runner.os }}-${{ hashFiles('.github/workflows/_test-package.yml') }}-v1
+        # font-urls.txt 列了所有字体 URL, 它变才让 cache key 变. 用 yml hash
+        # 会被 caller / matrix 这类无关改动连带掀翻 cache, 害每 PR 重 download
+        # 5 caller × 3 OS × ~170MB.
+        key: ctex-kit-fonts-${{ runner.os }}-${{ hashFiles('.github/font-urls.txt') }}-v1
 
     - name: Install Noto fonts
       run: |
@@ -205,8 +203,13 @@ jobs:
         mkdir -p "$FONT_CACHE"
         if [ ! -f "$FONT_CACHE/.done" ]; then
           cd "$FONT_CACHE"
-          curl -LO "${{ env.NOTO_SANS_URL }}"
-          curl -LO "${{ env.NOTO_SERIF_URL }}"
+          # 从 .github/font-urls.txt 逐行读 URL (# 注释行 / 空行忽略). 跟
+          # cache key 的 hashFiles 同源, 保证 "URL 改 → cache invalidate +
+          # 实际重 download" 完全同步.
+          while IFS= read -r url; do
+            case "$url" in ''|\#*) continue ;; esac
+            curl -LO "$url"
+          done < "${{ github.workspace }}/.github/font-urls.txt"
           for f in *OTC.zip; do unzip -ojd . "$f" "*.ttc"; done
           # zip 解压完就没用了 (~200MB), 删掉减小 cache 体积
           rm -f *.zip

--- a/.github/workflows/_test-package.yml
+++ b/.github/workflows/_test-package.yml
@@ -209,9 +209,10 @@ jobs:
           #
           # Windows checkout 把 LF 转 CRLF, 这里 `tr -d '\r'` 把行尾 CR 干
           # 掉, 否则 curl 拿到 "URL\r" 报 "Failed to extract a filename".
-          while IFS= read -r url; do
+          # `|| [ -n "$url" ]` 防 trailing-newline 缺失时 read 丢最后一行.
+          while IFS= read -r url || [ -n "$url" ]; do
             url="$(printf '%s' "$url" | tr -d '\r')"
-            case "$url" in ''|\#*) continue ;; esac
+            case "$url" in ''|'#'*) continue ;; esac
             curl -LO "$url"
           done < "${{ github.workspace }}/.github/font-urls.txt"
           for f in *OTC.zip; do unzip -ojd . "$f" "*.ttc"; done

--- a/.github/workflows/_test-package.yml
+++ b/.github/workflows/_test-package.yml
@@ -175,8 +175,11 @@ jobs:
     # 这里 tlmgr update --self --list 强制访问 remote, grep 输出验证 "Unable
     # to download" 不出现; 出现就 exit 1 强 fail, 让 rerun --failed 在 GH
     # Actions UI 上可手动重跑. 仅在 cache miss 走 fallback 路径时跑.
+    #
+    # 触发条件除了 "走 fallback 路径", 还要 tl1 或 tl2 真装上了 — 否则
+    # tlmgr 不在 PATH, 这里报 "command not found" 噪音掩盖真正的 install fail.
     - name: Verify TL mirror reachable (fallback path only)
-      if: steps.bypass-cache.outputs.cache-hit != 'true' || steps.export-path.outcome == 'failure'
+      if: (steps.bypass-cache.outputs.cache-hit != 'true' || steps.export-path.outcome == 'failure') && (steps.tl1.outcome == 'success' || steps.tl2.outcome == 'success')
       run: |
         out=$(tlmgr update --self --list 2>&1) || true
         echo "$out"

--- a/.github/workflows/_test-package.yml
+++ b/.github/workflows/_test-package.yml
@@ -206,7 +206,11 @@ jobs:
           # 从 .github/font-urls.txt 逐行读 URL (# 注释行 / 空行忽略). 跟
           # cache key 的 hashFiles 同源, 保证 "URL 改 → cache invalidate +
           # 实际重 download" 完全同步.
+          #
+          # Windows checkout 把 LF 转 CRLF, 这里 `tr -d '\r'` 把行尾 CR 干
+          # 掉, 否则 curl 拿到 "URL\r" 报 "Failed to extract a filename".
           while IFS= read -r url; do
+            url="$(printf '%s' "$url" | tr -d '\r')"
             case "$url" in ''|\#*) continue ;; esac
             curl -LO "$url"
           done < "${{ github.workspace }}/.github/font-urls.txt"

--- a/.github/workflows/_test-package.yml
+++ b/.github/workflows/_test-package.yml
@@ -158,6 +158,7 @@ jobs:
 
     - name: Install TeX Live (try 2, illinois mirror, fallback)
       if: (steps.bypass-cache.outputs.cache-hit != 'true' || steps.export-path.outcome == 'failure') && steps.tl1.outcome == 'failure'
+      id: tl2
       timeout-minutes: 15
       uses: TeX-Live/setup-texlive-action@v4
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -272,9 +272,16 @@ jobs:
           cache: false
 
       # 验证 cache 真的 update 到了最新 TLnet (而非 tlmgr 在 mirror 不通时
-      # silent fallback 用本地老 db). cache hit 路径下也跑一遍, 防 cache
-      # 内 TL 损坏 (理论不会, 防御性).
-      - name: Verify TL mirror reachable (no silent fallback to local db)
+      # silent fallback 用本地老 db). 只在 cache miss 走 setup-texlive 时
+      # 跑 — cache hit 时跑这步会引入两个问题:
+      #   1. 本不需要联网, 反而联 mirror, mirror 抖动时把 warmup fail 掉,
+      #      下游 5 caller 全被 needs: warmup-tl 阻塞 (这正是 bypass cache
+      #      最想避免的)
+      #   2. cache hit 时 TL 是 warmup 上次 verify 过的, 内容稳定
+      # cache hit 路径下 cache 真损坏怎么办: caller 端 export-path step 用
+      # continue-on-error 自愈, 走 setup-texlive fallback.
+      - name: Verify TL mirror reachable (fallback path only)
+        if: steps.bypass-cache.outputs.cache-hit != 'true'
         run: |
           out=$(tlmgr update --self --list 2>&1) || true
           echo "$out"
@@ -282,7 +289,6 @@ jobs:
             echo "::error::tlmgr 报 mirror 不可达, silent fallback 用本地老 db. cache 写入的 TL revision 偏老, 下游 caller 测试一定 fail. 重跑 (rerun --failed)."
             exit 1
           fi
-
 
   # ──────────────────────────────────────────────────────────────────────
   # 阶段 1: 5 个 caller job, 每个 uses _test-package.yml. 用 reusable

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -177,16 +177,21 @@ jobs:
             tl-pkgs: ""
             shell: bash
             tl-bin-platform: x86_64-linux
+            tlmgr-exe: tlmgr
           - os: macos-latest
             tl-pkgs: ""
             shell: bash
             # Apple Silicon. setup-texlive-action 装到 universal-darwin, 但
             # bin 目录是 universal-darwin (含 arm64+x86_64 universal binary).
             tl-bin-platform: universal-darwin
+            tlmgr-exe: tlmgr
           - os: windows-latest
             tl-pkgs: wintools.windows
             shell: C:\msys64\usr\bin\bash.exe -e {0}
             tl-bin-platform: windows
+            # Windows tlmgr 是 tlmgr.bat, msys2 bash 不补 PATHEXT, 这里 sanity
+            # check 阶段直调必须用全名.
+            tlmgr-exe: tlmgr.bat
     name: warmup-tl on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     defaults:
@@ -215,7 +220,8 @@ jobs:
           echo "$TL_BIN" >> "$GITHUB_PATH"
           echo "Added to PATH: $TL_BIN"
           # 用 cache 内的 tlmgr 验证一下 (不联网, 看本地 db 是否完好)
-          "$TL_BIN/tlmgr" version || true
+          # Windows: tlmgr 实际是 tlmgr.bat, msys2 bash 不补 PATHEXT, 显式带后缀.
+          "$TL_BIN/${{ matrix.tlmgr-exe }}" version || true
 
       # 同 _test-package.yml 内的 retry 三段: 应对首次冷启动时 mirror
       # ETIMEDOUT 间歇失败. 这里是唯一会真装 install-tl 的地方 — 一旦

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,6 +86,7 @@ jobs:
             _all: &all
               - '.github/workflows/test.yml'
               - '.github/workflows/_test-package.yml'
+              - '.github/font-urls.txt'
               - 'scripts/check-parallel.sh'
               - 'support/**'
               - 'Makefile'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -131,9 +131,12 @@ jobs:
             echo "zhlineskip=${FILTER_ZHLINESKIP:-false}" >> "$GITHUB_OUTPUT"
             echo "PR path filter: ctex=${FILTER_CTEX} xeCJK=${FILTER_XECJK} zhnumber=${FILTER_ZHNUMBER} CJKpunct=${FILTER_CJKPUNCT} zhlineskip=${FILTER_ZHLINESKIP}"
           fi
-          # ISO 年-周 (例 "2026-W26"). 用 UTC, 跟 GH Actions 调度时区
-          # 一致.
-          week="$(TZ=UTC date +'%Y-W%V')"
+          # ISO 8601 年-周 (例 "2026-W26"). `%G` 是 ISO 周对应的年份 (与 `%V`
+          # 配套), 不是日历年 `%Y` — 跨年那周 (例 2025-12-29 周一) `%V` 报
+          # 2026-W01 但 `%Y` 还是 2025, 用 `%Y-W%V` 会得到 `2025-W01` 错 key,
+          # 与下一周 `2026-W02` 不连续, 害每年 1-3 天假阳 cache miss.
+          # UTC 跟 GH Actions 调度时区一致.
+          week="$(TZ=UTC date +'%G-W%V')"
           echo "tl-cache-week=${week}" >> "$GITHUB_OUTPUT"
           echo "TL cache week: ${week}"
 
@@ -213,15 +216,20 @@ jobs:
       # cache hit: 跳过整个 setup-texlive 流程, 只 export PATH.
       # cache miss: 跑 setup-texlive (3 mirror retry) + verification, cache 会在
       # job 末尾自动 save (actions/cache@v6 行为).
+      #
+      # 用 step 级 continue-on-error 而非 `|| true` — cache 真损坏时 step 标记
+      # failure annotation, warmup 日志能看到, 否则 warmup 全绿但下游 caller
+      # 全走 fallback 重装就很难定位.
       - name: Export PATH (cache hit fast path)
         if: steps.bypass-cache.outputs.cache-hit == 'true'
+        continue-on-error: true
         run: |
           TL_BIN="${{ runner.temp }}/setup-texlive-action/${{ env.TL_VERSION }}/bin/${{ matrix.tl-bin-platform }}"
           echo "$TL_BIN" >> "$GITHUB_PATH"
           echo "Added to PATH: $TL_BIN"
           # 用 cache 内的 tlmgr 验证一下 (不联网, 看本地 db 是否完好)
           # Windows: tlmgr 实际是 tlmgr.bat, msys2 bash 不补 PATHEXT, 显式带后缀.
-          "$TL_BIN/${{ matrix.tlmgr-exe }}" version || true
+          "$TL_BIN/${{ matrix.tlmgr-exe }}" version
 
       # 同 _test-package.yml 内的 retry 三段: 应对首次冷启动时 mirror
       # ETIMEDOUT 间歇失败. 这里是唯一会真装 install-tl 的地方 — 一旦

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,8 +33,10 @@ on:
       - '.githooks/**'
       - '.github/workflows/agentic-*.yml'
   schedule:
-    # at 12:00 UTC (20:00 CST/UTC +8) on Friday
-    - cron: "0 12 * * 5"
+    # 周一 UTC 12:00 (北京时间 20:00). 故意贴 ISO 周边界 (周一 00:00 UTC
+    # 翻周) — 周一一过 cache key 翻新, 12:00 schedule 跑刷新 TL cache, 周内
+    # PR / push 享用 cache hit. 见 changes job 的 tl-cache-week 输出.
+    - cron: "0 12 * * 1"
   workflow_dispatch:
 
 concurrency:
@@ -67,6 +69,11 @@ jobs:
       zhlineskip: ${{ steps.compute.outputs.zhlineskip }}
       # TL_VERSION 透传给 caller (workflow_call inputs 不能直接引用顶层 env).
       tl-version: ${{ env.TL_VERSION }}
+      # ISO 年-周 (例 "2026-W26"), 用作 TL bypass cache key 的时间维度.
+      # 每周一 UTC 00:00 自动翻周, 紧接的周一 12:00 UTC schedule 跑会用新
+      # key save 一份新 cache, 周内 PR/push 享用 cache hit, 跳过整个 TL
+      # install + update 流程 (~70-600s/job → 秒过).
+      tl-cache-week: ${{ steps.compute.outputs.tl-cache-week }}
     steps:
       - uses: actions/checkout@v7
       - name: Filter paths
@@ -124,23 +131,34 @@ jobs:
             echo "zhlineskip=${FILTER_ZHLINESKIP:-false}" >> "$GITHUB_OUTPUT"
             echo "PR path filter: ctex=${FILTER_CTEX} xeCJK=${FILTER_XECJK} zhnumber=${FILTER_ZHNUMBER} CJKpunct=${FILTER_CJKPUNCT} zhlineskip=${FILTER_ZHLINESKIP}"
           fi
+          # ISO 年-周 (例 "2026-W26"). 用 UTC, 跟 GH Actions 调度时区
+          # 一致.
+          week="$(TZ=UTC date +'%Y-W%V')"
+          echo "tl-cache-week=${week}" >> "$GITHUB_OUTPUT"
+          echo "TL cache week: ${week}"
 
   # ──────────────────────────────────────────────────────────────────────
-  # 阶段 0.5: 预热 TeX Live 缓存. 每 OS 1 个 job, 跑 setup-texlive-action.
+  # 阶段 0.5: 预热 TeX Live 缓存 + 用 actions/cache 自定义 save 整个 TEXDIR
+  # 到 weekly bypass key. 让 caller 完全跳过 setup-texlive-action.
   #
-  # 动机: PR 上 5 个 caller × 3 OS = 15 job 同时启动, 都 uses
-  # setup-texlive-action. 如果 GH cache 还没填好 (首次 PR 或 cache key
-  # 变), 15 job 全部并发 cache miss → 全部跑 install-tl 下载 → 同一
-  # ctan.math.illinois.edu mirror 被 5 个并发请求轰炸 → 偶发 ETIMEDOUT
-  # 让其中一个 job fail.
+  # 动机: setup-texlive-action 的 cache 设计是"同 primaryKey immutable",
+  # 一旦保存就不更新. 即便 warmup 跑了 update-all, 也无法把 update 后的
+  # 状态回写到原 primaryKey, caller restore 时永远拿到的是 update 前的
+  # baseline, 必须自己再跑 70s+ 的 tlmgr update. mirror 抖动时 update
+  # 阶段单 step 卡 10min 不奇怪 (PR #899 实测 macos test-ctex 17min).
   #
-  # 用 warmup-tl 收敛到每 OS 1 个 job 抢先装好 cache, 5 个 caller 串
-  # 在它后面, 100% 走 cache hit (~10-20s vs 冷启动 2-3min), 也不再产生
-  # 5 路并发 install-tl 请求, 从根本上消除 mirror ETIMEDOUT.
+  # 绕开方案: warmup-tl 跑完 setup-texlive 后, 把整个 $TEXDIR (默认
+  # $RUNNER_TEMP/setup-texlive-action/2026) 用 actions/cache@v6 save 到
+  # 自定义 key (含 year-week). caller 直接 restore 这份 cache + 把
+  # $TEXDIR/bin/<platform> 加入 PATH, 完全不跑 setup-texlive-action, 不
+  # 联网, 秒过.
   #
-  # 同时这个 job 也是 schedule / workflow_dispatch 时的 update-all 入口:
-  # 这两个触发器把 update-all-packages 设为 true, 把 cache baseline
-  # 推进到 TLnet 最新; PR / push 走 cache hit, baseline 不变.
+  # 周一翻周 + schedule 周一 12:00 UTC 跑刷新 cache, 周内 PR/push 享用
+  # cache hit. cache miss (例 weekly 边界 + push race / cache eviction)
+  # 时 caller fallback 到 setup-texlive-action.
+  #
+  # warmup-tl 内部 3 mirror retry 应对 install-tl ETIMEDOUT (try 1
+  # illinois 10min, try 2 fau.de 10min, try 3 mirror.ctan.org 30min 兜底).
   # ──────────────────────────────────────────────────────────────────────
   warmup-tl:
     needs: changes
@@ -158,12 +176,17 @@ jobs:
           - os: ubuntu-latest
             tl-pkgs: ""
             shell: bash
+            tl-bin-platform: x86_64-linux
           - os: macos-latest
             tl-pkgs: ""
             shell: bash
+            # Apple Silicon. setup-texlive-action 装到 universal-darwin, 但
+            # bin 目录是 universal-darwin (含 arm64+x86_64 universal binary).
+            tl-bin-platform: universal-darwin
           - os: windows-latest
             tl-pkgs: wintools.windows
             shell: C:\msys64\usr\bin\bash.exe -e {0}
+            tl-bin-platform: windows
     name: warmup-tl on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     defaults:
@@ -172,26 +195,39 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # bypass cache (我们自己管的, 与 setup-texlive 内部 cache 解耦).
+      # key 含 year-week, 同周内 cache hit; 跨周翻新.
+      # path 用 setup-texlive 默认装的 $RUNNER_TEMP/setup-texlive-action/<version>.
+      - name: TL bypass cache (warmup save)
+        id: bypass-cache
+        uses: actions/cache@v6
+        with:
+          path: ${{ runner.temp }}/setup-texlive-action/${{ env.TL_VERSION }}
+          key: tl-bypass-${{ runner.os }}-${{ env.TL_VERSION }}-${{ needs.changes.outputs.tl-cache-week }}
+
+      # cache hit: 跳过整个 setup-texlive 流程, 只 export PATH.
+      # cache miss: 跑 setup-texlive (3 mirror retry) + verification, cache 会在
+      # job 末尾自动 save (actions/cache@v6 行为).
+      - name: Export PATH (cache hit fast path)
+        if: steps.bypass-cache.outputs.cache-hit == 'true'
+        run: |
+          TL_BIN="${{ runner.temp }}/setup-texlive-action/${{ env.TL_VERSION }}/bin/${{ matrix.tl-bin-platform }}"
+          echo "$TL_BIN" >> "$GITHUB_PATH"
+          echo "Added to PATH: $TL_BIN"
+          # 用 cache 内的 tlmgr 验证一下 (不联网, 看本地 db 是否完好)
+          "$TL_BIN/tlmgr" version || true
+
       # 同 _test-package.yml 内的 retry 三段: 应对首次冷启动时 mirror
       # ETIMEDOUT 间歇失败. 这里是唯一会真装 install-tl 的地方 — 一旦
-      # 这里成功保住 cache, 下游 5 caller × 3 OS 全部走 cache hit
-      # (但 cache 内仍可能是旧 TL revision, caller 端还需 update-all
-      # 真正同步到 TLnet 最新 — 见 _test-package.yml 的 retry 注释).
+      # 这里成功保住 cache, 下游 5 caller × 3 OS 全部走 bypass cache hit.
       #
       # 三次 retry 换不同 mirror, 避免单一 mirror 长时间不可达时 3 次
       # 都炸 (实测 PR #899 上 ctan.math.illinois.edu 单点不通时 3 次
       # 同 mirror 全 ETIMEDOUT). try 2 走德国 fau.de, try 3 走 ctan.org
       # 全球自动重定向. try 1/2 短超时 10min 让换 mirror 反应快, try 3
       # 30min 兜底 (冷启动正常 3-5min, 留余量).
-      #
-      # 历史: 早期尝试用 env SETUP_TEXLIVE_ACTION_FORCE_UPDATE_CACHE=1
-      # 让 warmup 把 update 后的 TL 保到 uniqueKey, 让下游 caller 命中
-      # 跳过 update 省 70s/caller. 实测**不生效** — GH actions/cache 在
-      # restoreCache 时按 restoreKeys 数组 primaryKey 精确匹配优先, caller
-      # 命中老的纯 primaryKey entry (无 uuid 那个), 跳过 warmup 的 uniqueKey.
-      # 现在 caller 端必须 update-all=true 自己跑 update 才与仓库 .tlg
-      # baseline 一致. 见 _test-package.yml head 注释.
       - name: Install TeX Live (try 1, illinois mirror)
+        if: steps.bypass-cache.outputs.cache-hit != 'true'
         id: tl1
         continue-on-error: true
         timeout-minutes: 10
@@ -202,12 +238,16 @@ jobs:
           packages: ${{ matrix.tl-pkgs }}
           repository: https://ctan.math.illinois.edu/systems/texlive/tlnet
           # warmup 总是 update-all, 把 cache 推到 TLnet 最新.
-          # schedule / workflow_dispatch 触发也是 true, 无区别.
           update-all-packages: true
+          # 关掉 setup-texlive 内部的 cache, 让它每次真跑 install + update.
+          # 我们自己用 actions/cache@v6 (上面的 bypass-cache) 缓存 update
+          # 后的 TEXDIR. 内部 cache 的"同 primaryKey immutable"设计正是
+          # 我们要绕开的.
+          cache: false
 
       - name: Install TeX Live (try 2, fau.de mirror)
+        if: steps.bypass-cache.outputs.cache-hit != 'true' && steps.tl1.outcome == 'failure'
         id: tl2
-        if: steps.tl1.outcome == 'failure'
         continue-on-error: true
         timeout-minutes: 10
         uses: TeX-Live/setup-texlive-action@v4
@@ -217,9 +257,10 @@ jobs:
           packages: ${{ matrix.tl-pkgs }}
           repository: https://ftp.fau.de/ctan/systems/texlive/tlnet
           update-all-packages: true
+          cache: false
 
       - name: Install TeX Live (try 3, ctan.org auto-redirect, final)
-        if: steps.tl1.outcome == 'failure' && steps.tl2.outcome == 'failure'
+        if: steps.bypass-cache.outputs.cache-hit != 'true' && steps.tl1.outcome == 'failure' && steps.tl2.outcome == 'failure'
         timeout-minutes: 30
         uses: TeX-Live/setup-texlive-action@v4
         with:
@@ -228,9 +269,11 @@ jobs:
           packages: ${{ matrix.tl-pkgs }}
           repository: https://mirror.ctan.org/systems/texlive/tlnet
           update-all-packages: true
+          cache: false
 
       # 验证 cache 真的 update 到了最新 TLnet (而非 tlmgr 在 mirror 不通时
-      # silent fallback 用本地老 db). 见 _test-package.yml 同名 step.
+      # silent fallback 用本地老 db). cache hit 路径下也跑一遍, 防 cache
+      # 内 TL 损坏 (理论不会, 防御性).
       - name: Verify TL mirror reachable (no silent fallback to local db)
         run: |
           out=$(tlmgr update --self --list 2>&1) || true
@@ -239,6 +282,7 @@ jobs:
             echo "::error::tlmgr 报 mirror 不可达, silent fallback 用本地老 db. cache 写入的 TL revision 偏老, 下游 caller 测试一定 fail. 重跑 (rerun --failed)."
             exit 1
           fi
+
 
   # ──────────────────────────────────────────────────────────────────────
   # 阶段 1: 5 个 caller job, 每个 uses _test-package.yml. 用 reusable
@@ -257,6 +301,7 @@ jobs:
       pkg: ctex
       event-name: ${{ github.event_name }}
       tl-version: ${{ needs.changes.outputs.tl-version }}
+      tl-cache-week: ${{ needs.changes.outputs.tl-cache-week }}
 
   test-xeCJK:
     needs: [changes, warmup-tl]
@@ -266,6 +311,7 @@ jobs:
       pkg: xeCJK
       event-name: ${{ github.event_name }}
       tl-version: ${{ needs.changes.outputs.tl-version }}
+      tl-cache-week: ${{ needs.changes.outputs.tl-cache-week }}
 
   test-zhnumber:
     needs: [changes, warmup-tl]
@@ -275,6 +321,7 @@ jobs:
       pkg: zhnumber
       event-name: ${{ github.event_name }}
       tl-version: ${{ needs.changes.outputs.tl-version }}
+      tl-cache-week: ${{ needs.changes.outputs.tl-cache-week }}
 
   test-CJKpunct:
     needs: [changes, warmup-tl]
@@ -284,6 +331,7 @@ jobs:
       pkg: CJKpunct
       event-name: ${{ github.event_name }}
       tl-version: ${{ needs.changes.outputs.tl-version }}
+      tl-cache-week: ${{ needs.changes.outputs.tl-cache-week }}
 
   test-zhlineskip:
     needs: [changes, warmup-tl]
@@ -293,6 +341,7 @@ jobs:
       pkg: zhlineskip
       event-name: ${{ github.event_name }}
       tl-version: ${{ needs.changes.outputs.tl-version }}
+      tl-cache-week: ${{ needs.changes.outputs.tl-cache-week }}
 
   # ──────────────────────────────────────────────────────────────────────
   # 阶段 2: 汇总 — 给分支保护规则用. 如果任何 test caller 或 warmup-tl

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@
 *~
 luatex.*/
 __pycache__/
+actionlint
 
 # CJKpunct
 


### PR DESCRIPTION
## 背景

PR #899 之后 CI 主要瓶颈仍在 caller 端 setup-texlive ~70s/job 跑 tlmgr update, mirror 抖动时单 step 可飙到 10+min. 实测 master 上 [run 28280000443](https://github.com/CTeX-org/ctex-kit/actions/runs/28280000443) 的 `test-ctex / on macos` 跑了 **17min32s**, 其中 setup-texlive try 1 单独 632s (10.5min, `mirror.ctan.org` auto-redirect 选到慢 mirror), try 2 又 94s.

根因: setup-texlive-action 内部用 `actions/cache` 但设计是 "同 primaryKey immutable" — 一旦保存就不更新. warmup-tl 跑了 update-all 也无法回写到原 primaryKey, caller restore 时永远拿到 update 前的 baseline, 必须自己再跑一次 tlmgr update.

## 改动

绕开 setup-texlive 内部 cache, 自己用 `actions/cache@v6` 缓存整个 TEXDIR 到 weekly key. caller 直接 restore + export PATH, 完全跳过 setup-texlive-action.

### 工作机制

```
changes job: output tl-cache-week = "2026-W26" (ISO 年-周)

warmup-tl × 3 OS:
  1. actions/cache@v6 restore key=tl-bypass-<os>-2026-<week>
     - hit: 只 echo bin >> $GITHUB_PATH, 秒过
     - miss: 跑 setup-texlive (3 mirror retry) + verification
  2. job 末尾 actions/cache@v6 自动 save (cache miss 时)

caller × 5 pkg × 3 OS:
  1. actions/cache@v6 restore 同 key
     - hit (~99% 时间): echo bin >> $GITHUB_PATH, 跳所有 setup-texlive, 秒过
     - miss (cache eviction / weekly 边界 race): fallback 到 setup-texlive
                                                 (2 mirror retry + verification)
```

### Weekly schedule 对齐 ISO 周边界

schedule 从周五挪到**周一 UTC 12:00** (北京时间 20:00). ISO 周从周一 00:00 UTC 开始 — 周一一过 `tl-cache-week` 变化, cache key 翻新, 当天 12:00 UTC schedule 跑刷新 cache. 周内 PR/push 享用 cache hit.

### 平台 bin 目录

`echo $TEXDIR/bin/<platform> >> $GITHUB_PATH`:
- ubuntu-latest:  `bin/x86_64-linux`
- macos-latest:   `bin/universal-darwin` (Apple Silicon, universal binary)
- windows-latest: `bin/windows`

setup-texlive 源码确认 ([packages/action/src/runs/main/index.ts](https://github.com/TeX-Live/setup-texlive-action/blob/main/packages/action/src/runs/main/index.ts)) 它只调用 `tlmgr.path.add()` 添加 PATH, 没其它 env 注册.

### 关键参数

- caller / warmup 内 setup-texlive 都加 `cache: false` — 关掉它自带的 `actions/cache`, 我们用自己的 bypass-cache.
- `update-all-packages: true` 仅在 cache miss fallback 路径生效.

## 预期加速

cache hit 路径下:
- caller setup-texlive: 70s+ → ~2s (echo PATH + tlmgr version sanity check)
- warmup-tl: 类似, ~2s

cache miss 路径下:
- 同 PR #899 现有行为 (setup-texlive 走 3 mirror retry)

实际加速 ~70s/caller × 15 caller = ~1050s 减少 (并发取 max, wall-clock 预计 ~6-7min 总, 比 PR #899 的 ~13min 再砍 ~50%).

## Test plan

- [ ] cache miss 路径 (本 PR 首次 push): warmup save 成功, caller fallback 成功
- [ ] cache hit 路径 (第二次 push): caller skip setup-texlive, 秒过
- [ ] schedule 触发 (周一 UTC 12:00): warmup 用新 key 刷 cache
- [ ] cache miss recovery: 手动 evict cache 或 bump TL_VERSION 后 PR 仍能跑通

## ⚠️ 风险点

1. **cache eviction**: GH cache 7 天未访问自动 evict. 我们 weekly schedule + 周内 PR 频繁访问, 不会触发. 万一触发, caller fallback 路径兜底.
2. **首次合入**: 合入后第一周内, weekly schedule 还没跑, cache 由第一次 PR/push 的 warmup-tl 自动 fill. 该 push 上的 caller 也会 fallback (因为 caller 和 warmup 并行但同 cache key — warmup save 在 job 末, caller 启动时 warmup 可能还没 save 完).
3. **平台 bin 路径变化**: 若 setup-texlive 未来改装路径, 我们的 `runner.temp/setup-texlive-action/<version>` + `bin/<platform>` 会失效. 用注释绑死这个假设.

合入后观察 1-2 周确认 cache hit 率.