### PR TITLE
fix(ci): tl_packages 加 docext + xurl, 修 release.yml zhlineskip typeset

### DIFF
--- a/.github/tl_packages
+++ b/.github/tl_packages
@@ -85,6 +85,7 @@ colortbl
 comment
 context
 csquotes
+docext
 enumitem
 environ
 esint
@@ -164,6 +165,7 @@ xecjk
 xint
 xits
 xstring
+xurl
 zhmetrics
 zhmetrics-uptex
 zhnumber

--- a/.github/workflows/_test-package.yml
+++ b/.github/workflows/_test-package.yml
@@ -314,19 +314,6 @@ jobs:
             else
               echo "No test configuration found, skipping"
             fi
-            # 临时: PR #906 / #907 验证 release.yml typeset 路径. l3build check
-            # 不 typeset doc, 看不出 .dtx driver 部分缺哪些 TL 包. 这里加跑
-            # l3build doc 提早暴露. 验证通过后改回 (跑 doc 慢 + 字体 fc-cache
-            # 也得装).
-            l3build doc -q || {
-              echo "::group::zhlineskip doc logs"
-              for f in build/local/*.log build/doc/*.log; do
-                echo "=== $f ==="
-                head -120 "$f" 2>/dev/null || echo "(not found)"
-              done
-              echo "::endgroup::"
-              exit 1
-            }
             ;;
           *)
             # xeCJK / zhnumber / CJKpunct 等小包, 默认串行直接跑.

--- a/.github/workflows/_test-package.yml
+++ b/.github/workflows/_test-package.yml
@@ -314,6 +314,19 @@ jobs:
             else
               echo "No test configuration found, skipping"
             fi
+            # 临时: PR #906 / #907 验证 release.yml typeset 路径. l3build check
+            # 不 typeset doc, 看不出 .dtx driver 部分缺哪些 TL 包. 这里加跑
+            # l3build doc 提早暴露. 验证通过后改回 (跑 doc 慢 + 字体 fc-cache
+            # 也得装).
+            l3build doc -q || {
+              echo "::group::zhlineskip doc logs"
+              for f in build/local/*.log build/doc/*.log; do
+                echo "=== $f ==="
+                head -120 "$f" 2>/dev/null || echo "(not found)"
+              done
+              echo "::endgroup::"
+              exit 1
+            }
             ;;
           *)
             # xeCJK / zhnumber / CJKpunct 等小包, 默认串行直接跑.

--- a/zhlineskip/zhlineskip.dtx
+++ b/zhlineskip/zhlineskip.dtx
@@ -201,12 +201,13 @@ The Current Maintainer of this work is **Ruixi Zhang**.
   ItalicFont        = * Black,
   BoldFont          = * Bold
 ]
+% Sans/Mono 不显式 UprightFont. fontspec 默认让 fontconfig 模糊匹配
+% Regular weight (Noto OTC 集合里没有单独 "Regular" 暴露名). 显式
+% `* Regular` 反而让 fontconfig 查不到. xeCJK 也是直接 `Noto Sans CJK SC`.
 \setCJKsansfont{Noto Sans CJK SC}[
-  UprightFont       = * Regular,
   BoldFont          = * Bold
 ]
 \setCJKmonofont{Noto Sans CJK SC}[
-  UprightFont       = * Regular,
   BoldFont          = * Bold
 ]
 \frenchspacing


### PR DESCRIPTION
## 背景

zhlineskip-v1.0f tag release.yml 走 fallback 装完 TL 后, Build CTAN zip 在 typeset zhlineskip.pdf 时报:

\`\`\`
! LaTeX Error: File \`docext.sty' not found.
\`\`\`

[Failed run 28286265504](https://github.com/CTeX-org/ctex-kit/actions/runs/28286265504/job/83810646703)

## 修法

zhlineskip.dtx driver 部分:

\`\`\`latex
\usepackage{caption, docext, xurl, booktabs, hyperref}
\`\`\`

\`caption\` / \`booktabs\` / \`hyperref\` 在 tl_packages 已有; \`docext\` / \`xurl\` 缺.

- **docext**: @myhsia 自己写的 doc 扩展 (codedemo 环境 + doc 包修正), 2026-06-13 上 CTAN
- **xurl**: URL 任意字符断行, 独立小包

LaTeX 第一个 missing 抛错退出, 没暴露 \`xurl\` 的 missing. 同时加上避免下轮 release fail 再炸一次.

\`tabularx\` / \`fancyvrb-ex\` / \`zref-base\` 看似缺其实在 \`tools\` / \`fancyvrb\` / \`zref\` 集合里, 已经会跟着装.

## /cc @myhsia

明子哥, 我才看到 docext 是你自己写的!这玩意儿没在 tl_packages 里 — 重构时把 docext 引进来用是好事, 但没意识到 CI 装包列表也得跟一下. 不黑哈, 单独提一句.

## Test plan

- [ ] CI \`test-zhlineskip\` pass (cache miss 走 fallback, 装新 packages)
- [ ] PR merge 后再 force-push zhlineskip-v1.0f tag, release.yml typeset 不再炸 docext / xurl