### PR TITLE
fix(zhlineskip): build.lua 删 ctanzip = module, 跟 ctex/xeCJK 对齐

### DIFF
--- a/zhlineskip/build.lua
+++ b/zhlineskip/build.lua
@@ -24,7 +24,8 @@ description         = "This package supports typesetting CJK documents. It allow
 checkengines        = {"pdftex"}
 checkruns           = 1
 cleanfiles          = {"*.log", "*.pdf", "*.zip", "*.curlopt"}
-ctanzip             = module
+-- ctanzip 不显式设, 走 l3build 默认 (= module .. "-ctan"), 跟 ctex/xeCJK 等
+-- 对齐. release.yml 的 Prepare release asset step 期望 zhlineskip-ctan.zip.
 demofiles           = {module .. "-test.tex"}
 excludefiles        = {"*~"}
 installfiles        = {module .. ".sty", module .. ".ins"}


### PR DESCRIPTION
## 背景

PR #906 修完 typeset 路径后, zhlineskip-v1.0f tag release.yml 终于跑过 Build CTAN zip, 但 Prepare release asset 报:

\`\`\`
mv: cannot stat 'zhlineskip/zhlineskip-ctan.zip': No such file or directory
\`\`\`

[Failed run 28286823123](https://github.com/CTeX-org/ctex-kit/actions/runs/28286823123/job/83812939331)

## 根因

\`zhlineskip/build.lua\` L27 显式设了:

\`\`\`lua
ctanzip = module
\`\`\`

这覆盖了 l3build 默认值 (默认 \`<module>-ctan\`). 产物变成 \`zhlineskip.zip\` 而非 \`zhlineskip-ctan.zip\`.

\`ctex\` / \`xeCJK\` / \`zhnumber\` / \`CJKpunct\` 都没显式设, 全用默认. release.yml 的 Prepare release asset step 写的是 \`\${MODULE}-ctan.zip\`, 跟其他四个包对齐.

## 修法

删 \`ctanzip = module\`, 加注释说明跟 release.yml 期望对齐.

## /cc @myhsia

明子哥又给我整新活了... build.lua 里这个 \`ctanzip = module\` 是 PR #892 重构带进来的, 看似无害但跟 release.yml 期望对不上号. 删了就行.

## Test plan

- [ ] CI test-zhlineskip pass
- [ ] PR merge 后再 force-push zhlineskip-v1.0f tag, release.yml 全过, GH Release prerelease 真正创建出来