### PR TITLE
refactor(zhlineskip): CJK 字体对齐 xeCJK + release 工作流接入 TL bypass cache

### DIFF
--- a/.github/workflows/release-ctan-upload.yml
+++ b/.github/workflows/release-ctan-upload.yml
@@ -36,6 +36,11 @@ on:
 permissions:
   contents: write
 
+env:
+  # 跟 test.yml 顶层 env 保持一致, 复用 PR #901 weekly bypass cache (key 含
+  # TL_VERSION). 年度 TL 升级只需改这一处 (test.yml / release.yml 同步).
+  TL_VERSION: '2026'
+
 jobs:
   # ── 阶段 A: 生成英文 announcement ──────────────────────────────────────
   prepare-announcement:
@@ -268,16 +273,48 @@ jobs:
           # 那时 build.lua 还没 uploadconfig, l3build 会拿到空 author 而 abort.
           # 实际的 zip 资产由下面 gh release download 拉, 与本次 checkout 无关.
 
-      - name: Install TeX Live (minimal for l3build)
+      # PR #901 weekly bypass cache, 跟 test.yml warmup-tl / release.yml 共享同
+      # 一个 key (tl-bypass-Linux-2026-<ISO 周>). cache 内是全套 tl_packages 而
+      # 不只是 l3build + luatex, 但 restore + PATH export ~10s 还是比 setup-
+      # texlive 真装 minimal (~30s) 快, 且不依赖 mirror 通畅.
+      - name: Compute TL cache week
+        id: tlcache
+        run: |
+          week="$(TZ=UTC date +'%G-W%V')"
+          echo "week=${week}" >> "$GITHUB_OUTPUT"
+          echo "TL cache week: ${week}"
+
+      - name: TL bypass cache (restore)
+        id: bypass-cache
+        uses: actions/cache@v6
+        with:
+          path: ${{ runner.temp }}/setup-texlive-action/${{ env.TL_VERSION }}
+          key: tl-bypass-${{ runner.os }}-${{ env.TL_VERSION }}-${{ steps.tlcache.outputs.week }}
+
+      - name: Export PATH (cache hit fast path)
+        id: export-path
+        if: steps.bypass-cache.outputs.cache-hit == 'true'
+        continue-on-error: true
+        run: |
+          TL_BIN="${{ runner.temp }}/setup-texlive-action/${{ env.TL_VERSION }}/bin/x86_64-linux"
+          echo "$TL_BIN" >> "$GITHUB_PATH"
+          echo "Added to PATH: $TL_BIN"
+          "$TL_BIN/tlmgr" version
+
+      - name: Install TeX Live (minimal for l3build, fallback)
+        if: steps.bypass-cache.outputs.cache-hit != 'true' || steps.export-path.outcome == 'failure'
         timeout-minutes: 15
         uses: TeX-Live/setup-texlive-action@v4
         with:
+          version: ${{ env.TL_VERSION }}
           # l3build upload 只需要 l3build script 本身 + LuaTeX (用于跑 build.lua).
           # 全套字体 / Unihan / makeindex 都不需要 — 我们不重新打 zip.
           packages: |
             l3build
             luatex
           repository: https://ctan.math.illinois.edu/systems/texlive/tlnet
+          # 关闭 setup-texlive 内部 cache, 我们自己用 bypass-cache.
+          cache: false
 
       - name: Download announcement artifact
         uses: actions/download-artifact@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,8 @@ permissions:
 env:
   NOTO_SANS_URL: https://github.com/notofonts/noto-cjk/releases/download/Sans2.004/03_NotoSansCJK-OTC.zip
   NOTO_SERIF_URL: https://github.com/notofonts/noto-cjk/releases/download/Serif2.002/04_NotoSerifCJKOTC.zip
+  # 跟 test.yml 顶层 env 保持一致, 复用 PR #901 weekly bypass cache.
+  TL_VERSION: '2026'
 
 jobs:
   release:
@@ -114,13 +116,48 @@ jobs:
             ;;
         esac
 
-    - name: Install TeX Live
+    # PR #901 weekly bypass cache, 跟 test.yml 的 caller / warmup-tl 共享同
+    # 一个 key (tl-bypass-Linux-2026-<ISO 周>). Schedule 每周一 12:00 UTC
+    # 跑 test.yml warmup-tl 刷新这个 cache, 周内打 release tag 触发本工作流
+    # 时直接 cache hit, 跳过 setup-texlive-action (~70s → ~10s restore).
+    - name: Compute TL cache week
+      id: tlcache
+      run: |
+        week="$(TZ=UTC date +'%G-W%V')"
+        echo "week=${week}" >> "$GITHUB_OUTPUT"
+        echo "TL cache week: ${week}"
+
+    - name: TL bypass cache (restore)
+      id: bypass-cache
+      uses: actions/cache@v6
+      with:
+        path: ${{ runner.temp }}/setup-texlive-action/${{ env.TL_VERSION }}
+        key: tl-bypass-${{ runner.os }}-${{ env.TL_VERSION }}-${{ steps.tlcache.outputs.week }}
+
+    # cache hit fast path: export PATH + sanity check. 失败时 continue-on-error
+    # 让下面 setup-texlive fallback 接管 (cache 损坏 / 极少). Linux runner 上
+    # tlmgr 直接可调用, 不需要 tlmgr.bat hack.
+    - name: Export PATH (cache hit fast path)
+      id: export-path
+      if: steps.bypass-cache.outputs.cache-hit == 'true'
+      continue-on-error: true
+      run: |
+        TL_BIN="${{ runner.temp }}/setup-texlive-action/${{ env.TL_VERSION }}/bin/x86_64-linux"
+        echo "$TL_BIN" >> "$GITHUB_PATH"
+        echo "Added to PATH: $TL_BIN"
+        "$TL_BIN/tlmgr" version
+
+    - name: Install TeX Live (fallback, cache miss or corrupt)
+      if: steps.bypass-cache.outputs.cache-hit != 'true' || steps.export-path.outcome == 'failure'
       timeout-minutes: 30
       uses: TeX-Live/setup-texlive-action@v4
       with:
+        version: ${{ env.TL_VERSION }}
         package-file: .github/tl_packages
         repository: https://ctan.math.illinois.edu/systems/texlive/tlnet
         update-all-packages: true
+        # 关闭 setup-texlive 内部 cache, 我们自己用 bypass-cache.
+        cache: false
 
     - name: Install zhmakeindex
       run: |

--- a/zhlineskip/build.lua
+++ b/zhlineskip/build.lua
@@ -70,25 +70,18 @@ function update_tag(file, content, tagname, tagdate)
 end
 
 --[================== "Hacks" to `l3build` | Do not Modify ==================]--
-function fetchdocsupp(shortlink)
-  -- run() 返回 shell rc. curl 失败 (网络不通 / 链接失效) 时 rc != 0,
-  -- 让 l3build 在 docinit 阶段就报错, 避免后续 typeset 因缺字体静默生成
-  -- 缺字符的 pdf. (PR #892 bot review #3.)
-  local rc = run(typesetdir, "curl -O -L --fail \"https://" .. shortlink .. "\"")
-  if rc ~= 0 then
-    error("fetchdocsupp: curl failed (rc=" .. rc .. ") for " .. shortlink)
-  end
-  return 0
-end
+-- docinit_hook 在 typeset 前给 build/local 准备额外文件:
+--   1. ctxdoc.cls / ctxdocstrip.tex / ctex-zhconv*.lua 来自 ../support/
+--      (跟 ctex/xeCJK 一样, 用 ctex-kit 的 ctxdoc 排版类)
+--   2. README.md cp 到包根目录, l3build ctan 打包 zip 时要带上
+--
+-- 不再从 mirrors.ctan.org 下载 Noto CJK 字体: zhlineskip.dtx driver 部分已
+-- 跟 xeCJK 对齐用 fontconfig 风格字体名 (`Noto Serif CJK SC` 而非
+-- `NotoSerifCJKsc-Medium.otf`), 走系统 fontconfig 查找. CI 上 release.yml
+-- 的 "Install CJK fonts" step 已 fontfetch + fc-cache; 本地开发需自行装
+-- Noto CJK (Debian: `fonts-noto-cjk`; mac: `brew install --cask
+-- font-noto-serif-cjk-sc font-noto-sans-cjk-sc`).
 function docinit_hook()
-  local notofontset = {
-    "SerifCJKsc-Medium", "SerifCJKsc-Bold", "SerifCJKsc-Black",
-    "SansCJKsc-Regular", "SansCJKsc-Bold"
-  }
-  for _, series in pairs(notofontset) do
-    fetchdocsupp(
-      "mirrors.ctan.org/fonts/notocjksc/Noto" .. series .. ".otf")
-  end
   for _,i in ipairs{"ctxdoc.cls", "ctxdocstrip.tex", "ctex-zhconv*.lua"} do
     cp(i, supportdir, localdir)
   end

--- a/zhlineskip/zhlineskip.dtx
+++ b/zhlineskip/zhlineskip.dtx
@@ -196,15 +196,18 @@ The Current Maintainer of this work is **Ruixi Zhang**.
 \setmathfont{texgyrepagella-math.otf}[
   Scale             = 1.05924855491329480
 ]
-\setCJKmainfont{NotoSerifCJKsc-Medium.otf}[
-  ItalicFont        = NotoSerifCJKsc-Black.otf,
-  BoldFont          = NotoSerifCJKsc-Bold.otf
+\setCJKmainfont{Noto Serif CJK SC}[
+  UprightFont       = * Medium,
+  ItalicFont        = * Black,
+  BoldFont          = * Bold
 ]
-\setCJKsansfont{NotoSansCJKsc-Regular.otf}[
-  BoldFont          = NotoSansCJKsc-Bold.otf
+\setCJKsansfont{Noto Sans CJK SC}[
+  UprightFont       = * Regular,
+  BoldFont          = * Bold
 ]
-\setCJKmonofont{NotoSansCJKsc-Regular.otf}[
-  BoldFont          = NotoSansCJKsc-Bold.otf
+\setCJKmonofont{Noto Sans CJK SC}[
+  UprightFont       = * Regular,
+  BoldFont          = * Bold
 ]
 \frenchspacing
 % zhlineskip 在 `restoremathleading=true` (默认) 时会 \RequirePackage{mathtools},


### PR DESCRIPTION
## 背景

PR #903 之后, 用 \`zhlineskip-v1.0f\` tag (force-pushed 到含 inconsolata fix 的 master) 再触发 release.yml 仍然 fail:

\`\`\`
build.lua:79: fetchdocsupp: curl failed (rc=7168)
  for mirrors.ctan.org/fonts/notocjksc/NotoSerifCJKsc-Medium.otf
curl: (28) Failed to connect to mirror.latigo.net port 443 after 134942 ms
\`\`\`

[Run 28285121137 fail log](https://github.com/CTeX-org/ctex-kit/actions/runs/28285121137/job/83808042544)

## 根因 — zhlineskip 跟 ctex/xeCJK 不一致

| 包 | CJK 字体配置 |
|---|---|
| xeCJK | \`\setCJKmainfont{Noto Serif CJK SC}\` (fontconfig) |
| ctex | 走 \`ctex-fontset-*.def\` 切换, 类似 fontconfig 风格 |
| **zhlineskip** | \`\setCJKmainfont{NotoSerifCJKsc-Medium.otf}\` (文件名带后缀) |

fontspec 看到 \`.otf\` 后缀就**优先在 typesetdir 找单文件**, 不退到 fontconfig. 这逼着 \`docinit_hook\` 从 \`mirrors.ctan.org\` 下载 5 个单 OTF 到 \`build/local/\` — 而 \`mirrors.ctan.org\` 是 round-robin 随机 mirror, 抖动概率高.

xeCJK / ctex 都没 \`docinit_hook\`, 因为它们走 fontconfig.

## 顺便: release 工作流也没用上 PR #901 的 TL bypass cache

调研 release fail 时发现 \`release.yml\` / \`release-ctan-upload.yml\` 都还走老路: 直接跑 \`setup-texlive-action\`, 没用 PR #901 的 weekly bypass cache. 每次 release 多花 60-70s TL setup, 而且暴露在 mirror 抖动下 (跟 PR #901 修过的老坑同源).

## 修法 (4 个 commit, 单域分明)

### 1. \`refactor(zhlineskip)\`: dtx driver CJK 字体名换 fontconfig 风格

\`\`\`latex
% before
\setCJKmainfont{NotoSerifCJKsc-Medium.otf}[
  ItalicFont = NotoSerifCJKsc-Black.otf,
  BoldFont   = NotoSerifCJKsc-Bold.otf
]

% after
\setCJKmainfont{Noto Serif CJK SC}[
  UprightFont = * Medium,
  ItalicFont  = * Black,
  BoldFont    = * Bold
]
\`\`\`

字体 weight 保持跟原 .otf 文件一致, 手册视觉无差.

### 2. \`chore(zhlineskip)\`: 删 \`fetchdocsupp\` + \`docinit_hook\` 内字体下载

字体走 fontconfig 后, \`docinit_hook\` 只剩 cp 共享文件 + cp README.md (跟字体无关, 保留). 跟 xeCJK / ctex 一致.

### 3. \`perf(ci)\`: release / release-ctan-upload 接入 weekly bypass cache

两个 release workflow 都加 PR #901 同款 3 step 链:
1. Compute TL cache week (ISO \`%G-W%V\`)
2. TL bypass cache (restore), key = \`tl-bypass-Linux-2026-<week>\`
3. Export PATH (cache hit fast path) + continue-on-error 自愈

旧 setup-texlive step 加 fallback if. cache key 跟 test.yml 共享, weekly 翻新.

- release.yml: 直接复用全套 \`tl_packages\` cache.
- release-ctan-upload.yml: 即便只要 minimal (l3build + luatex), cache restore 全套 ~10s 仍比真装 minimal ~30s 快.

## 副作用

- **release.yml CI**: \`Install CJK fonts\` step 已经装好 Noto CJK OTC + \`fc-cache\`, 字体走 fontconfig 即可. **不用改 release.yml 字体相关步骤**.
- **本地开发**: 新开发者要本地装 Noto CJK 才能 typeset 手册. 加注释指明 Debian / macOS 装法.
- **release 速度**: 预期 release.yml 整 run ~3-5min → ~2-3min (省 ~70s TL setup).

## /cc @myhsia

明子哥, 不是黑你, 是想说明: docinit_hook 自动下载字体看起来贴心 (本地开发不用预装), 但代价是 release pipeline 依赖一个 round-robin mirror, 抖一下就 release fail 一次. xeCJK / ctex 都选择"让开发者自己装字体", 多打一行 \`brew install --cask font-noto-serif-cjk-sc\` 换来 release 稳定, 这个 trade-off 值. PR #892 还把 \`--fail\` 加上去暴露问题(那条建议本身是对的), 但根本问题不是 curl 怎么写, 是字体配置风格.

## Test plan

- [x] CI \`test-zhlineskip\` pass (l3build check 不 typeset, 不会触发字体问题)
- [ ] PR merge 后, 重新打 zhlineskip-v1.0f tag (force-push 重定向到含本 PR 的 master), release.yml 真去 typeset 成功
- [ ] release.yml 走 cache hit fast path, TL setup ~2s 而非 ~70s