### PR TITLE
fix(ci): tl_packages 加 inconsolata 修 zhlineskip release typeset 失败

### DIFF
--- a/.github/tl_packages
+++ b/.github/tl_packages
@@ -101,6 +101,7 @@ hologo
 hycolor
 hypdoc
 hyperref
+inconsolata
 infwarerr
 intcalc
 ipaex


### PR DESCRIPTION
## 背景

#892 刚 squash merge, 打了 \`zhlineskip-v1.0f\` tag 触发 release.yml — 直接炸:

\`\`\`
! Package fontspec Error:
(fontspec)                The font "Inconsolatazi4-Regular" cannot be found;
\`\`\`

[Failed run](https://github.com/CTeX-org/ctex-kit/actions/runs/28284878972/job/83807021063)

## 根因

\`zhlineskip.dtx\` 的 driver 部分:

\`\`\`latex
\setmonofont{Inconsolatazi4}[
  Extension         = .otf,
  ...
]
\`\`\`

但 \`.github/tl_packages\` 里没有 \`inconsolata\` 包. xeCJK 用的是 TeX Gyre Cursor (TL 自带), ctex 没定制 mono 字体, 所以历史上谁都没踩这洞.

## 为什么 #892 CI 全 27 pass 但 release 才炸?

\`l3build check\` 只跑 .lvt 测试, 不 typeset 手册. release.yml 跑的 \`l3build ctan\` 才会 typeset \`zhlineskip.pdf\` — typeset 才碰 driver 部分的 \`\setmonofont{Inconsolatazi4}\`.

\`docinit_hook\` 下载了 Noto CJK 但漏了 Inconsolatazi4 (TL 自带, 装 \`inconsolata\` 包即可, 不必 curl).

## 修法

\`.github/tl_packages\` extra 段加一行 \`inconsolata\`. 其他包不受影响, 下次推 zhlineskip tag 会用上.

## /cc @myhsia

明子哥, 你之前本地 \`l3build upload\` ([这条评论的 log](https://github.com/CTeX-org/ctex-kit/pull/892#issuecomment-4807769266)) 没炸是因为你 mac 上有 inconsolata. 但 CI runner 是裸的, 得显式装. 下次重构记得把 \`docinit_hook\` 用到的所有字体都验证一遍 CI 装不装得起来 (或者抠出来跟 \`tl_packages\` 比一下) — DocStrip 重写省了你 700 行的 .tex, 但代价是 release pipeline 不再帮你 typeset 检查, .lvt 测试也 cover 不到 driver 部分 😅

下个 zhlineskip release tag 推 (你想发就发, 我已经把 v1.0f 的 GH Release 失败状态留着) 就能验证修好了.

## Test plan

- [ ] CI 上 \`test-zhlineskip\` 全 pass (跟原来一样, l3build check 不 typeset)
- [ ] 后续推 zhlineskip-v1.0g 或者 retry tag, release.yml 不再炸 fontspec