### PR TITLE
feat(ci): release-ctan-upload 支持 CTAN note 内部备注作为手动 input

### DIFF
--- a/.github/workflows/release-ctan-upload.yml
+++ b/.github/workflows/release-ctan-upload.yml
@@ -349,6 +349,27 @@ jobs:
           mv "$ASSET" "${DIR}/${MODULE}-ctan.zip"
           ls -la "${DIR}/${MODULE}-ctan.zip"
 
+      - name: Validate note length
+        # CTAN 表单 note 字段上限 4096 字符 (l3build-upload.lua ctan_field 写死).
+        # 提前在 workflow 内卡掉超长 note 比让 l3build 跑到 CTAN 服务端再返回
+        # 错误友好得多 — 后者要等真的 POST 一轮才能拿到反馈.
+        # 走 env 不走 ${{ }} 字符串插值, 防 note 内嵌 shell 元字符注入.
+        env:
+          NOTE: ${{ inputs.note }}
+        run: |
+          if [ -z "$NOTE" ]; then
+            echo "::notice::No CTAN note provided."
+            exit 0
+          fi
+          # 用 ${#NOTE} 数字符数; bash 默认按 byte 数 (locale=C), UTF-8 多字节
+          # 字符按字节算偏严, 但 CTAN 4096 上限本身也是 byte 级, 一致.
+          LEN=${#NOTE}
+          echo "::notice::CTAN note length: ${LEN} bytes (limit 4096)."
+          if [ "$LEN" -gt 4096 ]; then
+            echo "::error::CTAN note 超过 4096 byte 上限 (实际 ${LEN}). 请缩短后重新触发 workflow." >&2
+            exit 1
+          fi
+
       - name: Run l3build upload
         working-directory: ${{ needs.prepare-announcement.outputs.dir }}
         env:

--- a/.github/workflows/release-ctan-upload.yml
+++ b/.github/workflows/release-ctan-upload.yml
@@ -27,6 +27,12 @@ on:
         description: 'CTAN 上传者 email (CTAN reviewer 回邮地址)'
         required: true
         type: string
+      note:
+        description: 'CTAN 内部备注 (可选, ≤4096 字符). 用于告知 CTAN 团队
+          维护者变更等需要 reviewer 注意的事项. 留空则不写 note 字段.'
+        required: false
+        type: string
+        default: ''
       dry_run:
         description: '只跑 l3build upload --dry-run, 不真上传'
         required: true
@@ -352,6 +358,11 @@ jobs:
           # 不需要把个人信息硬编码进 git, 本地跑 l3build upload 也是同一套.
           CTAN_UPLOADER: ${{ inputs.uploader }}
           CTAN_EMAIL: ${{ inputs.email }}
+          # ctex_kit_uploadconfig() 同样从 env 读 note (CTAN 内部备注).
+          # l3build CLI 不暴露 --note, 仅认 uploadconfig.note / note_file.
+          # input 留空时 GH Actions 会注入空串 "", build-config.lua 的
+          # ctex_kit_env_or_nil() 把空串当成 nil, 不会写入空 note 字段.
+          CTAN_NOTE: ${{ inputs.note }}
         run: |
           # --file 把 announcement.md 喂给 CTAN announcement 表单.
           # --email 显式再传一次 (l3build CLI 接受, 兜底防 build.lua 里漏读 env).
@@ -387,6 +398,10 @@ jobs:
 
       - name: Summary
         if: always()
+        env:
+          # 走 env 不走 ${{ }} 字符串插值, 防 note 内嵌 shell 元字符
+          # (`$(...)` / `` ` `` / `;` / 换行) 注入命令.
+          NOTE: ${{ inputs.note }}
         run: |
           echo "## CTAN Upload Summary" >> $GITHUB_STEP_SUMMARY
           echo "- **Package**: ${{ needs.prepare-announcement.outputs.pkg }} v${{ needs.prepare-announcement.outputs.ver }}" >> $GITHUB_STEP_SUMMARY
@@ -394,4 +409,12 @@ jobs:
           echo "- **CTAN Path**: ${{ needs.prepare-announcement.outputs.ctan_path }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Uploader**: ${{ inputs.uploader }} <${{ inputs.email }}>" >> $GITHUB_STEP_SUMMARY
           echo "- **Mode**: ${{ inputs.dry_run == true && 'DRY-RUN' || 'LIVE' }}" >> $GITHUB_STEP_SUMMARY
+          if [ -n "$NOTE" ]; then
+            {
+              echo "- **Note to CTAN**:"
+              echo '  ```'
+              printf '%s\n' "$NOTE" | sed 's/^/  /'
+              echo '  ```'
+            } >> $GITHUB_STEP_SUMMARY
+          fi
           echo "- **Result**: ${{ job.status }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release-ctan-upload.yml
+++ b/.github/workflows/release-ctan-upload.yml
@@ -350,7 +350,7 @@ jobs:
           ls -la "${DIR}/${MODULE}-ctan.zip"
 
       - name: Validate note length
-        # CTAN 表单 note 字段上限 4096 字符 (l3build-upload.lua ctan_field 写死).
+        # CTAN 表单 note 字段上限 4096 byte (l3build-upload.lua ctan_field 写死).
         # 提前在 workflow 内卡掉超长 note 比让 l3build 跑到 CTAN 服务端再返回
         # 错误友好得多 — 后者要等真的 POST 一轮才能拿到反馈.
         # 走 env 不走 ${{ }} 字符串插值, 防 note 内嵌 shell 元字符注入.
@@ -361,9 +361,10 @@ jobs:
             echo "::notice::No CTAN note provided."
             exit 0
           fi
-          # 用 ${#NOTE} 数字符数; bash 默认按 byte 数 (locale=C), UTF-8 多字节
-          # 字符按字节算偏严, 但 CTAN 4096 上限本身也是 byte 级, 一致.
-          LEN=${#NOTE}
+          # 用 wc -c 数 byte; bash 的 ${#NOTE} 在 LANG=C.UTF-8 (GH runner 默认)
+          # 下数的是 Unicode 字符数而非 byte 数, 中文等多字节字符会让校验偏宽.
+          # CTAN 4096 上限是 byte 级, 必须按 byte 算.
+          LEN=$(printf '%s' "$NOTE" | wc -c)
           echo "::notice::CTAN note length: ${LEN} bytes (limit 4096)."
           if [ "$LEN" -gt 4096 ]; then
             echo "::error::CTAN note 超过 4096 byte 上限 (实际 ${LEN}). 请缩短后重新触发 workflow." >&2

--- a/support/build-config.lua
+++ b/support/build-config.lua
@@ -232,13 +232,24 @@ function read_dtx_version(dtx_path)
   return content:match("\\GetIdInfo%s+%$Id:%s+%S+%s+v?([%w%.]+)%s")
 end
 
+-- env 读取小工具: GH Actions `env: X: ${{ inputs.x }}` 在 input 留空时
+-- 会注入空串 "", 而 `os.getenv("X") or fallback` 把空串当 truthy, 不会
+-- 走 fallback. 这里把 nil 和 "" 一并视为未设置, 让 uploadconfig 的
+-- `opts.note or ctex_kit_env_or_nil("CTAN_NOTE")` 在空 input 时跳过.
+function ctex_kit_env_or_nil(name)
+  local v = os.getenv(name)
+  if v == nil or v == "" then return nil end
+  return v
+end
+
 -- 构造 l3build uploadconfig 表. 仓库公共字段固定写在这里, 各包传 opts 覆写
 -- pkg / version / author / summary / description / ctanPath 等差异字段.
 --
--- 注意: uploader / email 留空 (从环境变量读), 由 release-ctan-upload.yml
--- workflow 用 `CTAN_UPLOADER=... CTAN_EMAIL=... l3build upload` 注入, 避免
--- 把任何个人 email 落到 git 里. l3build CLI 只支持 --email 覆盖, 不支持
--- --uploader, 所以走 env 是最通用的办法 (本地 / CI 同一套).
+-- 注意: uploader / email / note 留空 (从环境变量读), 由 release-ctan-upload.yml
+-- workflow 用 `CTAN_UPLOADER=... CTAN_EMAIL=... CTAN_NOTE=... l3build upload`
+-- 注入, 避免把任何个人 email / 临时备注落到 git 里. l3build CLI 只支持
+-- --email 覆盖, 不支持 --uploader / --note, 所以走 env 是最通用的办法
+-- (本地 / CI 同一套).
 function ctex_kit_uploadconfig(opts)
   return {
     pkg               = opts.pkg,
@@ -246,6 +257,13 @@ function ctex_kit_uploadconfig(opts)
     author            = opts.author,
     uploader          = opts.uploader     or os.getenv("CTAN_UPLOADER"),
     email             = opts.email        or os.getenv("CTAN_EMAIL"),
+    -- CTAN reviewer 内部备注 (≤4096 字符). l3build CLI 不暴露 note 参数,
+    -- 仅认 uploadconfig.note / note_file. 走 env 与 uploader/email 一致,
+    -- 避免把临时备注写进 build.lua. release-ctan-upload.yml 用 workflow
+    -- input 注入 CTAN_NOTE; 本地跑 l3build upload 也是同一套.
+    -- CTAN_NOTE 留空 (workflow input 默认值) 时 GH Actions 会注入空串,
+    -- 需显式过滤为 nil — 否则 l3build 会把空 note 字段提交给 CTAN.
+    note              = opts.note         or ctex_kit_env_or_nil("CTAN_NOTE"),
     license           = opts.license       or "lppl1.3c",
     summary           = opts.summary,
     description       = opts.description,


### PR DESCRIPTION
## Summary

- 给 `release-ctan-upload.yml` 加 `workflow_dispatch` input `note`（可选, ≤4096 字符），用来在上传 CTAN 时附带内部备注（给 CTAN reviewer 看）。
- l3build CLI 不暴露 `--note`（`--message` 实际写入的是 `announcement`，不是 `note`），所以沿用 `uploader/email` 的模式：从 `CTAN_NOTE` env 读入 `uploadconfig.note`。
- 新增 `ctex_kit_env_or_nil()` 把 nil 和 `""` 一并视作未设置——避免 workflow input 留空时空串经 `os.getenv` 被当 truthy，把空 note 字段提交给 CTAN。
- Summary 显示 note 时走 `env:` 注入而非 `${{ inputs.note }}` 字符串插值，防 shell 元字符（反引号 / `$(...)` / `;` / 换行）注入命令。

## 动机

#912 需要在下次 zhlineskip 发版时告知 CTAN team「Mingyu Xia 已成为正式 co-author，请更新数据库」。CTAN team 也明确要求这次上传时留 note。

本 PR 一次性解决"以后再有类似元数据变更需要附 note"的通用问题，而不是临时硬编码这一次的内容到 build.lua。

## Test plan

- [x] `support/build-config.lua` `luac -p` 语法通过
- [x] 单元测试 `ctex_kit_env_or_nil` 三种场景（CTAN_NOTE 未设置 / 空串 / 有值）输出符合预期
- [ ] 实际跑 release-ctan-upload workflow 的 dry-run（dry_run=true），note 设为非空字符串，确认 l3build upload `--dry-run` 输出里 note 字段被填上
- [ ] 实际跑 release-ctan-upload workflow 的 dry-run（dry_run=true），note 留空，确认 l3build upload `--dry-run` 输出里没有 note 字段

Closes part of #912 (note injection mechanism).