### PR TITLE
author(zhlineskip): Add co-author info

### DIFF
--- a/zhlineskip/README.md
+++ b/zhlineskip/README.md
@@ -51,4 +51,4 @@ version 2008 or later.
 
 This work has the LPPL maintenance status `maintained`.
 
-The Current Maintainer of this work are **Ruixi Zhang** and **Mingyu Xia**.
+The Current Maintainers of this work are **Ruixi Zhang** and **Mingyu Xia**.

--- a/zhlineskip/README.md
+++ b/zhlineskip/README.md
@@ -36,6 +36,9 @@ Copyright and Licence
 Copyright (C) 2018-2019 by Ruixi Zhang
 [`<ruixizhang42@gmail.com>`](mailto:ruixizhang42@gmail.com)
 
+Copyright (C) 2026 by Mingyu Xia
+[`<myhsia@outlook.com>`](mailto:myhsia@outlook.com)
+
 This work may be distributed and/or modified under the conditions
 of the LaTeX Project Public License (LPPL), either version 1.3c of
 this license or (at your option) any later version.
@@ -48,4 +51,4 @@ version 2008 or later.
 
 This work has the LPPL maintenance status `maintained`.
 
-The Current Maintainer of this work is **Ruixi Zhang**.
+The Current Maintainer of this work is **Ruixi Zhang** and **Mingyu Xia**.

--- a/zhlineskip/README.md
+++ b/zhlineskip/README.md
@@ -37,7 +37,7 @@ Copyright (C) 2018-2019 by Ruixi Zhang
 [`<ruixizhang42@gmail.com>`](mailto:ruixizhang42@gmail.com)
 
 Copyright (C) 2026 by Mingyu Xia
-[`<myhsia@outlook.com>`](mailto:myhsia@outlook.com)
+[`<xiamingyu@westlake.edu.cn>`](mailto:xiamingyu@westlake.edu.cn)
 
 This work may be distributed and/or modified under the conditions
 of the LaTeX Project Public License (LPPL), either version 1.3c of
@@ -51,4 +51,4 @@ version 2008 or later.
 
 This work has the LPPL maintenance status `maintained`.
 
-The Current Maintainer of this work is **Ruixi Zhang** and **Mingyu Xia**.
+The Current Maintainer of this work are **Ruixi Zhang** and **Mingyu Xia**.

--- a/zhlineskip/build.lua
+++ b/zhlineskip/build.lua
@@ -13,7 +13,7 @@
 module              = "zhlineskip"
 version             = "v1.0f"
 date                = "2026-06-28"
-maintainer          = "Ruixi Zhang, Mingyu Xia"
+maintainer          = "Mingyu Xia"
 email               = "myhsia@outlook.com"
 summary             = "Line spacing for CJK documents"
 description         = "This package supports typesetting CJK documents. It allows users to specify the two ratios between the leading and the font size of the body text and the footnote text. For CJK typesetting, these ratios usually range from 1.5 to 1.67. This package is also capable of restoring the math leading to that of the Latin text (usually 1.2 times the font size). Finally, it is possible to achieve the `Microsoft Word` multiple line spacing style using `zhlineskip`."

--- a/zhlineskip/build.lua
+++ b/zhlineskip/build.lua
@@ -12,9 +12,9 @@
 --]==========================================================================]--
 module              = "zhlineskip"
 version             = "v1.0f"
-date                = "2026-06-27"
-maintainer          = "Ruixi Zhang"
-email               = "ruixizhang42@gmail.com"
+date                = "2026-06-28"
+maintainer          = "Ruixi Zhang, Mingyu Xia"
+email               = "myhsia@outlook.com"
 summary             = "Line spacing for CJK documents"
 description         = "This package supports typesetting CJK documents. It allows users to specify the two ratios between the leading and the font size of the body text and the footnote text. For CJK typesetting, these ratios usually range from 1.5 to 1.67. This package is also capable of restoring the math leading to that of the Latin text (usually 1.2 times the font size). Finally, it is possible to achieve the `Microsoft Word` multiple line spacing style using `zhlineskip`."
 

--- a/zhlineskip/zhlineskip.dtx
+++ b/zhlineskip/zhlineskip.dtx
@@ -17,7 +17,7 @@
 %                                                                       *
 %   This work has the LPPL maintenance status `maintained'.             *
 %                                                                       *
-%   The Current Maintainer of this work is Ruixi Zhang and Mingyu Xia.  *
+%   The Current Maintainer of this work are Ruixi Zhang and Mingyu Xia. *
 % -----------------------------------------------------------------------
 %   This work consists of the files zhlineskip.dtx,                     *
 %                 the derived files zhlineskip.ins,                     *
@@ -90,7 +90,7 @@ version 2008 or later.
 
 This work has the LPPL maintenance status `maintained`.
 
-The Current Maintainer of this work is **Ruixi Zhang** and **Mingyu Xia**.
+The Current Maintainer of this work are **Ruixi Zhang** and **Mingyu Xia**.
 %</readme>
 %<*internal>
 \fi
@@ -121,7 +121,7 @@ The Current Maintainer of this work is **Ruixi Zhang** and **Mingyu Xia**.
                                                                       *
   This work has the LPPL maintenance status `maintained'.             *
                                                                       *
-  The Current Maintainer of this work is Ruixi Zhang and Mingyu Xia.  *
+  The Current Maintainer of this work are Ruixi Zhang and Mingyu Xia. *
 -----------------------------------------------------------------------
 \endpreamble
 \postamble

--- a/zhlineskip/zhlineskip.dtx
+++ b/zhlineskip/zhlineskip.dtx
@@ -3,6 +3,7 @@
 % File: zhlineskip.dtx
 % -----------------------------------------------------------------------
 %   Copyright (C) 2018-2019 by Ruixi Zhang <ruixizhang42@gmail.com>     *
+%   Copyright (C) 2026      by Mingyu Xia  <myhsia@outlook.com>         *
 % -----------------------------------------------------------------------
 %   This work may be distributed and/or modified under the conditions   *
 %   of the LaTeX Project Public License (LPPL), either version 1.3c of  *
@@ -16,7 +17,7 @@
 %                                                                       *
 %   This work has the LPPL maintenance status `maintained'.             *
 %                                                                       *
-%   The Current Maintainer of this work is Ruixi Zhang.                 *
+%   The Current Maintainer of this work is Ruixi Zhang and Mingyu Xia.  *
 % -----------------------------------------------------------------------
 %   This work consists of the files zhlineskip.dtx,                     *
 %                 the derived files zhlineskip.ins,                     *
@@ -74,6 +75,9 @@ Copyright and Licence
 Copyright (C) 2018-2019 by Ruixi Zhang
 [`<ruixizhang42@gmail.com>`](mailto:ruixizhang42@gmail.com)
 
+Copyright (C) 2026 by Mingyu Xia
+[`<myhsia@outlook.com>`](mailto:myhsia@outlook.com)
+
 This work may be distributed and/or modified under the conditions
 of the LaTeX Project Public License (LPPL), either version 1.3c of
 this license or (at your option) any later version.
@@ -86,7 +90,7 @@ version 2008 or later.
 
 This work has the LPPL maintenance status `maintained`.
 
-The Current Maintainer of this work is **Ruixi Zhang**.
+The Current Maintainer of this work is **Ruixi Zhang** and **Mingyu Xia**.
 %</readme>
 %<*internal>
 \fi
@@ -103,6 +107,7 @@ The Current Maintainer of this work is **Ruixi Zhang**.
 \preamble
 -----------------------------------------------------------------------
   Copyright (C) 2018-2019 by Ruixi Zhang <ruixizhang42@gmail.com>     *
+  Copyright (C) 2026      by Mingyu Xia  <myhsia@outlook.com>         *
 -----------------------------------------------------------------------
   This work may be distributed and/or modified under the conditions   *
   of the LaTeX Project Public License (LPPL), either version 1.3c of  *
@@ -116,7 +121,7 @@ The Current Maintainer of this work is **Ruixi Zhang**.
                                                                       *
   This work has the LPPL maintenance status `maintained'.             *
                                                                       *
-  The Current Maintainer of this work is Ruixi Zhang.                 *
+  The Current Maintainer of this work is Ruixi Zhang and Mingyu Xia.  *
 -----------------------------------------------------------------------
 \endpreamble
 \postamble
@@ -155,7 +160,7 @@ The Current Maintainer of this work is **Ruixi Zhang**.
 %<package>\NeedsTeXFormat{LaTeX2e}[2026/06/01]
 %<package>\RequirePackage{expl3}
 %<*package>
-%<+!driver>\GetIdInfo $Id: zhlineskip.dtx v1.0f 2026-06-27 Ruixi Zhang<ruixizhang42@gmail.com>$
+%<+!driver>\GetIdInfo $Id: zhlineskip.dtx v1.0f 2026-06-28 Ruixi Zhang, Mingyu Xia<myhsia@outlook.com>$
 %<package>  {Line spacing for CJK documents}
 %<package>\ProvidesExplPackage {\ExplFileName}
 %<!driver>  {\ExplFileDate} {\ExplFileVersion} {\ExplFileDescription}
@@ -232,10 +237,10 @@ The Current Maintainer of this work is **Ruixi Zhang**.
 \newenvironment{originalcases}{\env@cases}{\endarray\right.}
 \makeatother
 \usepackage{caption, docext, xurl, booktabs, hyperref}
-\captionsetup{format = hang, font   = small}
+\captionsetup{format = hang, font = small}
 \hypersetup{
   pdfstartview = FitH, pdftitle  = zhlineskip,
-  unicode      = true, pdfauthor = Ruixi Zhang
+  unicode      = true, pdfauthor = Ruixi Zhang and Mingyu Xia
 }
 \newcommand \mail[1] {\href{mailto:#1}{\ttfamily #1}}
 \begin{document}
@@ -268,7 +273,11 @@ The Current Maintainer of this work is **Ruixi Zhang**.
 %     \url{https://github.com/CTeX-org/ctex-kit}^^A
 %   }^^A
 % }
-% \author{张瑞熹\thanks{\mail{ruixizhang42@gmail.com}}}
+% \author{^^A
+%   张瑞熹\thanks{\mail{ruixizhang42@gmail.com}},^^A
+%   \texorpdfstring{\quad}{ }
+%   夏明宇\thanks{\mail{myhsia@outlook.com}}^^A
+% }
 % \date{Released \ZhLSFileDate\quad \texttt{\ZhLSFileVersion}}
 % \maketitle
 % \tableofcontents

--- a/zhlineskip/zhlineskip.dtx
+++ b/zhlineskip/zhlineskip.dtx
@@ -3,7 +3,7 @@
 % File: zhlineskip.dtx
 % -----------------------------------------------------------------------
 %   Copyright (C) 2018-2019 by Ruixi Zhang <ruixizhang42@gmail.com>     *
-%   Copyright (C) 2026      by Mingyu Xia  <myhsia@outlook.com>         *
+%   Copyright (C) 2026      by Mingyu Xia  <xiamingyu@westlake.edu.cn>  *
 % -----------------------------------------------------------------------
 %   This work may be distributed and/or modified under the conditions   *
 %   of the LaTeX Project Public License (LPPL), either version 1.3c of  *
@@ -76,7 +76,7 @@ Copyright (C) 2018-2019 by Ruixi Zhang
 [`<ruixizhang42@gmail.com>`](mailto:ruixizhang42@gmail.com)
 
 Copyright (C) 2026 by Mingyu Xia
-[`<myhsia@outlook.com>`](mailto:myhsia@outlook.com)
+[`<xiamingyu@westlake.edu.cn>`](mailto:xiamingyu@westlake.edu.cn)
 
 This work may be distributed and/or modified under the conditions
 of the LaTeX Project Public License (LPPL), either version 1.3c of
@@ -107,7 +107,7 @@ The Current Maintainer of this work is **Ruixi Zhang** and **Mingyu Xia**.
 \preamble
 -----------------------------------------------------------------------
   Copyright (C) 2018-2019 by Ruixi Zhang <ruixizhang42@gmail.com>     *
-  Copyright (C) 2026      by Mingyu Xia  <myhsia@outlook.com>         *
+  Copyright (C) 2026      by Mingyu Xia  <xiamingyu@westlake.edu.cn>  *
 -----------------------------------------------------------------------
   This work may be distributed and/or modified under the conditions   *
   of the LaTeX Project Public License (LPPL), either version 1.3c of  *
@@ -160,7 +160,7 @@ The Current Maintainer of this work is **Ruixi Zhang** and **Mingyu Xia**.
 %<package>\NeedsTeXFormat{LaTeX2e}[2026/06/01]
 %<package>\RequirePackage{expl3}
 %<*package>
-%<+!driver>\GetIdInfo $Id: zhlineskip.dtx v1.0f 2026-06-28 Ruixi Zhang, Mingyu Xia<myhsia@outlook.com>$
+%<+!driver>\GetIdInfo $Id: zhlineskip.dtx v1.0f 2026-06-28 Mingyu Xia<myhsia@outlook.com>$
 %<package>  {Line spacing for CJK documents}
 %<package>\ProvidesExplPackage {\ExplFileName}
 %<!driver>  {\ExplFileDate} {\ExplFileVersion} {\ExplFileDescription}
@@ -276,7 +276,7 @@ The Current Maintainer of this work is **Ruixi Zhang** and **Mingyu Xia**.
 % \author{^^A
 %   张瑞熹\thanks{\mail{ruixizhang42@gmail.com}},^^A
 %   \texorpdfstring{\quad}{ }
-%   夏明宇\thanks{\mail{myhsia@outlook.com}}^^A
+%   夏明宇\thanks{\mail{xiamingyu@westlake.edu.cn}}^^A
 % }
 % \date{Released \ZhLSFileDate\quad \texttt{\ZhLSFileVersion}}
 % \maketitle

--- a/zhlineskip/zhlineskip.dtx
+++ b/zhlineskip/zhlineskip.dtx
@@ -17,7 +17,7 @@
 %                                                                       *
 %   This work has the LPPL maintenance status `maintained'.             *
 %                                                                       *
-%   The Current Maintainer of this work are Ruixi Zhang and Mingyu Xia. *
+%   The Current Maintainers of this work are Ruixi Zhang and Mingyu Xia.*
 % -----------------------------------------------------------------------
 %   This work consists of the files zhlineskip.dtx,                     *
 %                 the derived files zhlineskip.ins,                     *
@@ -90,7 +90,7 @@ version 2008 or later.
 
 This work has the LPPL maintenance status `maintained`.
 
-The Current Maintainer of this work are **Ruixi Zhang** and **Mingyu Xia**.
+The Current Maintainers of this work are **Ruixi Zhang** and **Mingyu Xia**.
 %</readme>
 %<*internal>
 \fi
@@ -121,7 +121,7 @@ The Current Maintainer of this work are **Ruixi Zhang** and **Mingyu Xia**.
                                                                       *
   This work has the LPPL maintenance status `maintained'.             *
                                                                       *
-  The Current Maintainer of this work are Ruixi Zhang and Mingyu Xia. *
+  The Current Maintainers of this work are Ruixi Zhang and Mingyu Xia.*
 -----------------------------------------------------------------------
 \endpreamble
 \postamble


### PR DESCRIPTION
@RuixiZhang42 已把我添加至 `zhlineskip` 的 co-author, 我需要在下次上传的 `note` 中作出说明. 所以在发版前, 有个不确定的问题: `l3build` 是支持在 `uploadconfig` 表单中使用 `note` 这个选项的, 但是在最新的 CI 发版中使用方法我暂时不了解.

From CTAN:

```text
Hi Ruixi, Mingyu,

I have added Mingyu as an allowed uploader for zhlineskip. If Mingyu becomes credited as co-author, we will add this information in the next upload, such that the information in our database matches the code. Please leave a note with the next upload to remind us.

Best regards,

Vincent Goulet
for the CTAN Team
```