### PR TITLE
fix(support): 去掉 home 默认值, 避免与 repository URL 重复触发 CTAN 去重提示

### DIFF
--- a/support/build-config.lua
+++ b/support/build-config.lua
@@ -269,7 +269,13 @@ function ctex_kit_uploadconfig(opts)
     description       = opts.description,
     topic             = opts.topic         or { "chinese" },
     ctanPath          = opts.ctanPath,
-    home              = opts.home          or "https://github.com/CTeX-org/ctex-kit",
+    -- home 字段刻意不设默认值: 默认 home 会与 repository 同为
+    -- https://github.com/CTeX-org/ctex-kit, CTAN 对同一包内重复 URL 会
+    -- 自动去重并在每次上传回执里提示 "I omitted the identical URL for
+    -- 'Home'. (Mind that we wish to use each URL only once.)". 留空 ⟹
+    -- l3build ctan_field 跳过 home, CTAN 上 source repository 链接已涵盖
+    -- 同一 URL 的导航需求 (见 #914).
+    home              = opts.home,
     bugtracker        = opts.bugtracker
                       or "https://github.com/CTeX-org/ctex-kit/issues",
     support           = opts.support


### PR DESCRIPTION
## Summary

- CTAN 对同一包内重复 URL 自动去重，每次上传回执都会提示 `I omitted the identical URL for "Home". (Mind that we wish to use each URL only once.)`，原因是 `ctex_kit_uploadconfig` 把 `home` 和 `repository` 都默认设为 `https://github.com/CTeX-org/ctex-kit`。
- 本 PR 去掉 `home` 默认值（仍保留 `opts.home` 显式覆盖通路），让 l3build `ctan_field` 跳过 home 字段。CTAN 上 source repository 链接已涵盖同一 URL 的导航需求。
- bugtracker 和 support 同样都默认指向 issues 链接，但 #914 原文范围只点了 home，按 user 意见此次只处理 home，未来如 CTAN 再提示再单独修。

## Verification

本地用 `l3build upload --debug`（POST 到 `httpbin.org/post` 而非真 CTAN）跑 zhlineskip dry-run，form 字段中 `home` 已消失，`repository / bugtracker / support / development` 保留：

```
"bugtracker": "https://github.com/CTeX-org/ctex-kit/issues",
"development": "https://github.com/CTeX-org",
"repository": "https://github.com/CTeX-org/ctex-kit",
"support":    "https://github.com/CTeX-org/ctex-kit/issues",
```

## Test plan

- [x] 本地 dry-run 确认 home 字段从 form 中消失
- [ ] 下次真上传 zhlineskip / ctex / xeCJK 到 CTAN 时回执不再出现 "I omitted the identical URL" 提示

Closes #914.