### PR TITLE
fix(ci): TL bypass cache key 加 tl_packages hash, 防新加包 cache 假阳

### DIFF
--- a/.github/workflows/_test-package.yml
+++ b/.github/workflows/_test-package.yml
@@ -117,7 +117,8 @@ jobs:
       uses: actions/cache@v6
       with:
         path: ${{ runner.temp }}/setup-texlive-action/${{ inputs.tl-version }}
-        key: tl-bypass-${{ runner.os }}-${{ inputs.tl-version }}-${{ inputs.tl-cache-week }}
+        # key 含 weekly + tl_packages hash. 见 test.yml warmup-tl 同款 key 注释.
+        key: tl-bypass-${{ runner.os }}-${{ inputs.tl-version }}-${{ inputs.tl-cache-week }}-${{ hashFiles('.github/tl_packages') }}
 
     # cache hit fast path. sanity check 用 `continue-on-error: true` 兜底 cache
     # 真损坏的极端情况 (理论极少 — warmup 验证过才 save). 失败时

--- a/.github/workflows/release-ctan-upload.yml
+++ b/.github/workflows/release-ctan-upload.yml
@@ -289,7 +289,8 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ${{ runner.temp }}/setup-texlive-action/${{ env.TL_VERSION }}
-          key: tl-bypass-${{ runner.os }}-${{ env.TL_VERSION }}-${{ steps.tlcache.outputs.week }}
+          # key 含 weekly + tl_packages hash. 见 test.yml warmup-tl 同款 key 注释.
+          key: tl-bypass-${{ runner.os }}-${{ env.TL_VERSION }}-${{ steps.tlcache.outputs.week }}-${{ hashFiles('.github/tl_packages') }}
 
       - name: Export PATH (cache hit fast path)
         id: export-path

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,7 +132,8 @@ jobs:
       uses: actions/cache@v6
       with:
         path: ${{ runner.temp }}/setup-texlive-action/${{ env.TL_VERSION }}
-        key: tl-bypass-${{ runner.os }}-${{ env.TL_VERSION }}-${{ steps.tlcache.outputs.week }}
+        # key 含 weekly + tl_packages hash. 见 test.yml warmup-tl 同款 key 注释.
+        key: tl-bypass-${{ runner.os }}-${{ env.TL_VERSION }}-${{ steps.tlcache.outputs.week }}-${{ hashFiles('.github/tl_packages') }}
 
     # cache hit fast path: export PATH + sanity check. 失败时 continue-on-error
     # 让下面 setup-texlive fallback 接管 (cache 损坏 / 极少). Linux runner 上

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -212,7 +212,13 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ${{ runner.temp }}/setup-texlive-action/${{ env.TL_VERSION }}
-          key: tl-bypass-${{ runner.os }}-${{ env.TL_VERSION }}-${{ needs.changes.outputs.tl-cache-week }}
+          # key 含 weekly + tl_packages hash:
+          #   - weekly: schedule 周一刷新 cache, 周内 PR 享用
+          #   - tl_packages hash: 改 tl_packages (例加新包) 立即 invalidate, 防
+          #     PR 加新包时 release / 下游 caller 用到老 cache 找不到包 fail
+          #     (实测 zhlineskip-v1.0f 加 inconsolata 后老 cache 没含, release.yml
+          #     从 cache restore 后直接 fontspec 报 Inconsolatazi4 找不到).
+          key: tl-bypass-${{ runner.os }}-${{ env.TL_VERSION }}-${{ needs.changes.outputs.tl-cache-week }}-${{ hashFiles('.github/tl_packages') }}
 
       # cache hit: 跳过整个 setup-texlive 流程, 只 export PATH.
       # cache miss: 跑 setup-texlive (3 mirror retry) + verification, cache 会在


### PR DESCRIPTION
## 背景

PR #903 加 inconsolata 到 \`tl_packages\` → PR #904 把 release.yml 接入 PR #901 weekly bypass cache → force-push \`zhlineskip-v1.0f\` tag 重触发 release.yml 仍 fail:

\`\`\`
! Package fontspec Error:
(fontspec)                The font "Inconsolatazi4-Regular" cannot be found;
\`\`\`

[Failed run 28285884898](https://github.com/CTeX-org/ctex-kit/actions/runs/28285884898/job/83809658113)

## 根因

PR #904 让 release.yml 走 cache hit fast path 用了**周一 schedule 刷的老 cache** (那时还没 inconsolata). cache key 只看 \`runner.os + TL_VERSION + ISO 周\`, **不看 \`tl_packages\` 内容**.

PR #901 weekly cache 设计的固有 trade-off: schedule 周一刷新, 周内 PR 改 \`tl_packages\` 不会立即翻 cache. 但这场景下, 新加包跟新 release 撞同一周就炸.

## 修法

4 个 cache key 引用处都拼上 \`hashFiles('.github/tl_packages')\`:

- \`test.yml\` warmup-tl (line 215)
- \`_test-package.yml\` caller (line 120)
- \`release.yml\` (line 135, PR #904 加的)
- \`release-ctan-upload.yml\` (line ~278, PR #904 加的)

\`tl_packages\` 改一行 → 4 处 key 同步变 → cache miss 走 fallback 装最新, 然后新 cache save 含新包, 后续 release 直接命中.

## 副作用

加新包的 PR merge 后, master 上下个 schedule 跑 warmup-tl (周一 12:00 UTC) 之前所有 caller 都得 cache miss 走 fallback ~70s. \`tl_packages\` 改频率极低, 历次只有:

- PR #883 (LaTeX 2026-06-01 基线声明)
- PR #903 (inconsolata)

可接受.

## Test plan

- [ ] CI \`test-zhlineskip\` 全 pass (cache miss 走 fallback, 也能跑过)
- [ ] PR merge 后再 force-push zhlineskip-v1.0f tag, release.yml cache miss → fallback → save 新 cache (含 inconsolata) → typeset 成功