### PR TITLE
perf(ci): ctex 拆 luatex 独立 job + Phase 2 configs 并行隔离, wall-clock 砍到 5m54s

### DIFF
--- a/.github/workflows/_test-package.yml
+++ b/.github/workflows/_test-package.yml
@@ -236,8 +236,12 @@ jobs:
         case "${{ inputs.pkg }}" in
           ctex)
             # ctex 默认跨 4 engine 跑 181 测试, 用并行 wrapper.
-            # wall-clock ~5-8min (串行旧法 ~13-17min).
+            # 实测 (PR #901): wall-clock 瓶颈是 luatex 单 engine ~8min,
+            # 其他三个加起来才 ~3min. 用 LUATEX_BUCKETS=2 把 luatex 切两桶
+            # 内部并行, 4 engine 并行总共 5 进程 (3+2), 4 vCPU 略超载但
+            # 大部分时间是 tex 启动 + I/O 等待, 实测加速明显.
             CONFIGS="test/config-cmap test/config-contrib test/config-ctxdoc" \
+            LUATEX_BUCKETS=2 \
               ../scripts/check-parallel.sh "$L3BUILD_EXTRA_OPTIONS" || {
               echo "::group::patch-health raw log"
               for f in build/check-test/config-ctxdoc/patch-health.log \

--- a/.github/workflows/_test-package.yml
+++ b/.github/workflows/_test-package.yml
@@ -38,6 +38,21 @@ on:
         description: 'ISO 年-周字符串 (例 2026-W26). 由 test.yml changes job 计算.'
         required: true
         type: string
+      engines:
+        # 仅 ctex 用. 空 = 跑全 4 engine + Phase 2 configs (单 caller 默认).
+        # 非空 = 只跑指定 engine 列表, 跳过 Phase 2 configs (用于拆 ctex 为
+        # test-ctex / test-ctex-luatex 两 job 时只跑各自的 engine 子集).
+        description: '可选 ENGINES 透传 (空 = 默认全 engine + configs).'
+        required: false
+        type: string
+        default: ''
+      luatex-buckets:
+        # 仅 ctex 用. luatex 单 engine 比其他三个加起来还慢一倍, 拆桶并行打平
+        # 瓶颈. 1 = 不拆桶. 拆 job 后 luatex 独占 runner 4 vCPU, 可设 4.
+        description: '可选 LUATEX_BUCKETS 透传 (1 = 不切桶).'
+        required: false
+        type: number
+        default: 1
 
 jobs:
   run:
@@ -237,21 +252,40 @@ jobs:
           ctex)
             # ctex 默认跨 4 engine 跑 181 测试, 用并行 wrapper.
             # 实测 (PR #901): wall-clock 瓶颈是 luatex 单 engine ~8min,
-            # 其他三个加起来才 ~3min. 用 LUATEX_BUCKETS=2 把 luatex 切两桶
-            # 内部并行, 4 engine 并行总共 5 进程 (3+2), 4 vCPU 略超载但
-            # 大部分时间是 tex 启动 + I/O 等待, 实测加速明显.
-            CONFIGS="test/config-cmap test/config-contrib test/config-ctxdoc" \
-            LUATEX_BUCKETS=2 \
-              ../scripts/check-parallel.sh "$L3BUILD_EXTRA_OPTIONS" || {
-              echo "::group::patch-health raw log"
-              for f in build/check-test/config-ctxdoc/patch-health.log \
-                       ../tmp/parallel-check/*/ctex/build/check/patch-health.log \
-                       build/check-*/patch-health.log; do
-                [ -f "$f" ] && { echo "=== $f ==="; cat "$f"; }
-              done
-              echo "::endgroup::"
-              exit 1
-            }
+            # 其他三个加起来才 ~3min. 拆 caller 后:
+            #   - inputs.engines 空: 跑全 4 engine + Phase 2 configs (单
+            #     caller 默认, 同旧行为)
+            #   - inputs.engines 非空: 只跑指定 engine, 跳 configs. test.yml
+            #     用此模式把 ctex 拆 test-ctex (3 engine) + test-ctex-luatex
+            #     (luatex only, LUATEX_BUCKETS=4), 两 job 同时跑, wall-clock
+            #     = max. configs (~44s) 跟 3 engine job 一起跑.
+            if [ -n "${{ inputs.engines }}" ]; then
+              ENGINES="${{ inputs.engines }}" \
+              LUATEX_BUCKETS="${{ inputs.luatex-buckets }}" \
+                ../scripts/check-parallel.sh "$L3BUILD_EXTRA_OPTIONS" || {
+                echo "::group::patch-health raw log"
+                for f in build/check-test/config-ctxdoc/patch-health.log \
+                         ../tmp/parallel-check/*/ctex/build/check/patch-health.log \
+                         build/check-*/patch-health.log; do
+                  [ -f "$f" ] && { echo "=== $f ==="; cat "$f"; }
+                done
+                echo "::endgroup::"
+                exit 1
+              }
+            else
+              CONFIGS="test/config-cmap test/config-contrib test/config-ctxdoc" \
+              LUATEX_BUCKETS="${{ inputs.luatex-buckets }}" \
+                ../scripts/check-parallel.sh "$L3BUILD_EXTRA_OPTIONS" || {
+                echo "::group::patch-health raw log"
+                for f in build/check-test/config-ctxdoc/patch-health.log \
+                         ../tmp/parallel-check/*/ctex/build/check/patch-health.log \
+                         build/check-*/patch-health.log; do
+                  [ -f "$f" ] && { echo "=== $f ==="; cat "$f"; }
+                done
+                echo "::endgroup::"
+                exit 1
+              }
+            fi
             ;;
           zhlineskip)
             # zhlineskip 失败时 dump 完整 .log 帮调试 (上游沿用风格).

--- a/.github/workflows/_test-package.yml
+++ b/.github/workflows/_test-package.yml
@@ -53,6 +53,14 @@ on:
         required: false
         type: number
         default: 1
+      configs:
+        # 仅 ctex 用. ctex Phase 2 跑 -c <config> 列表 (config-cmap /
+        # config-contrib / config-ctxdoc). 空 = 不跑 Phase 2. 拆 job 时
+        # configs 跟 3 engine job (test-ctex) 一起跑, luatex job 不跑 configs.
+        description: '可选 CONFIGS 透传 (空 = 不跑 Phase 2 configs).'
+        required: false
+        type: string
+        default: ''
 
 jobs:
   run:
@@ -250,42 +258,38 @@ jobs:
         set -x
         case "${{ inputs.pkg }}" in
           ctex)
-            # ctex 默认跨 4 engine 跑 181 测试, 用并行 wrapper.
-            # 实测 (PR #901): wall-clock 瓶颈是 luatex 单 engine ~8min,
-            # 其他三个加起来才 ~3min. 拆 caller 后:
-            #   - inputs.engines 空: 跑全 4 engine + Phase 2 configs (单
-            #     caller 默认, 同旧行为)
-            #   - inputs.engines 非空: 只跑指定 engine, 跳 configs. test.yml
-            #     用此模式把 ctex 拆 test-ctex (3 engine) + test-ctex-luatex
-            #     (luatex only, LUATEX_BUCKETS=4), 两 job 同时跑, wall-clock
-            #     = max. configs (~44s) 跟 3 engine job 一起跑.
-            if [ -n "${{ inputs.engines }}" ]; then
-              ENGINES="${{ inputs.engines }}" \
-              LUATEX_BUCKETS="${{ inputs.luatex-buckets }}" \
-                ../scripts/check-parallel.sh "$L3BUILD_EXTRA_OPTIONS" || {
-                echo "::group::patch-health raw log"
-                for f in build/check-test/config-ctxdoc/patch-health.log \
-                         ../tmp/parallel-check/*/ctex/build/check/patch-health.log \
-                         build/check-*/patch-health.log; do
-                  [ -f "$f" ] && { echo "=== $f ==="; cat "$f"; }
-                done
-                echo "::endgroup::"
-                exit 1
-              }
-            else
-              CONFIGS="test/config-cmap test/config-contrib test/config-ctxdoc" \
-              LUATEX_BUCKETS="${{ inputs.luatex-buckets }}" \
-                ../scripts/check-parallel.sh "$L3BUILD_EXTRA_OPTIONS" || {
-                echo "::group::patch-health raw log"
-                for f in build/check-test/config-ctxdoc/patch-health.log \
-                         ../tmp/parallel-check/*/ctex/build/check/patch-health.log \
-                         build/check-*/patch-health.log; do
-                  [ -f "$f" ] && { echo "=== $f ==="; cat "$f"; }
-                done
-                echo "::endgroup::"
-                exit 1
-              }
+            # ctex 跨 4 engine 跑 181 测试 + 3 个 -c configs (cmap / contrib /
+            # ctxdoc). 用并行 wrapper. 实测 (PR #901) luatex 单 engine ~8min
+            # 远慢于其他 3 个 (加起来 ~3min). PR #902 拆 caller:
+            #
+            #   单 caller 模式 (engines 空): 全 4 engine + 全 configs, 旧行为.
+            #   拆 job 模式: test.yml 的 caller 显式传 engines/configs/luatex-buckets:
+            #     - test-ctex:        engines="pdftex xetex uptex", 跑 configs
+            #     - test-ctex-luatex: engines="luatex", luatex-buckets=4, 不跑 configs
+            #
+            # 关键: ENGINES / CONFIGS / LUATEX_BUCKETS 都是 check-parallel.sh
+            # 读的 env. 这里写一次, 错误处理只一份, 避免 if/else 两分支漂移
+            # (bot review #902 抓到上一版 if 分支漏传 CONFIGS, Phase 2 静默丢).
+            ENGINES_ENV="${{ inputs.engines }}"
+            CONFIGS_ENV="${{ inputs.configs }}"
+            LUATEX_BUCKETS_ENV="${{ inputs.luatex-buckets }}"
+            # engines 空 = 单 caller 模式, 默认全 4 engine + 全 3 configs.
+            if [ -z "$ENGINES_ENV" ]; then
+              CONFIGS_ENV="test/config-cmap test/config-contrib test/config-ctxdoc"
             fi
+            ENGINES="$ENGINES_ENV" \
+            CONFIGS="$CONFIGS_ENV" \
+            LUATEX_BUCKETS="$LUATEX_BUCKETS_ENV" \
+              ../scripts/check-parallel.sh "$L3BUILD_EXTRA_OPTIONS" || {
+              echo "::group::patch-health raw log"
+              for f in build/check-test/config-ctxdoc/patch-health.log \
+                       ../tmp/parallel-check/*/ctex/build/check/patch-health.log \
+                       build/check-*/patch-health.log; do
+                [ -f "$f" ] && { echo "=== $f ==="; cat "$f"; }
+              done
+              echo "::endgroup::"
+              exit 1
+            }
             ;;
           zhlineskip)
             # zhlineskip 失败时 dump 完整 .log 帮调试 (上游沿用风格).

--- a/.github/workflows/_test-package.yml
+++ b/.github/workflows/_test-package.yml
@@ -282,9 +282,16 @@ jobs:
             LUATEX_BUCKETS="$LUATEX_BUCKETS_ENV" \
               ../scripts/check-parallel.sh "$L3BUILD_EXTRA_OPTIONS" || {
               echo "::group::patch-health raw log"
+              # 三种可能位置:
+              #   1. 单 caller 模式 Phase 2 在 pkg_dir 跑: build/check-*/patch-health.log
+              #   2. 拆 job 模式 Phase 2 在独立 workdir (PR #902 a420bfe1):
+              #      ../tmp/parallel-check/config-config-ctxdoc/ctex/build/check-test/config-ctxdoc/patch-health.log
+              #   3. 拆 job 模式 Phase 1 engine bucket (luatex 不跑 ctxdoc, 但留通用 glob 防未来其他 patch):
+              #      ../tmp/parallel-check/<engine|luatex-bN>/ctex/build/check/patch-health.log
               for f in build/check-test/config-ctxdoc/patch-health.log \
+                       build/check-*/patch-health.log \
                        ../tmp/parallel-check/*/ctex/build/check/patch-health.log \
-                       build/check-*/patch-health.log; do
+                       ../tmp/parallel-check/config-*/ctex/build/check-test/config-ctxdoc/patch-health.log; do
                 [ -f "$f" ] && { echo "=== $f ==="; cat "$f"; }
               done
               echo "::endgroup::"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -330,6 +330,7 @@ jobs:
       tl-version: ${{ needs.changes.outputs.tl-version }}
       tl-cache-week: ${{ needs.changes.outputs.tl-cache-week }}
       engines: pdftex xetex uptex
+      configs: test/config-cmap test/config-contrib test/config-ctxdoc
 
   test-ctex-luatex:
     needs: [changes, warmup-tl]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -314,6 +314,12 @@ jobs:
   # 5 个 caller 都 needs warmup-tl: cache 已被 warmup 填好, caller 内的
   # setup-texlive-action 100% 走 cache hit, 不再有 mirror ETIMEDOUT 风险.
   # ──────────────────────────────────────────────────────────────────────
+  # ctex 主测拆 2 job 并行: 实测 (PR #902) luatex 单 engine ~8min 远慢于
+  # 其他 3 engine 加起来 ~3min. 同一 caller 内开 5 进程 (3 engine + luatex
+  # 切 2 桶) 会 oversubscribe 4 vCPU 反而拖慢全体. 拆 job 后:
+  #   - test-ctex: pdftex/xetex/uptex 3 engine 并行 + Phase 2 configs
+  #   - test-ctex-luatex: luatex 切 4 桶并行, 独占 runner 4 vCPU
+  # 两 job 同时跑, wall-clock = max(两者), 都 ~3-4min, 整 run 进 6min 内.
   test-ctex:
     needs: [changes, warmup-tl]
     if: needs.changes.outputs.ctex == 'true'
@@ -323,6 +329,19 @@ jobs:
       event-name: ${{ github.event_name }}
       tl-version: ${{ needs.changes.outputs.tl-version }}
       tl-cache-week: ${{ needs.changes.outputs.tl-cache-week }}
+      engines: pdftex xetex uptex
+
+  test-ctex-luatex:
+    needs: [changes, warmup-tl]
+    if: needs.changes.outputs.ctex == 'true'
+    uses: ./.github/workflows/_test-package.yml
+    with:
+      pkg: ctex
+      event-name: ${{ github.event_name }}
+      tl-version: ${{ needs.changes.outputs.tl-version }}
+      tl-cache-week: ${{ needs.changes.outputs.tl-cache-week }}
+      engines: luatex
+      luatex-buckets: 4
 
   test-xeCJK:
     needs: [changes, warmup-tl]
@@ -371,22 +390,24 @@ jobs:
   # ──────────────────────────────────────────────────────────────────────
   test-result:
     if: ${{ !cancelled() }}
-    needs: [warmup-tl, test-ctex, test-xeCJK, test-zhnumber, test-CJKpunct, test-zhlineskip]
+    needs: [warmup-tl, test-ctex, test-ctex-luatex, test-xeCJK, test-zhnumber, test-CJKpunct, test-zhlineskip]
     runs-on: ubuntu-latest
     steps:
       - name: Verify all caller jobs (incl. warmup-tl) succeeded or were skipped
         env:
-          R_WARMUP:     ${{ needs.warmup-tl.result }}
-          R_CTEX:       ${{ needs.test-ctex.result }}
-          R_XECJK:      ${{ needs.test-xeCJK.result }}
-          R_ZHNUMBER:   ${{ needs.test-zhnumber.result }}
-          R_CJKPUNCT:   ${{ needs.test-CJKpunct.result }}
-          R_ZHLINESKIP: ${{ needs.test-zhlineskip.result }}
+          R_WARMUP:        ${{ needs.warmup-tl.result }}
+          R_CTEX:          ${{ needs.test-ctex.result }}
+          R_CTEX_LUATEX:   ${{ needs.test-ctex-luatex.result }}
+          R_XECJK:         ${{ needs.test-xeCJK.result }}
+          R_ZHNUMBER:      ${{ needs.test-zhnumber.result }}
+          R_CJKPUNCT:      ${{ needs.test-CJKpunct.result }}
+          R_ZHLINESKIP:    ${{ needs.test-zhlineskip.result }}
         run: |
           fail=0
           for nv in \
             "warmup-tl:$R_WARMUP" \
             "ctex:$R_CTEX" \
+            "ctex-luatex:$R_CTEX_LUATEX" \
             "xeCJK:$R_XECJK" \
             "zhnumber:$R_ZHNUMBER" \
             "CJKpunct:$R_CJKPUNCT" \

--- a/scripts/check-parallel.sh
+++ b/scripts/check-parallel.sh
@@ -196,21 +196,34 @@ for pid in $pid_list; do
   [ "$rc" -ne 0 ] && MAIN_FAIL=1
 done
 
-# Phase 2: -c configs 串行, 在原 pkg_dir 跑 (configs 不并行, 相对路径无忧).
+# Phase 2: -c configs 并行, 在原 pkg_dir 跑.
+# 每个 -c <config> 的 testdir 是 build/check-<configbasename>, 各自独立 dir,
+# 不会冲突. l3build 内部相对路径在 -c 模式下走 testdir/<config>, 也不会因为
+# 多 config 并行而搞乱 .tlg 对比. 实测 (PR #902) 3 个 config 串行 ~43s 是
+# wall-clock 超 6min 的最后一根稻草, 并行后压到最慢的单 config (~23s).
 CONFIG_FAIL=0
 config_exits=""
 if [ -n "$CONFIGS" ]; then
   echo ""
-  echo "==================== Phase 2: configs (串行: $CONFIGS) ===================="
+  echo "==================== Phase 2: configs (并行: $CONFIGS) ===================="
+  config_pids=""
+  pid_for_config=""    # "pid:config pid:config ..."
   for c in $CONFIGS; do
-    echo "--- config: $c ---"
-    if l3build check -c "$c" -q ${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"}; then
-      config_exits="$config_exits ${c}:0"
-    else
-      rc=$?
-      config_exits="$config_exits ${c}:${rc}"
-      CONFIG_FAIL=1
-    fi
+    (
+      l3build check -c "$c" -q ${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"} 2>&1 \
+        | awk -v prefix="[$c] " '{ print prefix $0; fflush() }'
+      exit "${PIPESTATUS[0]}"
+    ) &
+    pid=$!
+    config_pids="$config_pids $pid"
+    pid_for_config="$pid_for_config ${pid}:${c}"
+  done
+  for pid in $config_pids; do
+    wait "$pid"
+    rc=$?
+    c=$(echo "$pid_for_config" | tr ' ' '\n' | grep "^${pid}:" | cut -d: -f2)
+    config_exits="$config_exits ${c}:${rc}"
+    [ "$rc" -ne 0 ] && CONFIG_FAIL=1
   done
 fi
 

--- a/scripts/check-parallel.sh
+++ b/scripts/check-parallel.sh
@@ -196,11 +196,11 @@ for pid in $pid_list; do
   [ "$rc" -ne 0 ] && MAIN_FAIL=1
 done
 
-# Phase 2: -c configs 并行, 在原 pkg_dir 跑.
-# 每个 -c <config> 的 testdir 是 build/check-<configbasename>, 各自独立 dir,
-# 不会冲突. l3build 内部相对路径在 -c 模式下走 testdir/<config>, 也不会因为
-# 多 config 并行而搞乱 .tlg 对比. 实测 (PR #902) 3 个 config 串行 ~43s 是
-# wall-clock 超 6min 的最后一根稻草, 并行后压到最慢的单 config (~23s).
+# Phase 2: -c configs 并行, 各自独立 workdir.
+# 同 Phase 1 设计: 每个 config 在 work_root/config-<name>/<pkg> 的 git
+# snapshot 里跑, build/local/ 完全独立, 不会有多个 l3build 并发 cp installfiles
+# 到同一 build/local/ 的 race ("File exists" 警告; PR #902 实测).
+# Phase 1 跑串行 ~43s, 并行后 wall-clock = max(三 config) ≈ 23s.
 CONFIG_FAIL=0
 config_exits=""
 if [ -n "$CONFIGS" ]; then
@@ -209,7 +209,12 @@ if [ -n "$CONFIGS" ]; then
   config_pids=""
   pid_for_config=""    # "pid:config pid:config ..."
   for c in $CONFIGS; do
+    # config 名字含 '/' (例 "test/config-cmap"), workdir slot 用 basename 避免
+    # 路径分层. test/config-cmap -> config-cmap.
+    slot="$(basename "$c")"
+    workdir=$(prepare_workdir "config-${slot}")
     (
+      cd "$workdir"
       l3build check -c "$c" -q ${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"} 2>&1 \
         | awk -v prefix="[$c] " '{ print prefix $0; fflush() }'
       exit "${PIPESTATUS[0]}"

--- a/scripts/check-parallel.sh
+++ b/scripts/check-parallel.sh
@@ -90,14 +90,24 @@ TESTFILEDIR="${TESTFILEDIR:-./testfiles}"
 #   bucket_range <idx> <total>   # idx 从 1 到 total
 # 输出 "first last" (空格分隔). l3build --first/--last 按字母序选区间, 这跟
 # 它 globbing testfiledir/*.lvt 后 sort 的行为一致.
+# 空 testfiledir 或 N > 文件数等极端 case: 返回 "EMPTY", 调用方应跳过该桶.
 bucket_range() {
   local idx="$1" total="$2"
   local files all_count start_idx end_idx first last
   files=$(ls "${TESTFILEDIR}"/*.lvt 2>/dev/null | sort | awk -F/ '{n=$NF; sub(/\.lvt$/,"",n); print n}')
+  if [ -z "$files" ]; then
+    echo "EMPTY"
+    return
+  fi
   all_count=$(echo "$files" | wc -l)
   # 整数除法 + 余数分摊给前几个 bucket. idx=1..total.
   start_idx=$(( (idx - 1) * all_count / total + 1 ))
   end_idx=$(( idx * all_count / total ))
+  if [ "$start_idx" -gt "$end_idx" ]; then
+    # bucket 数比文件数还多, 当前桶分不到东西.
+    echo "EMPTY"
+    return
+  fi
   first=$(echo "$files" | sed -n "${start_idx}p")
   last=$(echo "$files" | sed -n "${end_idx}p")
   echo "$first" "$last"
@@ -158,6 +168,11 @@ for engine in $ENGINES; do
       slot="luatex-b${i}"
       workdir=$(prepare_workdir "$slot")
       range=$(cd "$workdir" && bucket_range "$i" "$LUATEX_BUCKETS")
+      if [ "$range" = "EMPTY" ]; then
+        echo "skip luatex/b${i}: empty bucket (LUATEX_BUCKETS > testfile count?)"
+        i=$((i + 1))
+        continue
+      fi
       first=${range% *}
       last=${range#* }
       label="luatex/b${i}"

--- a/scripts/check-parallel.sh
+++ b/scripts/check-parallel.sh
@@ -11,6 +11,9 @@
 # 用法 (在 ctex/ 等包目录内执行):
 #   ENGINES="pdftex xetex luatex uptex"
 #   CONFIGS="test/config-cmap test/config-contrib test/config-ctxdoc"
+#   LUATEX_BUCKETS=2    # 可选: luatex 内部再切 N 桶 (--first/--last)
+#                       # 并行, 用于打平 luatex 远慢于其他 engine 的瓶颈.
+#                       # 默认 1 (不切桶).
 #   ../scripts/check-parallel.sh [extra-l3build-args...]
 #
 # bash 兼容: 不依赖 bash 4+ 特性 (declare -A 等). macOS 自带 bash 3.2 可跑.
@@ -18,6 +21,7 @@ set -uo pipefail
 
 ENGINES="${ENGINES:-pdftex xetex luatex uptex}"
 CONFIGS="${CONFIGS:-}"
+LUATEX_BUCKETS="${LUATEX_BUCKETS:-1}"
 # 用数组保 EXTRA_ARGS, 避免单字符串模式下 word splitting 出错 (例如未来
 # 有用户传 --first foo 这种带空格的参数). bash 3.2 安全: 不依赖 4+ 特性.
 EXTRA_ARGS=("$@")
@@ -78,46 +82,102 @@ CHECKDEPS=$(awk '/^checkdeps/,/}/ {
 # 末尾 dofile. 即使 checkdeps 没列也必须 cp.
 SIBLING_ALWAYS="support"
 
+# 从 build.lua 抠 testfiledir (默认 "./testfiles"). 用于 luatex bucket split.
+TESTFILEDIR=$(awk -F'"' '/^[[:space:]]*testfiledir[[:space:]]*=/ {print $2; exit}' build.lua)
+TESTFILEDIR="${TESTFILEDIR:-./testfiles}"
+
+# bucket-<idx>-of-<N> 的 first/last test 名字 (按字母序). 调用约定:
+#   bucket_range <idx> <total>   # idx 从 1 到 total
+# 输出 "first last" (空格分隔). l3build --first/--last 按字母序选区间, 这跟
+# 它 globbing testfiledir/*.lvt 后 sort 的行为一致.
+bucket_range() {
+  local idx="$1" total="$2"
+  local files all_count start_idx end_idx first last
+  files=$(ls "${TESTFILEDIR}"/*.lvt 2>/dev/null | sort | awk -F/ '{n=$NF; sub(/\.lvt$/,"",n); print n}')
+  all_count=$(echo "$files" | wc -l)
+  # 整数除法 + 余数分摊给前几个 bucket. idx=1..total.
+  start_idx=$(( (idx - 1) * all_count / total + 1 ))
+  end_idx=$(( idx * all_count / total ))
+  first=$(echo "$files" | sed -n "${start_idx}p")
+  last=$(echo "$files" | sed -n "${end_idx}p")
+  echo "$first" "$last"
+}
+
 # Phase 1: 主测多 engine 并行
-echo "==================== Phase 1: 主测 (并行 engines: $ENGINES) ===================="
+PHASE1_DESC="并行 engines: $ENGINES"
+if [ "$LUATEX_BUCKETS" -gt 1 ] && echo "$ENGINES" | grep -qw luatex; then
+  PHASE1_DESC="$PHASE1_DESC; luatex 切 ${LUATEX_BUCKETS} 桶"
+fi
+echo "==================== Phase 1: 主测 ($PHASE1_DESC) ===================="
 
-# 为每个 engine 准备一个独立子工作目录, 后台跑.
-declare_pids() { :; }   # no-op marker
-pid_list=""              # space-separated; 用字符串避免 declare -A
-engine_for_pid=""        # "pid:engine pid:engine ..." 格式
-exit_for_engine=""       # "engine:rc engine:rc ..."
+# 为每个 engine (或 luatex bucket) 准备独立子工作目录, 后台跑.
+# 用字符串列表保留 pid / label / rc 映射, 避免 declare -A (bash 3.2).
+pid_list=""              # space-separated pids
+label_for_pid=""         # "pid:label pid:label ..."
+exit_for_label=""        # "label:rc label:rc ..."
 
-for engine in $ENGINES; do
-  engine_workdir="${work_root}/${engine}/${pkg_name}"
-  snapshot_pkg "$engine_workdir"
-  for dep in $CHECKDEPS; do
-    snapshot_dep "$dep" "${work_root}/${engine}"
-  done
-  for sib in $SIBLING_ALWAYS; do
-    snapshot_dep "$sib" "${work_root}/${engine}"
-  done
-
+spawn_check() {
+  # spawn_check <label> <workdir> [extra l3build args...]
+  local label="$1" workdir="$2"
+  shift 2
+  local extra=("$@")
   (
-    cd "$engine_workdir"
+    cd "$workdir"
     # bash 3.2 安全: 空数组用 ${arr[@]+"${arr[@]}"} 形式避免 set -u 炸.
     # 用 awk 而非 sed -u 加前缀: awk 默认按行刷, 跨平台 (sed -u 是 GNU 扩展,
     # windows git bash 的 sed 不支持).
-    l3build check -e "${engine}" -q ${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"} 2>&1 \
-      | awk -v prefix="[${engine}] " '{ print prefix $0; fflush() }'
+    l3build check -q ${extra[@]+"${extra[@]}"} ${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"} 2>&1 \
+      | awk -v prefix="[${label}] " '{ print prefix $0; fflush() }'
     exit "${PIPESTATUS[0]}"
   ) &
-  pid=$!
+  local pid=$!
   pid_list="$pid_list $pid"
-  engine_for_pid="$engine_for_pid ${pid}:${engine}"
+  label_for_pid="$label_for_pid ${pid}:${label}"
+}
+
+prepare_workdir() {
+  # prepare_workdir <slot>  — slot 是 work_root 下的子目录名 (engine 或 engine-bucketK).
+  local slot="$1"
+  local workdir="${work_root}/${slot}/${pkg_name}"
+  snapshot_pkg "$workdir"
+  local dep
+  for dep in $CHECKDEPS; do
+    snapshot_dep "$dep" "${work_root}/${slot}"
+  done
+  for dep in $SIBLING_ALWAYS; do
+    snapshot_dep "$dep" "${work_root}/${slot}"
+  done
+  echo "$workdir"
+}
+
+for engine in $ENGINES; do
+  if [ "$engine" = "luatex" ] && [ "$LUATEX_BUCKETS" -gt 1 ]; then
+    # luatex 切桶: 各桶独立 workdir, 用 --first/--last 切区间.
+    i=1
+    while [ "$i" -le "$LUATEX_BUCKETS" ]; do
+      slot="luatex-b${i}"
+      workdir=$(prepare_workdir "$slot")
+      range=$(cd "$workdir" && bucket_range "$i" "$LUATEX_BUCKETS")
+      first=${range% *}
+      last=${range#* }
+      label="luatex/b${i}"
+      echo "spawn ${label}: --first ${first} --last ${last}"
+      spawn_check "$label" "$workdir" -e luatex --first "$first" --last "$last"
+      i=$((i + 1))
+    done
+  else
+    workdir=$(prepare_workdir "$engine")
+    spawn_check "$engine" "$workdir" -e "$engine"
+  fi
 done
 
 MAIN_FAIL=0
 for pid in $pid_list; do
   wait "$pid"
   rc=$?
-  # 从 engine_for_pid 找回对应 engine
-  engine=$(echo "$engine_for_pid" | tr ' ' '\n' | grep "^${pid}:" | cut -d: -f2)
-  exit_for_engine="$exit_for_engine ${engine}:${rc}"
+  # 从 label_for_pid 找回对应 label
+  label=$(echo "$label_for_pid" | tr ' ' '\n' | grep "^${pid}:" | cut -d: -f2)
+  exit_for_label="$exit_for_label ${label}:${rc}"
   [ "$rc" -ne 0 ] && MAIN_FAIL=1
 done
 
@@ -142,14 +202,14 @@ fi
 # 汇总
 echo ""
 echo "==================== check-parallel summary ===================="
-echo "Phase 1 (main test, parallel by engine):"
-for entry in $exit_for_engine; do
-  engine="${entry%:*}"
+echo "Phase 1 (main test, parallel):"
+for entry in $exit_for_label; do
+  label="${entry%:*}"
   rc="${entry#*:}"
   if [ "$rc" -eq 0 ]; then
-    echo "  ✓ ${engine}"
+    echo "  ✓ ${label}"
   else
-    echo "  ✗ ${engine} (rc=${rc})"
+    echo "  ✗ ${label} (rc=${rc})"
   fi
 done
 if [ -n "$CONFIGS" ]; then


### PR DESCRIPTION
## 背景

PR #901 把 caller TL setup 砍到 ~2s 后, ctex 测试 wall-clock 完全被 Phase 1 (engine 并行) 内单 engine 串行主导. 实测 master `9395664a`:

| Engine  | Windows | 备注 |
|---------|---------|------|
| pdftex  | 2m56s   |      |
| xetex   | 3m50s   |      |
| uptex   | 2m42s   |      |
| **luatex** | **8m18s** | 一个 engine 比其余三个加起来还慢 |

整 run wall-clock = **10m58s**, 由 test-ctex/windows 10m08s 决定.

## 迭代历程

| Commit | 改动 | wall-clock | 现象 |
|--------|------|-----------|------|
| baseline (#901) | — | 10m58s | luatex 主导 |
| `fb76a4d9` `a831c0e3` | 单 caller LUATEX_BUCKETS=2 | 8m39s | 5 进程 vs 4 vCPU oversubscribe, 全体被拖慢 |
| `c37a3c6c` | 拆 test-ctex / test-ctex-luatex, luatex 切 4 桶 | 5m14s | **Phase 2 configs 漏传 CONFIGS 静默丢失** (bot review #902 抓到) |
| `03321d39` | 修 CONFIGS 漏传 (统一 ctex case 单流程) | 6m05s | Phase 2 回来了, 但串行 43s 让 wall-clock 涨破 6min |
| `e91c947b` | Phase 2 改并行 | 5m19s | **存在 build/local/ race**: ubuntu File exists, windows File not found × 11 (测试碰巧幂等过, bot 也预警了) |
| `a420bfe1` | Phase 2 每 config 独立 workdir | **5m54s** | race 完全消失, 0 个 File exists / not found 警告 |
| 还有: `c5999ad2` bucket 空桶防御, 不影响 wall-clock | | | |

## 最终方案

### `scripts/check-parallel.sh`
- 新增 `LUATEX_BUCKETS` env (默认 1 = 旧行为). `>1` 时 luatex 按 testfiledir 字母序均匀切 N 桶, 各桶独立 workdir + `l3build --first/--last` 范围, 与其他 engine 一起后台并行
- 字母序切分跟 l3build 内部 globbing sort 同源, testfile 增删自动重分布
- `bucket_range` 空 testfiledir / 空桶防御 (返回 "EMPTY", 调用方跳过)
- Phase 2 configs 改并行, 每个 config 独立 workdir (避免 build/local/ race)
- 重构: 提取 `spawn_check` / `prepare_workdir` 统一 Phase 1 / Phase 2 隔离模式

### `.github/workflows/_test-package.yml`
新增三个 optional inputs:
- `engines`: 透传 ENGINES (空 = 全 4 engine + 默认 configs, 旧行为)
- `configs`: 透传 CONFIGS (空 = 不跑 Phase 2 configs)
- `luatex-buckets`: 透传 LUATEX_BUCKETS

ctex case 统一为"先收集 env, 再调一次 check-parallel + 一份错误处理", 消除 if/else 分支漂移风险.

### `.github/workflows/test.yml`
- `test-ctex`: pdftex + xetex + uptex + Phase 2 configs
  ```yaml
  engines: pdftex xetex uptex
  configs: test/config-cmap test/config-contrib test/config-ctxdoc
  ```
- `test-ctex-luatex`: 仅 luatex, `LUATEX_BUCKETS=4` 独占 runner 4 vCPU 切桶并行
- `test-result` needs 加 `test-ctex-luatex` + 校验列表加 `ctex-luatex:$R_CTEX_LUATEX`

两 job 共享 `if: needs.changes.outputs.ctex == 'true'`, 永远同步触发同步跳过. ctex path-filter 已包含 `xeCJK/**` / `zhnumber/**`, 改 dep 也会同时启两个 job. checkdeps 由 `snapshot_dep` 自包含, 不依赖 test-xeCJK / test-zhnumber 先跑.

## 最终性能 (commit `a420bfe1` run `28283924391`)

整 run wall-clock = **5m54s** ✅ (目标 ≤ 6min)

| Job | Windows | Ubuntu | macOS |
|---|---|---|---|
| test-ctex (3 engine + 3 configs) | 5m05s | ~ | ~ |
| test-ctex-luatex (4 bucket luatex) | 2m59s | 2m38s | 2m16s |

Phase 2 三个 config 并行后 wall-clock = max(三 config) ≈ 30s (windows), 从串行 43s 略省.

## Test plan

- [x] CI 实测 wall-clock = **5m54s** ≤ 6min
- [x] luatex 4 桶 baseline 对齐 — l3build `--first`/`--last` 跟内部 sort 同源, 全 success
- [x] Phase 2 三 config 全跑了 (cmap / contrib / ctxdoc patch-health 都执行)
- [x] build/local/ race 彻底消失 (windows / ubuntu 日志零警告, vs `e91c947b` 实测的 race)
- [x] 拆 job 依赖关系正确: ctex / xeCJK / zhnumber path-filter 都触发两个 job
- [x] 单 caller 模式向后兼容 (engines 空时自动注入默认 configs)