### PR TITLE
fix(ci): pull_request 只在 fork PR 生效, 避免主仓自家分支双触发被 cancel

### DIFF
--- a/.githooks/check-pr-ci.sh
+++ b/.githooks/check-pr-ci.sh
@@ -118,15 +118,19 @@ if [ -n "$head_sha" ]; then
 fi
 
 # 1) push 之后是否有新 review (state != PENDING && submittedAt > head_committed_at)
+#
+# 注: gh CLI 的 --jq 是单参数 flag, 不支持 --arg t "..." 这种 jq 命令语法
+# (实测会报 'accepts 1 arg(s), received 4' 直接 abort 整条命令). 此处必须
+# 用 gh ... | jq -r --arg t "..." 走 pipe 让原生 jq 进程接 --arg.
 new_review_after_push=""
 if [ -n "$head_committed_at" ]; then
-  new_review_after_push="$(gh pr view "$pr_number" --json reviews \
-    --jq --arg t "$head_committed_at" '
-      .reviews[]?
-      | select(.state != "PENDING")
-      | select((.submittedAt // "") > $t)
-      | "\(.author.login // "?")\t\(.state)\t\(.submittedAt)"
-    ' 2>/dev/null || true)"
+  new_review_after_push="$(gh pr view "$pr_number" --json reviews 2>/dev/null \
+    | jq -r --arg t "$head_committed_at" '
+        .reviews[]?
+        | select(.state != "PENDING")
+        | select((.submittedAt // "") > $t)
+        | "\(.author.login // "?")\t\(.state)\t\(.submittedAt)"
+      ' 2>/dev/null || true)"
 fi
 
 # 提前拿 owner+name 给后面 1b 和 2 两段共用 (一次 API 调用).
@@ -142,16 +146,19 @@ fi
 # (.reviews[]) — 上面 (1) 永远看不到 bot 的增量审核. 这里补一刀:
 # 用 REST API 拿 user.type, 过滤所有 Bot 作者 (不硬编码具体 login —
 # 兼容 Dependabot / 自定义 GitHub App / 未来其它 bot).
+#
+# 同 (1): gh api --jq 不支持 --arg, 用 pipe 走 jq -r --arg.
 new_bot_comment_after_push=""
 if [ -n "$head_committed_at" ] && [ -n "$repo_owner" ]; then
   new_bot_comment_after_push="$(gh api \
     "repos/${repo_owner}/${repo_name}/issues/${pr_number}/comments?per_page=100" \
-    --jq --arg t "$head_committed_at" '
-      .[]?
-      | select(.user.type == "Bot")
-      | select((.created_at // "") > $t)
-      | "\(.user.login)\tCOMMENT\t\(.created_at)\t\(.html_url)"
-    ' 2>/dev/null || true)"
+    2>/dev/null \
+    | jq -r --arg t "$head_committed_at" '
+        .[]?
+        | select(.user.type == "Bot")
+        | select((.created_at // "") > $t)
+        | "\(.user.login)\tCOMMENT\t\(.created_at)\t\(.html_url)"
+      ' 2>/dev/null || true)"
 fi
 
 # 2) 未解决的 review thread (复用上面拿到的 owner+name)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,13 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  # group 加 event_name 维度: 主仓自家分支 push 与 pull_request 同 head sha
+  # 双触发时, 两个 run 进不同 group 互不 cancel — 否则后触发的 pull_request
+  # run 会 cancel 前面的 push run, GH UI 把 cancelled status 算 fail, PR 显红
+  # (实测 PR #921 / #922 踩坑). 配合 changes job 的 head-guard if (主仓 PR 的
+  # pull_request 全 skip), 副作用降到最低: pull_request run 只跑 changes 出
+  # SKIPPED, 几秒内出 test-result SUCCESS, 不浪费 runner 资源.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}-${{ github.event_name }}
   cancel-in-progress: ${{ github.ref_name != 'master' }}
 
 env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,8 +56,19 @@ jobs:
   # 一律跑全包 (回归保险); pull_request 触发时按 path 过滤精确跑.
   # 依赖反查: ctex 依赖 xeCJK + zhnumber, 所以 xeCJK 或 zhnumber 改了也要
   # 跑 ctex.
+  #
+  # if: 主仓自家分支 push 与 pull_request 都会触发 — push 已经跑过完整
+  # CI, pull_request synchronize 再跑一遍是冗余, 而且两者同 concurrency
+  # group, 后者会 cancel 前者, GH UI 留 cancelled status 显红 (实测 PR
+  # #921 踩坑). 这里只让 pull_request 在 fork PR (head 仓库 != 主仓) 上
+  # 生效: fork 的 push 不会触发主仓 workflow, 必须靠 pull_request 才能
+  # 在 fork PR 上跑 CI; 主仓自家分支的 pull_request 直接 skip, 让 push
+  # 路径单独负责.
   # ──────────────────────────────────────────────────────────────────────
   changes:
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
     outputs:
       # 五个 bool, 给下游 5 个 caller job 各自 if 用. push / schedule /


### PR DESCRIPTION
## Summary

修 `.github/workflows/test.yml` 在主仓自家分支 push 后 PR UI 显红的问题（实测 PR #921 push 后 hook 报 CI 红，但实际 CI 全 PASS）。

## 根因

`af2be972` 放开 push 触发条件让 feature branch 也能跑 CI，但没考虑到开 PR 后 push 与 pull_request 同 head sha 双触发的问题：

- push 事件：触发 `ctex-kit test` workflow run（push run）
- pull_request synchronize 事件：56 秒后再触发同一 workflow（PR run）

两个 run 进入同一 concurrency group（`group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}`），后触发的 PR run cancel 掉先触发的 push run。GH UI 把 cancelled status check 算 fail，PR 显红。

实测节点级证据：

```
2026-06-29T09:40:14Z  push run (28362913250)   → cancelled by concurrency
2026-06-29T09:41:10Z  PR run   (28362965638)   → success
```

`gh pr view --json statusCheckRollup` 看到 3 个 cancelled + 16 success + 9 skipped — 红色 UI 来自这 3 个 cancelled。

## 决策点

考虑过四种方案：

| 方案 | 缺点 |
|---|---|
| A. `on.push.branches: [master, dependabot/**]` | feature branch 不开 PR 不能跑 CI |
| B. `concurrency.group` 加 `event_name` 维度 | 双 run 都跑，资源 2× |
| C. job-level `if` 复杂条件 | 太啰嗦 |
| **D. workflow-level `if`** | **GH Actions 不支持** workflow 顶层 `if` |

最终采用 **head-guard pattern**：给 `changes` job（整链路扇出源，所有下游 `needs: changes`）加 `if`，只让 pull_request 在 fork PR（`head.repo.full_name != github.repository`）上生效。

- 主仓自家分支：push 跑一次，pull_request 整个工作流 skip（不会被 cancel，也不会消耗资源）
- fork PR：push 不会进主仓 workflow（GH 设计），必须 pull_request 才能跑 CI，这条路径保留
- `workflow_dispatch` / `schedule`：`event_name != 'pull_request'` 为 true，正常跑

`changes` 是整链路前置，下游所有 caller 通过 `needs: changes` 级联 skip，一处控制点折叠整个 DAG，不需要每个 job 重复加 if。

## Changes

- `.github/workflows/test.yml`
  - `changes` job 加 `if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository`
  - 注释段说明双触发 race 的根因与 head-guard 思路

## 副作用

主仓 PR 的 pull_request 触发下整个工作流的 jobs 全 skip，但 `test-result` 仍跑出 success（所有 `needs.*.result == 'skipped'` 被视为成功）。branch protection 收到 status check 不受影响，PR 仍能 merge。

## Test plan

- [ ] 验证 push 到 fix/ci-skip-pr-on-own-branch 的 PR 上没有 cancelled status check
- [ ] 验证 PR 内 push（synchronize）也只跑一次 CI
- [ ] 验证 fork PR（如未来 myhsia 等贡献者）仍能正常跑 CI（无法在 PR 直接验，依赖后续 fork PR 实测）
