### PR TITLE
⟨doc|fix⟩(zhlineskip): 移除逻辑混乱的 `UseMSWordMultipleLineSpacing` 选项; 订正手册.

### DIFF
--- a/zhlineskip/zhlineskip.dtx
+++ b/zhlineskip/zhlineskip.dtx
@@ -769,7 +769,6 @@ race, colour, sex, language\dots
 % \begin{macro}
 %   {
 %     \@@_msg_new:nn,
-%     \@@_msg_new:ne,
 %     \@@_msg_error:nn,
 %     \@@_msg_error:ne,
 %     \@@_msg_warning:nn,
@@ -777,7 +776,6 @@ race, colour, sex, language\dots
 %     \@@_msg_info:nn,
 %     \@@_msg_info:ne,
 %     \@@_msg_new:nnn,
-%     \@@_msg_new:nne,
 %     \@@_msg_error:nnn,
 %     \@@_msg_error:nne,
 %     \@@_msg_warning:nnn,
@@ -787,7 +785,9 @@ race, colour, sex, language\dots
 %   }
 % 消息管理: 私有函数用来创建新消息并作为 error, warning, 或 info 进行广播.
 %    \begin{macrocode}
-\clist_map_inline:nn { new, error, warning, info }
+\cs_new_protected:Npn \@@_msg_new:nn  { \msg_new:nnn  { ZhLS } }
+\cs_new_protected:Npn \@@_msg_new:nnn { \msg_new:nnnn { ZhLS } }
+\clist_map_inline:nn { error, warning, info }
   {
     \cs_new_protected:cpn { @@_msg_#1:nn  }
       { \use:c { msg_#1:nnn  } { ZhLS } }

--- a/zhlineskip/zhlineskip.dtx
+++ b/zhlineskip/zhlineskip.dtx
@@ -196,7 +196,7 @@ The Current Maintainer of this work is **Ruixi Zhang**.
   ItalicFont        = *-italic,
   BoldFont          = *-bold,
   BoldItalicFont    = *-bolditalic,
-  Scale             = 1.00118564817432455
+  Scale             = 1.00685871056241427
 ]
 \setmonofont{Inconsolatazi4}[
   Extension         = .otf,

--- a/zhlineskip/zhlineskip.dtx
+++ b/zhlineskip/zhlineskip.dtx
@@ -467,7 +467,7 @@ The Current Maintainer of this work is **Ruixi Zhang**.
 %   它可以比正文的倍数稍小一些，建议设置在正文倍数的 $98\%$ 至 $100\%$ 之间。
 %   \item [\keys{restoremathleading}]\val{\TTF}：
 %   指定是否将数学公式行距恢复成西文基础行距。\hfill
-%   (初始值：|false|，默认值：|true|)\\
+%   (初始值：|true|，默认值：|true|)\\
 %   该选项为真时，会自动载入 \pkg{mathtools} 宏包，此时还能利用
 %   \begin{quote}
 %     \tn{SetMathEnvironmentSinglespace} \marg{real}
@@ -810,42 +810,42 @@ race, colour, sex, language\dots
     \space\space`footnoteleadingratio',                     \iow_newline:
     \space\space`restoremathleading',                       \iow_newline:
     \space\space`MSWordLineSpacingMultiple', ~ and          \iow_newline:
-    \space\space`MSWordSinglespaceRatio'
+    \space\space`MSWordSinglespaceRatio'.
   }
 %    \end{macrocode}
 % 创建新消息: |MSWord ~ Multiple ~ Line ~ Spacing|.
 %    \begin{macrocode}
 \@@_msg_new:nn { MSWord ~ Multiple ~ Line ~ Spacing }
   {
-    Use ~ Microsoft ~ Word ~ multiple ~ line ~ spacing      \iow_newline:
-    Singlespace ~ to ~ fontsize ~ ratio ~ = ~ `#1'          \iow_newline:
-    Multiple ~ = ~ `#2'
+    Use ~ Microsoft ~ Word ~ multiple ~ line ~ spacing:     \iow_newline:
+    Singlespace ~ to ~ fontsize ~ ratio ~ = ~ `#1'.         \iow_newline:
+    Multiple ~ = ~ `#2'.
   }
 %    \end{macrocode}
 % 创建新消息: |Invalid ~ Option|.
 %    \begin{macrocode}
 \@@_msg_new:nn { Invalid ~ Option }
   {
-    The ~ `#1' ~ Option ~ is ~ invalid ~ now                \iow_newline:
-    It is valid when #2
+    The ~ `#1' ~ Option ~ is ~ invalid ~ now.               \iow_newline:
+    It ~ takes ~ effect ~ only ~ when ~ #2.
   }
 %    \end{macrocode}
 % 创建新消息: |Not ~ Loaded ~ Package|.
 %    \begin{macrocode}
 \@@_msg_new:nn { Not ~ Loaded ~ Package }
   {
-    Package #1 ~ is ~ NOT ~ loaded ~ by ~ zhlineskip        \iow_newline:
-    Some ~ of ~ its ~ features ~ may ~ not ~ be ~ available \iow_newline:
-    #2
+    Package #1 ~ is ~ NOT ~ loaded ~ by ~ zhlineskip.       \iow_newline:
+    Some ~ of ~ its ~ features ~ may ~ not ~ be ~ available.\iow_newline:
+    #2.
   }
 %    \end{macrocode}
 % 创建新消息: |Illegal ~ Usage|.
 %    \begin{macrocode}
 \@@_msg_new:nn { Illegal ~ Usage }
   {
-    Cannot ~ use ~ \string#1\space here                     \iow_newline:
-    Try ~ loading ~ zhlineskip ~ with ~ option              \iow_newline:
-    `restoremathleading ~ = ~ true'
+    Cannot ~ use ~ \string#1\space here.                    \iow_newline:
+    Try ~ loading ~ zhlineskip ~ with ~ option:             \iow_newline:
+    `restoremathleading ~ = ~ true'.
   }
 %    \end{macrocode}
 % 加载依赖 \pkg{etoolbox} 宏包.
@@ -886,15 +886,15 @@ race, colour, sex, language\dots
     MSWordLineSpacingMultiple           .default:n  = { true  },
     MSWordLineSpacingMultiple / true    .code:n     =
       {
-        \bool_set_true:N \g_@@_MSWordLineSpacingMultiple_bool
-        \fp_set:Nn \g_@@_MSWordLineSpacingMultiple_fp { 1.15 }
+        \bool_gset_true:N \g_@@_MSWordLineSpacingMultiple_bool
+        \fp_gset:Nn \g_@@_MSWordLineSpacingMultiple_fp { 1.15 }
       },
     MSWordLineSpacingMultiple / false   .code:n     =
-      { \bool_set_false:N \g_@@_MSWordLineSpacingMultiple_bool },
+      { \bool_gset_false:N \g_@@_MSWordLineSpacingMultiple_bool },
     MSWordLineSpacingMultiple / unknown .code:n     =
       {
-        \bool_set_true:N \g_@@_MSWordLineSpacingMultiple_bool
-        \fp_set:Nn \g_@@_MSWordLineSpacingMultiple_fp {#1}
+        \bool_gset_true:N \g_@@_MSWordLineSpacingMultiple_bool
+        \fp_gset:Nn \g_@@_MSWordLineSpacingMultiple_fp {#1}
       },
     MSWordSinglespaceRatio              .fp_set:N   =
       \g_@@_MSWordSinglespaceRatio_fp,

--- a/zhlineskip/zhlineskip.dtx
+++ b/zhlineskip/zhlineskip.dtx
@@ -202,7 +202,7 @@ The Current Maintainer of this work is **Ruixi Zhang**.
   Extension         = .otf,
   UprightFont       = *-Regular,
   BoldFont          = *-Bold,
-  Scale             = 1.001185648,
+  Scale             = 1.00118564817432455,
   AutoFakeSlant     = .111
 ]
 \setCJKmainfont{Noto Serif CJK SC}[

--- a/zhlineskip/zhlineskip.dtx
+++ b/zhlineskip/zhlineskip.dtx
@@ -779,15 +779,13 @@ race, colour, sex, language\dots
 %     \@@_msg_error:nnn,
 %     \@@_msg_error:nne,
 %     \@@_msg_warning:nnn,
-%     \@@_msg_warning:nne,
-%     \@@_msg_info:nnn,
-%     \@@_msg_info:nne,
+%     \@@_msg_warning:nne
 %   }
 % 消息管理: 私有函数用来创建新消息并作为 error, warning, 或 info 进行广播.
 %    \begin{macrocode}
 \cs_new_protected:Npn \@@_msg_new:nn  { \msg_new:nnn  { ZhLS } }
 \cs_new_protected:Npn \@@_msg_new:nnn { \msg_new:nnnn { ZhLS } }
-\clist_map_inline:nn { error, warning, info }
+\clist_map_inline:nn { error, warning }
   {
     \cs_new_protected:cpn { @@_msg_#1:nn  }
       { \use:c { msg_#1:nnn  } { ZhLS } }
@@ -1160,6 +1158,6 @@ race, colour, sex, language\dots
 %<@@=>
 %    \end{macrocode}
 % \iffalse
-%<package>\endinput
+%<package>\file_input_stop:
 % \fi
 % \end{implementation}

--- a/zhlineskip/zhlineskip.dtx
+++ b/zhlineskip/zhlineskip.dtx
@@ -911,7 +911,7 @@ race, colour, sex, language\dots
       { \g_@@_MSWordLineSpacingMultiple_bool                                 }
       { \fp_compare_p:nNn { \g_@@_MSWordSinglespaceRatio_fp } = { 1.296875 } }
       {
-        \@@_msg_warning:nnn { Invalid ~ Option } { MSWordSinglespaceRatio }
+        \@@_msg_warning:nnn { Ineffective ~ Option } { MSWordSinglespaceRatio }
           { MSWordLineSpacingMultiple ~ = ~ true }
       }
   }

--- a/zhlineskip/zhlineskip.dtx
+++ b/zhlineskip/zhlineskip.dtx
@@ -820,12 +820,12 @@ race, colour, sex, language\dots
     Multiple ~ = ~ `#2'.
   }
 %    \end{macrocode}
-% 创建新消息: |Invalid ~ Option|.
+% 创建新消息: |Ineffective ~ Option|.
 %    \begin{macrocode}
-\@@_msg_new:nn { Invalid ~ Option }
+\@@_msg_new:nn { Ineffective ~ Option }
   {
-    The ~ `#1' ~ Option ~ is ~ invalid ~ now.               \iow_newline:
-    It ~ takes ~ effect ~ only ~ when ~ #2.
+    The ~ `#1' ~ option ~ is ~ ineffective.                 \iow_newline:
+    It ~ only ~ takes ~ effect ~ when ~ #2.
   }
 %    \end{macrocode}
 % 创建新消息: |Not ~ Loaded ~ Package|.

--- a/zhlineskip/zhlineskip.dtx
+++ b/zhlineskip/zhlineskip.dtx
@@ -769,25 +769,32 @@ race, colour, sex, language\dots
 % \begin{macro}
 %   {
 %     \@@_msg_new:nn,
+%     \@@_msg_new:ne,
 %     \@@_msg_error:nn,
+%     \@@_msg_error:ne,
 %     \@@_msg_warning:nn,
+%     \@@_msg_warning:ne,
 %     \@@_msg_info:nn,
+%     \@@_msg_info:ne,
+%     \@@_msg_new:nnn,
+%     \@@_msg_new:nne,
 %     \@@_msg_error:nnn,
+%     \@@_msg_error:nne,
 %     \@@_msg_warning:nnn,
+%     \@@_msg_warning:nne,
 %     \@@_msg_info:nnn,
+%     \@@_msg_info:nne,
 %   }
 % 消息管理: 私有函数用来创建新消息并作为 error, warning, 或 info 进行广播.
 %    \begin{macrocode}
 \clist_map_inline:nn { new, error, warning, info }
   {
-    \cs_new_protected:cpn { @@_msg_#1:n   }
-      { \use:c { msg_#1:nn   } { ZhLS } }
     \cs_new_protected:cpn { @@_msg_#1:nn  }
       { \use:c { msg_#1:nnn  } { ZhLS } }
-    \cs_new_protected:cpn { @@_msg_#1:nnn }
-      { \use:c { msg_#1:nnnn } { ZhLS } }
     \cs_new_protected:cpn { @@_msg_#1:ne  }
       { \use:c { msg_#1:nne  } { ZhLS } }
+    \cs_new_protected:cpn { @@_msg_#1:nnn }
+      { \use:c { msg_#1:nnnn } { ZhLS } }
     \cs_new_protected:cpn { @@_msg_#1:nee }
       { \use:c { msg_#1:nnee } { ZhLS } }
   }

--- a/zhlineskip/zhlineskip.dtx
+++ b/zhlineskip/zhlineskip.dtx
@@ -162,14 +162,25 @@ The Current Maintainer of this work is **Ruixi Zhang**.
 %<package>\edef \ZhLSFileDate        {\ExplFileDate}
 %<package>\edef \ZhLSFileVersion     {\ExplFileVersion}
 %<package>\edef \ZhLSFileDescription {\ExplFileDescription}
-%<package>% \ExplFileDate 是 "YYYY/MM/DD" 格式. 这里把斜杠换破折号统一显示风格.
-%<package>% 用全局 (g) 版本是因为 \ZhLSFileDate 由上方 \edef 在包加载期定义,
-%<package>% 此时无分组嵌套, g/l 等价, 用 g 跟 \edef 的全局可见性匹配.
+% ^^A \ExplFileDate 是 "YYYY/MM/DD" 格式, 手册标题格式需斜杠换 hyphen.
+% ^^A 用全局 (g) 版本是因为 \ZhLSFileDate 由上方 \edef 在包加载期定义,
+% ^^A 此时无分组嵌套, g/l 等价, 用 g 跟 \edef 的全局可见性匹配.
 %<package>\tl_greplace_all:Nnn \ZhLSFileDate { / } { - }
 %</package>
 %<*driver>
-\documentclass[cs-break, zihao = 5, a4paper, fontset = fandol]{ctxdoc}
-\unimathsetup{math-style = ISO}
+% `ctxdoc` 已经加载了 unicode-math, zhlineskip 在 `restoremathleading = true`
+% (默认) 时会加载 mathtools, 而 unicode-math 必须在 mathtools 之后加载, 否则
+% mathtools 的 `\colon` 之类 会被 unicode-math 后续重定义覆盖.
+% 顺序固定: ctxdoc -> unicode-math.
+\RequirePackage{mathtools}
+\documentclass[cs-break, zihao = 5, a4paper, fontset = none]{ctxdoc}
+\unimathsetup{
+  math-style   = ISO,
+  warnings-off = {mathtools-colon, mathtools-overbracket}
+}
+\setmathfont{texgyrepagella-math.otf}[
+  Scale             = 1.05924855491329480
+]
 \setmainfont{texgyrepagella}[
   Extension         = .otf,
   UprightFont       = *-regular,
@@ -185,16 +196,14 @@ The Current Maintainer of this work is **Ruixi Zhang**.
   ItalicFont        = *-italic,
   BoldFont          = *-bold,
   BoldItalicFont    = *-bolditalic,
-  Scale             = 1.00685871056241427
+  Scale             = 1.00118564817432455
 ]
 \setmonofont{Inconsolatazi4}[
   Extension         = .otf,
   UprightFont       = *-Regular,
   BoldFont          = *-Bold,
-  Scale             = .8696390658
-]
-\setmathfont{texgyrepagella-math.otf}[
-  Scale             = 1.05924855491329480
+  Scale             = 1.001185648,
+  AutoFakeSlant     = .111
 ]
 \setCJKmainfont{Noto Serif CJK SC}[
   UprightFont       = * Medium,
@@ -211,11 +220,7 @@ The Current Maintainer of this work is **Ruixi Zhang**.
   BoldFont          = * Bold
 ]
 \frenchspacing
-% zhlineskip 在 `restoremathleading=true` (默认) 时会 \RequirePackage{mathtools},
-% 而 unicode-math 必须在 mathtools 之后加载, 否则 mathtools 的 `\colon` 之类
-% 会被 unicode-math 后续重定义覆盖. 顺序固定: zhlineskip -> unicode-math.
 \usepackage{zhlineskip}
-\usepackage{unicode-math}
 \newenvironment{english}{\addvspace\medskipamount}
                         {\par\addvspace\medskipamount}
 \SetTextEnvironmentSinglespace{1.112}
@@ -270,11 +275,12 @@ The Current Maintainer of this work is **Ruixi Zhang**.
 %
 % \section{简介}
 %
-% \pkg{zhlineskip} 宏包允许用户指定正文行距相比于正文字号的倍数（通常建议设置在
-% $1.5$ 至 $1.67$ 之间），以及脚注行距相比于脚注字号的倍数。另一方面，由于数学公式
-% 主要是由西文字符构成的，\pkg{zhlineskip} 还能将数学公式的行距“恢复”成西文
-% 较为紧凑的行距（通常为西文字号的 $1.2$~倍），使得全文的视觉
-% 密度较为均匀。最后，本宏包还支持按照 Microsoft Word 进行“多倍行距”排版。
+% \pkg{zhlineskip} 宏包允许用户指定正文行距相比于正文字号的倍数
+% （通常建议设置在 $1.5$至 $1.67$ 之间），以及脚注行距相比于脚注字号的倍数。
+% 另一方面，由于数学公式主要是由西文字符构成的，
+% \pkg{zhlineskip} 还能将数学公式的行距“恢复”成西文较为紧凑的行距
+% （通常为西文字号的 $1.2$~倍），使得全文的视觉密度较为均匀。
+% 最后，本宏包还支持按照 Microsoft Word 进行“多倍行距”排版。
 %
 % \subsection{宏包依赖}
 %
@@ -453,36 +459,33 @@ The Current Maintainer of this work is **Ruixi Zhang**.
 % \begin{keyval}
 %   \item [\keys{bodytextleadingratio}]\val{real}：
 %   指定正文目标行距相比于正文字号的倍数\hfill
-%   (缺省值: |1.5|，$1/2$~的行间距)\\
+%   (初始值：|1.5|，$1/2$~的行间距)\\
 %   以书刊为例，建议设置在~$1.5$ 至~$1.67$ 之间。
 %   \item [\keys{footnoteleadingratio}]\val{real}：
 %   指定脚注目标行距相比于脚注字号的倍数\hfill
-%   (缺省值: |1.48|，正文倍数的~$98.67\%$)\\
+%   (初始值：|1.48|，正文倍数的~$98.67\%$)\\
 %   它可以比正文的倍数稍小一些，建议设置在正文倍数的 $98\%$ 至 $100\%$ 之间。
-%   \item [\keys{restoremathleading}]\val{bool}：
-%   指定是否要将数学公式的行距恢复成西文基础行距。\hfill
-%   (缺省值: |true|，恢复数学行距)\\
+%   \item [\keys{restoremathleading}]\val{\TTF}：
+%   指定是否将数学公式行距恢复成西文基础行距。\hfill
+%   (初始值：|false|，默认值：|true|)\\
 %   该选项为真时，会自动载入 \pkg{mathtools} 宏包，此时还能利用
 %   \begin{quote}
 %     \tn{SetMathEnvironmentSinglespace} \marg{real}
 %   \end{quote}
 %   命令\emph{微调}数学公式的基础行距。
-%   \item [\keys{UseMSWordMultipleLineSpacing}]\val{bool}：\hfill
-%   (缺省值: |false|)\\
+%   \item [\keys{MSWordLineSpacingMultiple}]\val{\TTF, real}：
+%   设置 MS Word“多倍行距”的“倍数”\hfill
+%   (初始值：|false|，默认值：|1.15|)\\
 %   在排版论文时，如果被要求按照 Microsoft Word 来设置“多倍行距”，那么用户可以
-%   将该选项设置为~\opt{true}，并通过设置 \opt{MSWordLineSpacingMultiple}
-%   指定“倍数”，这会忽略用户之前指定的正文行距与脚注行距倍数，但是与数学行距的设置独立。
-%   \item [\keys{MSWordLineSpacingMultiple}]\val{real}：
-%   设置 Microsoft Word“多倍行距”的“倍数”\hfill
-%   (缺省值: |1.15|)\\
-%   仅在 \opt{UseMSWordMultipleLineSpacing} 为真时生效。
+%   将该选项设置为~\opt{true}，亦或直接通过该选项指定“倍数”，
+%   这会忽略用户之前指定的正文行距与脚注行距倍数，但是与数学行距的设置独立。
 %   在不修改 \opt{MSWordSinglespaceRatio} 时，
 %   相当于设置了目标行距为字号的 $1.49140625$~倍，适用于中易字体
 %   （参见第~\ref{sec:MS-Word}~节）。
 %   \item [\keys{MSWordSinglespaceRatio}]\val{real}：
 %   设置 Microsoft Word 的“单倍行距”相比字号的倍数\hfill
-%   (缺省值: |1.296875|)\\
-%   仅在 \opt{UseMSWordMultipleLineSpacing} 为真时生效。
+%   (初始值：|1.296875|)\\
+%   仅在 \opt{MSWordLineSpacingMultiple} 为真时生效。
 %   适用于中易字体（参见第~\ref{sec:MS-Word}~节）。
 %   若改用其他字体，则需调整该选项的值。
 % \end{keyval}
@@ -547,8 +550,8 @@ The Current Maintainer of this work is **Ruixi Zhang**.
 % 实现的。
 % \meta{env name} 可以是由若干环境名构成的逗号列表。
 % \begin{texnote}
-%   在 \opt{restoremathleading} 为~\opt{false} 时，
-%   \tn{SetMathEnvironmentSinglespace} 与\linebreak
+%   在 |restoremathleading = false| 时，
+%   命令 \tn{SetMathEnvironmentSinglespace} 与\linebreak
 %   \tn{RestoreMathEnvironmentLeading} 无效。
 % \end{texnote}
 % \end{function}
@@ -577,7 +580,7 @@ The Current Maintainer of this work is **Ruixi Zhang**.
 %   使用范例：假设文中的表格仅含西文、数字，此时如果想要文本环境 \env{tabular}
 %   的行距与西文行距一致，可通过
 %   \begin{quote}
-%     |\RestoreTextEnvironmentLeading{tabular}|
+%     |\RestoreTextEnvironmentLeading {tabular}|
 %   \end{quote}
 %   实现。亦可参见\ref{example:english-block}
 %   \meta{env name} 可以是由若干环境名构成的逗号列表。
@@ -603,23 +606,20 @@ The Current Maintainer of this work is **Ruixi Zhang**.
 %   \end{document}
 % \end{verbatim}
 %
-% \subsubsection{设置正文行距为字号的 1.6 倍}
+% \subsubsection{导言区设置正文行距为字号的 1.6 倍}
 %
 % \begin{verbatim}
-%   % 导言区
 %   \usepackage[
 %     bodytextleadingratio = 1.6,             % 设置正文行距倍数为 1.6
 %     footnoteleadingratio = 1.57             % 设置脚注行距倍数为 1.57
-%   ]{zhlineskip}                             % 缺省数学行距倍数为 1.2
+%   ]{zhlineskip}                             % 初始数学行距倍数为 1.2
 % \end{verbatim}
 %
-% \subsubsection{按照 Microsoft Word 设置“1.62 倍行距”}
+% \subsubsection{导言区按照 Microsoft Word 设置“1.62 倍行距”}
 %
 % \begin{verbatim}
-%   % 导言区
 %   \usepackage[
 %     restoremathleading            = false,  % 可选
-%     UseMSWordMultipleLineSpacing,           % 需设置为真
 %     MSWordLineSpacingMultiple     = 1.62
 %   ]{zhlineskip}
 % \end{verbatim}
@@ -727,19 +727,19 @@ race, colour, sex, language\dots
 %     Line spacing}.
 %   \newblock \url{https://practicaltypography.com/line-spacing.html},
 %     访问日期: 2018/10/28.
-% 
+%
 %   \bibitem{knuth1986tex}
 %   \textsc{Knuth, Donald Ervin}.
 %   \newblock \textit{The \TeX book}.
 %   \newblock Addison--Wesley, 1986.
-% 
+%
 %   \bibitem{lunde2008cjkv}
 %   \textsc{Lunde, Ken}.
 %   \newblock \textit{CJKV Information Processing\textup:
 %     Chinese\textup, Japanese\textup, Korean \textup\&
 %     Vietnamese Computing} (2~ed.).
 %   \newblock O'Reilly Media, Inc., 2008.
-% 
+%
 %   \bibitem{zhang2005fang}
 %   张胜涛 \& 王忆波.
 %   \newblock \textbf{方正飞腾 4.0 实用培训教程}.
@@ -768,9 +768,6 @@ race, colour, sex, language\dots
 %    \end{macrocode}
 % \begin{macro}
 %   {
-%     \@@_msg_new:n,
-%     \@@_msg_error:n,
-%     \@@_msg_warning:n,
 %     \@@_msg_new:nn,
 %     \@@_msg_error:nn,
 %     \@@_msg_warning:nn,
@@ -789,6 +786,10 @@ race, colour, sex, language\dots
       { \use:c { msg_#1:nnn  } { ZhLS } }
     \cs_new_protected:cpn { @@_msg_#1:nnn }
       { \use:c { msg_#1:nnnn } { ZhLS } }
+    \cs_new_protected:cpn { @@_msg_#1:ne  }
+      { \use:c { msg_#1:nne  } { ZhLS } }
+    \cs_new_protected:cpn { @@_msg_#1:nee }
+      { \use:c { msg_#1:nnee } { ZhLS } }
   }
 %    \end{macrocode}
 % \end{macro}
@@ -801,30 +802,37 @@ race, colour, sex, language\dots
     \space\space`bodytextleadingratio',                     \iow_newline:
     \space\space`footnoteleadingratio',                     \iow_newline:
     \space\space`restoremathleading',                       \iow_newline:
-    \space\space`UseMSWordMultipleLineSpacing',             \iow_newline:
     \space\space`MSWordLineSpacingMultiple', ~ and          \iow_newline:
     \space\space`MSWordSinglespaceRatio'
   }
 %    \end{macrocode}
-% 创建新消息: |UseMSWordMultipleLineSpacing|.
+% 创建新消息: |MSWord ~ Multiple ~ Line ~ Spacing|.
 %    \begin{macrocode}
-\@@_msg_new:nn { UseMSWordMultipleLineSpacing }
+\@@_msg_new:nn { MSWord ~ Multiple ~ Line ~ Spacing }
   {
     Use ~ Microsoft ~ Word ~ multiple ~ line ~ spacing      \iow_newline:
     Singlespace ~ to ~ fontsize ~ ratio ~ = ~ `#1'          \iow_newline:
     Multiple ~ = ~ `#2'
   }
 %    \end{macrocode}
-% 创建新消息: |Not Loaded `mathtools'|.
+% 创建新消息: |Invalid ~ Option|.
 %    \begin{macrocode}
-\@@_msg_new:nn { Not ~ Loaded ~ `mathtools' }
+\@@_msg_new:nn { Invalid ~ Option }
   {
-    mathtools ~ is ~ NOT ~ loaded ~ by ~ zhlineskip         \iow_newline:
-    Some ~ of ~ its ~ features ~ may ~ not ~ be ~ available \iow_newline:
-    Leading ~ in ~ multi-line ~ math ~ will ~ be ~ stretched
+    The ~ `#1' ~ Option ~ is ~ invalid ~ now                \iow_newline:
+    It is valid when #2
   }
 %    \end{macrocode}
-% 创建新消息: |Illegal Usage|.
+% 创建新消息: |Not ~ Loaded ~ Package|.
+%    \begin{macrocode}
+\@@_msg_new:nn { Not ~ Loaded ~ Package }
+  {
+    Package #1 ~ is ~ NOT ~ loaded ~ by ~ zhlineskip        \iow_newline:
+    Some ~ of ~ its ~ features ~ may ~ not ~ be ~ available \iow_newline:
+    #2
+  }
+%    \end{macrocode}
+% 创建新消息: |Illegal ~ Usage|.
 %    \begin{macrocode}
 \@@_msg_new:nn { Illegal ~ Usage }
   {
@@ -839,33 +847,71 @@ race, colour, sex, language\dots
 %    \end{macrocode}
 %
 % \changes{v1.0c}{2018/10/29}{对未知的键值选项与无效的用户命令报错。}
+% \changes{v1.0f}{2026/06/27}{移除布尔选项 \texttt{UseMSWordMultipleLineSpacing}，
+%   将其并入选项 \texttt{MSWordLineSpacingMultiple} 中。}
 %
+% \begin{variable}
+%   {
+%     \g_@@_MSWordLineSpacingMultiple_bool,
+%     \g_@@_bodytextleadingratio_fp,
+%     \g_@@_footnoteleadingratio_fp,
+%     \g_@@_restoremathleading_bool,
+%     \g_@@_MSWordLineSpacingMultiple_fp,
+%     \g_@@_MSWordSinglespaceRatio_fp
+%   }
 % 声明宏包选项.
 %    \begin{macrocode}
+\bool_new:N \g_@@_MSWordLineSpacingMultiple_bool
+\fp_new:N   \g_@@_MSWordLineSpacingMultiple_fp
 \keys_define:nn { ZhLS / pkgopt }
   {
-    bodytextleadingratio           .fp_set:N  = \g_@@_bodytextleadingratio_fp,
-      bodytextleadingratio         .initial:n = { 1.5 },
-    footnoteleadingratio           .fp_set:N  = \g_@@_footnoteleadingratio_fp,
-      footnoteleadingratio         .initial:n = { 1.48 },
-    restoremathleading             .bool_set:N= \g_@@_restoremathleading_bool,
-      restoremathleading           .initial:n = { true },
-      restoremathleading           .default:n = { true },
-    UseMSWordMultipleLineSpacing   .bool_set:N=
-                                    \g_@@_UseMSWordMultipleLineSpacing_bool,
-      UseMSWordMultipleLineSpacing .initial:n = { false },
-      UseMSWordMultipleLineSpacing .default:n = { true },
-    MSWordLineSpacingMultiple      .fp_set:N  =
-                                    \g_@@_MSWordLineSpacingMultiple_fp,
-    MSWordLineSpacingMultiple      .initial:n = { 1.15 },
-    MSWordSinglespaceRatio         .fp_set:N  =
-                                    \g_@@_MSWordSinglespaceRatio_fp,
-    MSWordSinglespaceRatio         .initial:n = { 1.296875 },
-    unknown                        .code:n    = \exp_args:Nno
-      \@@_msg_error:nn { Unknown ~ Option } { \l_keys_key_str },
+    bodytextleadingratio                .fp_set:N   =
+      \g_@@_bodytextleadingratio_fp,
+      bodytextleadingratio              .initial:n  = { 1.5   },
+    footnoteleadingratio                .fp_set:N   =
+      \g_@@_footnoteleadingratio_fp,
+      footnoteleadingratio              .initial:n  = { 1.48  },
+    restoremathleading                  .bool_set:N =
+      \g_@@_restoremathleading_bool,
+      restoremathleading                .initial:n  = { true  },
+      restoremathleading                .default:n  = { true  },
+    MSWordLineSpacingMultiple           .choice:,
+    MSWordLineSpacingMultiple           .default:n  = { true  },
+    MSWordLineSpacingMultiple / true    .code:n     =
+      {
+        \bool_set_true:N \g_@@_MSWordLineSpacingMultiple_bool
+        \fp_set:Nn \g_@@_MSWordLineSpacingMultiple_fp { 1.15 }
+      },
+    MSWordLineSpacingMultiple / false   .code:n     =
+      { \bool_set_false:N \g_@@_MSWordLineSpacingMultiple_bool },
+    MSWordLineSpacingMultiple / unknown .code:n     =
+      {
+        \bool_set_true:N \g_@@_MSWordLineSpacingMultiple_bool
+        \fp_set:Nn \g_@@_MSWordLineSpacingMultiple_fp {#1}
+      },
+    MSWordSinglespaceRatio              .fp_set:N   =
+      \g_@@_MSWordSinglespaceRatio_fp,
+    MSWordSinglespaceRatio              .initial:n  = { 1.296875 },
+    unknown                             .code:n     = \exp_args:Nno
+      \@@_msg_error:ne { Unknown ~ Option } { \l_keys_key_str }
   }
 \ProcessKeyOptions [ ZhLS / pkgopt ]
 %    \end{macrocode}
+% 在用户更改 \opt{MSWordSinglespaceRatio} 但未将 \opt{MSWordLineSpacingMultiple}
+% 设置为 \opt{true} 时产生警告.
+%    \begin{macrocode}
+\AtEndOfPackage
+  {
+    \bool_lazy_or:nnF
+      { \g_@@_MSWordLineSpacingMultiple_bool                                 }
+      { \fp_compare_p:nNn { \g_@@_MSWordSinglespaceRatio_fp } = { 1.296875 } }
+      {
+        \@@_msg_warning:nnn { Invalid ~ Option } { MSWordSinglespaceRatio }
+          { MSWordLineSpacingMultiple ~ = ~ true }
+      }
+  }
+%    \end{macrocode}
+% \end{variable}
 %
 % \changes{v1.0a}{2018/07/07}{自动计算基础行距对字号的倍数。
 %   正文、脚注的基础行距与其字号的比值现在通过 \tn{f@baselineskip} 与 \tn{f@size}
@@ -876,17 +922,18 @@ race, colour, sex, language\dots
 % \begin{variable}{\g_@@_targetbodyleading_fp,  \g_@@_targetfootleading_fp}
 % \begin{variable}{\g_@@_bodylinespread_fp,     \g_@@_footlinespread_fp}
 % \begin{variable}{\g_@@_defaultbodyleading_fp, \g_@@_defaultfootleading_fp}
-% \begin{variable}{\g_@@_tmpa_fp}
-% \begin{variable}{\g_@@_tmpa_dim,              \g_@@_tmpb_dim}
-% 临时浮点数与 |dim| 变量, 用于在 \opt{UseMSWordMultipleLineSpacing}
+% \begin{variable}{\l_@@_tmpa_fp}
+% \begin{variable}{\l_@@_tmpa_dim,              \l_@@_tmpb_dim}
+% 临时浮点数与 |dim| 变量, 用于在 \opt{MSWordLineSpacingMultiple}
 % 的 TF 分支下计算正文和页脚的 |linespread|.
 % 两部分计算中分别采用 \tn{f@size} 和 \tn{f@baselineskip} 在 \tn{normalsize} 和
 % \tn{footnotesize} 下的值, 计算原理相同.
 %
-% 作用域说明: 这些 fp 变量用全局 (g) 命名空间, 因为计算结果 (linespread
-% 等) 要在用户文档全周期生效, 不受分组限制. 后面 \tn{SetTextEnvironmentSinglespace}
-% / \tn{SetMathEnvironmentSinglespace} 写的 tl 变量则用局部 (l), 它们只在
-% 当前作用域内影响 \tn{linespread}, 是用户文档级临时调整.
+% 作用域说明: 这些 |fp| 变量用全局 (|g|) 命名空间, 因为计算结果 (|linespread| 等)
+% 要在用户文档全周期生效, 不受分组限制.
+% 后面 \tn{SetTextEnvironmentSinglespace} / \tn{SetMathEnvironmentSinglespace}
+% 写的 |tl| 变量则用局部 (|l|), 它们只在当前作用域内影响 \tn{linespread},
+% 是用户文档级临时调整.
 %    \begin{macrocode}
 \fp_new:N  \g_@@_targetbodyleading_fp
 \fp_new:N  \g_@@_targetfootleading_fp
@@ -894,51 +941,51 @@ race, colour, sex, language\dots
 \fp_new:N  \g_@@_footlinespread_fp
 \fp_new:N  \g_@@_defaultbodyleading_fp
 \fp_new:N  \g_@@_defaultfootleading_fp
-\fp_new:N  \g_@@_tmpa_fp
-\dim_new:N \g_@@_tmpa_dim
-\dim_new:N \g_@@_tmpb_dim
+\fp_new:N  \l_@@_tmpa_fp
+\dim_new:N \l_@@_tmpa_dim
+\dim_new:N \l_@@_tmpb_dim
 \group_begin:
   \normalsize
-  \dim_set:Nn    \g_@@_tmpa_dim { \f@size\p@ }
-  \dim_set_eq:NN \g_@@_tmpb_dim \f@baselineskip
-  \fp_set:Nn \g_@@_tmpa_fp { \dim_to_decimal_in_sp:n { \g_@@_tmpa_dim } }
-  \bool_if:NTF \g_@@_UseMSWordMultipleLineSpacing_bool
+  \dim_set:Nn    \l_@@_tmpa_dim { \f@size\p@ }
+  \dim_set_eq:NN \l_@@_tmpb_dim \f@baselineskip
+  \fp_set:Nn \l_@@_tmpa_fp { \dim_to_decimal_in_sp:n { \l_@@_tmpa_dim } }
+  \bool_if:NTF \g_@@_MSWordLineSpacingMultiple_bool
     {
-      \exp_args:Nnff \@@_msg_warning:nnn { UseMSWordMultipleLineSpacing }
+      \@@_msg_warning:nee { MSWord ~ Multiple ~ Line ~ Spacing }
         { \fp_use:N \g_@@_MSWordSinglespaceRatio_fp    }
         { \fp_use:N \g_@@_MSWordLineSpacingMultiple_fp }
       \fp_gset:Nn \g_@@_targetbodyleading_fp
         {
-          \g_@@_tmpa_fp * \g_@@_MSWordSinglespaceRatio_fp
+          \l_@@_tmpa_fp * \g_@@_MSWordSinglespaceRatio_fp
                         * \g_@@_MSWordLineSpacingMultiple_fp
         }
     }
     {
       \fp_gset:Nn \g_@@_targetbodyleading_fp
-        { \g_@@_tmpa_fp * \g_@@_bodytextleadingratio_fp }
+        { \l_@@_tmpa_fp * \g_@@_bodytextleadingratio_fp }
     }
   \fp_gset:Nn \g_@@_defaultbodyleading_fp
-    { \dim_to_decimal_in_sp:n { \g_@@_tmpb_dim } }
+    { \dim_to_decimal_in_sp:n { \l_@@_tmpb_dim } }
 \group_end:
 \group_begin:
   \footnotesize
-  \dim_set:Nn    \g_@@_tmpa_dim { \f@size\p@ }
-  \dim_set_eq:NN \g_@@_tmpb_dim \f@baselineskip
-  \fp_set:Nn \g_@@_tmpa_fp { \dim_to_decimal_in_sp:n { \g_@@_tmpa_dim } }
-  \bool_if:NTF \g_@@_UseMSWordMultipleLineSpacing_bool
+  \dim_set:Nn    \l_@@_tmpa_dim { \f@size\p@ }
+  \dim_set_eq:NN \l_@@_tmpb_dim \f@baselineskip
+  \fp_set:Nn \l_@@_tmpa_fp { \dim_to_decimal_in_sp:n { \l_@@_tmpa_dim } }
+  \bool_if:NTF \g_@@_MSWordLineSpacingMultiple_bool
     {
       \fp_gset:Nn \g_@@_targetfootleading_fp
         {
-          \g_@@_tmpa_fp * \g_@@_MSWordSinglespaceRatio_fp
+          \l_@@_tmpa_fp * \g_@@_MSWordSinglespaceRatio_fp
                         * \g_@@_MSWordLineSpacingMultiple_fp
         }
     }
     {
       \fp_gset:Nn \g_@@_targetfootleading_fp
-        { \g_@@_tmpa_fp * \g_@@_footnoteleadingratio_fp }
+        { \l_@@_tmpa_fp * \g_@@_footnoteleadingratio_fp }
     }
   \fp_gset:Nn \g_@@_defaultfootleading_fp
-    { \dim_to_decimal_in_sp:n { \g_@@_tmpb_dim } }
+    { \dim_to_decimal_in_sp:n { \l_@@_tmpb_dim } }
 \group_end:
 %    \end{macrocode}
 % \end{variable}
@@ -1009,7 +1056,7 @@ race, colour, sex, language\dots
   {
     \hook_gput_code:nnn { env / #1 / begin } { . }
       { \linespread { \l_@@_textlinespread_tl } \selectfont \ignorespaces }
-}
+  }
 %    \end{macrocode}
 % \end{macro}
 % \end{macro}
@@ -1049,7 +1096,7 @@ race, colour, sex, language\dots
       {
         \vcenter\bgroup
         \linespread { \l_@@_mathlinespread_tl } \selectfont \spread@equation
-      } {}{}
+      } {} {}
     \clist_map_inline:nn
       {
         array,
@@ -1082,7 +1129,8 @@ race, colour, sex, language\dots
       } { \RestoreMathEnvironmentLeading {#1} }
   }
   {
-    \@@_msg_warning:n { Not ~ Loaded ~ `mathtools' }
+    \@@_msg_warning:nnn { Not ~ Loaded ~ Package } { mathtools }
+      { Leading ~ in ~ multi-line ~ math ~ will ~ be ~ stretched }
     \newcommand*\SetMathEnvironmentSinglespace[1]
       {
         \@@_msg_error:nn { Illegal ~ Usage }
@@ -1092,7 +1140,7 @@ race, colour, sex, language\dots
       {
         \@@_msg_error:nn { Illegal ~ Usage }
           { \RestoreMathEnvironmentLeading }
-    }
+      }
   }
 %    \end{macrocode}
 % \end{macro}

--- a/zhlineskip/zhlineskip.dtx
+++ b/zhlineskip/zhlineskip.dtx
@@ -899,7 +899,7 @@ race, colour, sex, language\dots
     MSWordSinglespaceRatio              .fp_set:N   =
       \g_@@_MSWordSinglespaceRatio_fp,
     MSWordSinglespaceRatio              .initial:n  = { 1.296875 },
-    unknown                             .code:n     = \exp_args:Nno
+    unknown                             .code:n     =
       \@@_msg_error:ne { Unknown ~ Option } { \l_keys_key_str }
   }
 \ProcessKeyOptions [ ZhLS / pkgopt ]

--- a/zhlineskip/zhlineskip.dtx
+++ b/zhlineskip/zhlineskip.dtx
@@ -179,7 +179,7 @@ The Current Maintainer of this work is **Ruixi Zhang**.
   warnings-off = {mathtools-colon, mathtools-overbracket}
 }
 \setmathfont{texgyrepagella-math.otf}[
-  Scale             = 1.05924855491329480
+  Scale             = 1.059248554913295
 ]
 \setmainfont{texgyrepagella}[
   Extension         = .otf,
@@ -187,7 +187,7 @@ The Current Maintainer of this work is **Ruixi Zhang**.
   ItalicFont        = *-italic,
   BoldFont          = *-bold,
   BoldItalicFont    = *-bolditalic,
-  Scale             = 1.05924855491329480,
+  Scale             = 1.059248554913295,
   SmallCapsFeatures = {LetterSpace = 5}
 ]
 \setsansfont{texgyreheros}[
@@ -196,13 +196,13 @@ The Current Maintainer of this work is **Ruixi Zhang**.
   ItalicFont        = *-italic,
   BoldFont          = *-bold,
   BoldItalicFont    = *-bolditalic,
-  Scale             = 1.00685871056241427
+  Scale             = 1.006858710562414
 ]
 \setmonofont{Inconsolatazi4}[
   Extension         = .otf,
   UprightFont       = *-Regular,
   BoldFont          = *-Bold,
-  Scale             = 1.00118564817432455,
+  Scale             = 1.001185648174325,
   AutoFakeSlant     = .111
 ]
 \setCJKmainfont{Noto Serif CJK SC}[


### PR DESCRIPTION
closes #603 

## PR 概述
1. 对 `\ExplFileData` 的描述不要释放到 package 里面 —— 即使是开发者也 *一般* 不会直接去看 `.sty`, 而是去看 `.dtx` 文档; 同时这一定程度上违背了 DocStrip 的初衷, DocStrip 提取的 `installfiles` 就是干干净净的底层代码, 注释一律放到 `.dtx` 里.

2. `ctxdoc` 已经加载了 unicode-math, 所以应该在其之前就去 `\RequirePackage{mathtools}`, 这样 `zhlineskip.sty` 里的 `\RequirePackage{mathtools}` 就会失效, 也就保证了 `mathtools` 一定在 `unicode-math` 前加载; BTW, `unicode-math` 会弹出覆盖一些东西的警告, 也给通过选项 suppress 掉了.

3. 为了保证视觉效果, 使文档的 `monofont` 和 `CJKmainfont` 尺寸上匹配, 我经过了手段计算, 方法如下
```tex
\documentclass[cs-break, zihao = 5, a4paper, fontset = none]{ctxdoc}
\setmonofont{Inconsolatazi4}[
  Extension         = .otf,
  UprightFont       = *-Regular,
  BoldFont          = *-Bold,
  Scale             = 1,
  AutoFakeSlant     = .111
]
\setCJKmainfont{Noto Serif CJK SC}[
  UprightFont       = * Medium,
  ItalicFont        = * Black,
  BoldFont          = * Bold
]

\begin{document}

\sbox0{哈哈哈哈哈}

\sbox1{\cmd{ABCDEFGHIJKLMNOPQRSTUVWXYZfgpqy}}

\copy0

\copy1

\the \numexpr \ht0

\the \numexpr \ht1 + \the \numexpr \dp1

\end{document}
```
将得到的两个数字前者除以后者即可. 最后得到比值为 `1.00118564817432455`.
- 由于自行设置 CJK 字体, 所以改为 `fontset = none`.
- 同时 PR #603 建议关闭, 里面对 `zhlineskip` 手册涉及的问题全部解决.

> [实话实说] 之前为什么设置为 `<1` 的数: 因为这个包的选项名字太长了, 以至于超出了页边界; 但是后来我对 `docext` 模仿 `l3doc` 的 macro 和 `variable` 环境, 采用长名字水平压缩的手段, 如下图)
> <img width="925" height="1021" alt="image" src="https://github.com/user-attachments/assets/d3a9349d-8646-4371-9ea5-12d16dc0b95f" />

[注: CI 使用的镜像可能还未更新, @RuixiZhang42 可在明日 18:13 后上传, 那时候 99% 没问题的]

4. 同时对 `monofont` 启用伪斜体, 但是程度设置为 `.111 ≈ 1/9` 而非默认的 `.167`, 否则我看需要 `monofont` 伪斜体的地方太斜了以至于都和后面的贴上了 (在不使用 `\/` 的情况下).
4. 在 @RuixiZhang42 最初的设计中, 使用了 Boolean `UseMSWordMultipleLineSpacing`, 然后用户才被允许使用 `MSWordLineSpacingMultiple` 和 `MSWordSinglespaceRatio`, 这一点很麻烦, 而且经过测试, 用户在宏包选项中必须把 `UseMSWordMultipleLineSpacing` 放在 `MSWordSinglespaceRatio` 前面. 如今有了 LaTeX3, 这里放着了 `ctex` (`xeCJK` 里也有), 使用选项格式: `MSWordSinglespaceRatio` 不仅可以 `true` 和 `false`, 还可以支持数字; 并且在之前用户如果未把 `UseMSWordMultipleLineSpacing` 设置为 true 并直接使用 `MSWordSinglespaceRatio` 时, 如果是个不认真看手册的小白 TA 甚至自己都无法察觉到. 现在如果发生这种情况, 添加了 `AtEndOfPackage` 检测机制, 会弹出警告.
5. 修订了文档对 `初始值 (对应 `l3keys` 里的 `initial`)` 和 `默认值` (对应 `l3keys` 里的 `default`) 的划分.
6. 优化了警告/报错信息的描述; 经查阅 `interface3.pdf`, 得知 `\msg_<error/warning/info/...>:nnn` 存在 `e-type`, 所以在 `package option` 的 `unknown .code` 中删掉了 `\exp_args:` 展开命令.
7. 规范了一些变量名字. 既然提到了是 `临时浮点数与 |dim| 变量`, 那就要用 `\l_@@_...`, 而非 `\g_@@_...`, 更何况是夹在 `group` 里而且确实是临时计算的过程值.

## 自查
1. 无新包加入
2. 重大的修改: `UseMSWordMultipleLineSpacing` 已在 `\changes` 中填入
3. 编译好的手册 [zhlineskip.pdf](https://github.com/user-attachments/files/29408419/zhlineskip.pdf) 供浏览.