### PR TITLE
fix(xeCJK): 为 l3doc \__codedoc_meta:n 加 hbox wrap (#920)

### DIFF
--- a/xeCJK/testfiles/codedoc-meta-ecglue01.lvt
+++ b/xeCJK/testfiles/codedoc-meta-ecglue01.lvt
@@ -1,0 +1,89 @@
+\input{regression-test}
+
+\documentclass{article}
+
+\usepackage{xeCJK}
+\setCJKmainfont{FandolSong-Regular.otf}
+
+% Simulate l3doc's \__codedoc_meta:n: $\langle$ #1 $\rangle$.
+% xeCJK patch wraps content with \hbox:n and drains preceding marker kern.
+\makeatletter
+\ExplSyntaxOn
+\cs_new_protected:Npn \__codedoc_meta:n #1
+  {
+    \ensuremath { \langle }
+    #1
+    \ensuremath { \rangle }
+  }
+\ExplSyntaxOff
+\makeatother
+
+\begin{document}
+
+\START
+
+% --- Test 1: \meta content compact at \langle boundary ---
+% \__codedoc_meta:n content should be wrapped in \hbox by xeCJK patch,
+% isolating internal Default<->CJK transitions and removing the auto-inserted
+% \CJKecglue at \langle/\rangle boundaries.
+
+\makeatletter
+\ExplSyntaxOn
+\setbox0=\hbox{\__codedoc_meta:n {键值列表}}
+\ExplSyntaxOff
+\makeatother
+\setbox1=\hbox{$\langle$\hbox{键值列表}$\rangle$}
+\setbox2=\hbox{$\langle$键值列表$\rangle$}
+
+\TEST{meta content wrapped in hbox isolates transitions (920)}{
+  % Patched box0 should be equivalent to box1 (manual hbox wrap).
+  % Unpatched box2 (without hbox) has 2 extra ecglues (3.33 each ≈ 6.66pt).
+  \TYPE{INFO: wd0=\the\wd0, wd1(target)=\the\wd1, wd2(unpatched)=\the\wd2}
+  \dimen0=\wd0 \advance\dimen0 by -\wd1
+  \ifdim\dimen0<0pt \dimen0=-\dimen0 \fi
+  \ifdim\dimen0<1pt
+    \TYPE{PASS: patched matches hbox-wrapped reference (diff: \the\dimen0)}
+  \else
+    \TYPE{FAIL: patched diverges from hbox-wrapped reference (diff: \the\dimen0)}
+  \fi
+  % Also check patched is narrower than unpatched
+  \dimen2=\wd2 \advance\dimen2 by -\wd0
+  \ifdim\dimen2>3pt
+    \TYPE{PASS: patched is narrower than unpatched (saved: \the\dimen2)}
+  \else
+    \TYPE{FAIL: patched did not reduce width (diff: \the\dimen2)}
+  \fi
+}
+
+% --- Test 2: \meta outer ecglue preserved (CJK ... \meta ... CJK) ---
+% \meta wrapped in CJK context should still have outer ecglue between
+% surrounding CJK and \langle/\rangle. The drain pattern in the patch
+% removes the cached CJK marker kern and emits ecglue at the entry point.
+% Reference box4 has \hbox{中文} content but no \hbox wrapping inside
+% the outer hbox, so its outer Default<->CJK transitions also fire.
+% After our patch box3 should produce equivalent layout to box4.
+
+\makeatletter
+\ExplSyntaxOn
+\setbox3=\hbox{中文 \__codedoc_meta:n {中文} 西文}
+\ExplSyntaxOff
+\makeatother
+\setbox4=\hbox{中文$\langle$\hbox{中文}$\rangle$西文}
+
+\TEST{outer ecglue preserved around \string\meta (920)}{
+  % box3 should equal box4 (both have outer ecglue from drain/transition,
+  % no inner ecglue because content is hbox-wrapped).
+  \TYPE{INFO: wd3=\the\wd3, wd4(target)=\the\wd4}
+  \dimen0=\wd3 \advance\dimen0 by -\wd4
+  \ifdim\dimen0<0pt \dimen0=-\dimen0 \fi
+  \ifdim\dimen0<1pt
+    \TYPE{PASS: outer ecglue preserved (diff: \the\dimen0)}
+  \else
+    \TYPE{FAIL: outer ecglue mismatch (diff: \the\dimen0)}
+  \fi
+}
+
+\END
+
+\end{document}
+

--- a/xeCJK/testfiles/codedoc-meta-ecglue01.tlg
+++ b/xeCJK/testfiles/codedoc-meta-ecglue01.tlg
@@ -1,0 +1,19 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+LaTeX Font Info:    External font `cmex10' loaded for size
+(Font)              <7> on input line ....
+LaTeX Font Info:    External font `cmex10' loaded for size
+(Font)              <5> on input line ....
+============================================================
+TEST 1: meta content wrapped in hbox isolates transitions (920)
+============================================================
+INFO: wd0=47.7778pt, wd1(target)=47.7778pt, wd2(unpatched)=54.4378pt
+PASS: patched matches hbox-wrapped reference (diff: 0.0pt)
+PASS: patched is narrower than unpatched (saved: 6.66pt)
+============================================================
+============================================================
+TEST 2: outer ecglue preserved around \string \meta (920)
+============================================================
+INFO: wd3=74.4378pt, wd4(target)=74.4378pt
+PASS: outer ecglue preserved (diff: 0.0pt)
+============================================================

--- a/xeCJK/xeCJK.dtx
+++ b/xeCJK/xeCJK.dtx
@@ -9968,6 +9968,10 @@ Copyright and Licence
 % 没有 marker 时 else 分支故意留空——与 \cs{@@_drain_ecglue:} 的唯一
 % 差别即在此处，不调用 \cs{tl_gclear:N} 是为了不破坏入口前的合法状态。
 %
+% 此 drain 还被 \cs{@@_patch_codedoc_meta:}（\#920 \pkg{l3doc} \cs{meta}
+% 补丁）复用：\cs{meta} 出口同样有 token-level interchar，需要保留
+% |\g_@@_last_node_tl| 状态。新增 drain 调用点请同步更新本节注释。
+%
 % \begin{macro}[int]{\@@_drain_ecglue_verb:,\@@_patch_verb:}
 %    \begin{macrocode}
 \cs_new_protected:Npn \@@_drain_ecglue_verb:
@@ -10019,11 +10023,12 @@ Copyright and Licence
 % \cs{__codedoc_meta_original:n} 入口的 \cs{ensuremath} math 节点把
 % 缓存的 CJK 标记 kern 遮蔽在自己之后，下游 transition 探测不到
 % marker，原本的 \texttt{CJKecglue} 也跟着丢。
-% 与 \pkg{url}（\#880）、\cs{verb}（\#910）同型，此处在 \cs{__codedoc_meta:n}
-% 入口调用 \cs{@@_drain_ecglue_verb:} 排空 marker 并补 \cs{CJKecglue}，
-% 恢复 outer 左侧边界的 ecglue；复用 \texttt{verb} 版本（else 分支
-% 不清 \cs{g_@@_last_node_tl}）：\cs{meta} 出口仍走 token-level
-% interchar，需要保留 tl 状态。
+% 与 \pkg{url}（\#880）、\cs{verb}（\#910，参见 \cs{@@_patch_verb:}）同型，
+% 此处在 \cs{__codedoc_meta:n} 入口调用 \cs{@@_drain_ecglue_verb:} 排空
+% marker 并补 \cs{CJKecglue}，恢复 outer 左侧边界的 ecglue；复用
+% \texttt{verb} 版本 drain（else 分支不清 \cs{g_@@_last_node_tl}）：
+% \cs{meta} 出口仍走 token-level interchar，需要保留 tl 状态。
+% \cs{@@_drain_ecglue_verb:} 的注释也列出此调用点。
 %
 % \cs{rangle} 之后到外部字符的 ecglue 仍由 \cs{__codedoc_meta:n}
 % 末尾 \cs{ensuremath} 退出后的 \texttt{Default\textrightarrow CJK}

--- a/xeCJK/xeCJK.dtx
+++ b/xeCJK/xeCJK.dtx
@@ -9998,6 +9998,65 @@ Copyright and Licence
 %    \end{macrocode}
 % \end{macro}
 %
+% \changes{v3.10.1}{2026/06/30}{为 \pkg{l3doc} 的 \cs{__codedoc_meta:n}
+%   添加补丁，将参数内容包入 \cs{hbox:n}，
+%   修复 \cs{meta} 内首字符前出现多余 \texttt{CJKecglue} 的问题（\#920）。}
+%
+% \pkg{l3doc} 类的 \cs{__codedoc_meta:n} 排版 \cs{meta} 命令的参数：
+% 由 \cs{__codedoc_meta_original:n} 输出 \texttt{\$\textbackslash langle\$}（数学节点）、
+% 内容、\texttt{\$\textbackslash rangle\$}。
+% 当内容首字符是 CJK 时，\texttt{Default\textrightarrow CJK} 类别转换的
+% \cs{xeCJK_pre_inter_class_toks:nnn} 自动 prepend \cs{CJKecglue}，
+% 在 \texttt{\$\textbackslash langle\$} 与首 CJK 字符之间产生多余间距。
+%
+% 此处采用与 myhsia 在 \pkg{hyperref}/\pkg{hypdoc} 兼容议题中提出的
+% \texttt{hbox} 包装方案：将 \cs{__codedoc_meta:n} 的参数包入
+% \cs{hbox:n}，\cs{hbox} 隔离了内部的 \XeTeX{} interchar transitions，
+% 使得 \texttt{Default\textrightarrow CJK} transition 不会跨越 \texttt{hbox}
+% 边界触发，从而避免插入多余 \cs{CJKecglue}。
+%
+% 仅 hbox 包装会丢失 \cs{meta} 之前 CJK 与 \cs{meta} 之间的边界 ecglue：
+% \cs{__codedoc_meta_original:n} 入口的 \cs{ensuremath} math 节点把
+% 缓存的 CJK 标记 kern 遮蔽在自己之后，下游 transition 探测不到
+% marker，原本的 \texttt{CJKecglue} 也跟着丢。
+% 与 \pkg{url}（\#880）、\cs{verb}（\#910）同型，此处在 \cs{__codedoc_meta:n}
+% 入口调用 \cs{@@_drain_ecglue_verb:} 排空 marker 并补 \cs{CJKecglue}，
+% 恢复 outer 左侧边界的 ecglue；复用 \texttt{verb} 版本（else 分支
+% 不清 \cs{g_@@_last_node_tl}）：\cs{meta} 出口仍走 token-level
+% interchar，需要保留 tl 状态。
+%
+% \cs{rangle} 之后到外部字符的 ecglue 仍由 \cs{__codedoc_meta:n}
+% 末尾 \cs{ensuremath} 退出后的 \texttt{Default\textrightarrow CJK}
+% transition 正常处理。
+%
+% 由于 \cs{__codedoc_meta:n} 与 \cs{Arg}、\cs{oarg}、\cs{parg} 等共用，
+% 此补丁也间接修复后者的类似问题。
+%
+% 选择 \cs{@@_at_end_preamble:n} 而非 \cs{@@_package_hook:nn}：
+% \pkg{l3doc} 是文档类，文档类加载早于 \pkg{xeCJK}，需要在 preamble 结束时
+% 才能确定 \cs{__codedoc_meta:n} 是否定义。
+%
+% \begin{macro}[int]{\@@_patch_codedoc_meta:}
+%    \begin{macrocode}
+\cs_new_protected:Npn \@@_patch_codedoc_meta:
+  {
+    \cs_if_exist:NT \__codedoc_meta:n
+      {
+        \cs_if_exist:NF \@@_orig_codedoc_meta:n
+          {
+            \cs_set_eq:NN \@@_orig_codedoc_meta:n \__codedoc_meta:n
+            \cs_gset_protected:Npn \__codedoc_meta:n ##1
+              {
+                \mode_if_math:F { \@@_drain_ecglue_verb: }
+                \@@_orig_codedoc_meta:n { \hbox:n {##1} }
+              }
+          }
+      }
+  }
+\@@_at_end_preamble:n { \@@_patch_codedoc_meta: }
+%    \end{macrocode}
+% \end{macro}
+%
 % \changes{v3.1.0}{2012/11/13}{取消 \tn{cprotect} 的外部宏限制。}
 % 当探测到 \pkg{cprotect} 宏包被引入时，则取消 \tn{cprotect} 宏的 \tn{outer} 定义。
 %    \begin{macrocode}


### PR DESCRIPTION
## 修复内容

`\__codedoc_meta:n` (l3doc 用于排版 `\meta` / `\Arg` / `\oarg` / `\parg`) 输出 `$\langle$ #1 $\rangle$`. 当 `#1` 首字符是 CJK 时, `$\langle$` 的 math 节点之后, Default→CJK transition 自动 prepend `\CJKecglue`, 在 `\meta` 内 `$\langle$` 与首 CJK 字符之间产生多余间距; `$\rangle$` 之前同理.

仿 myhsia 在 [#873 评论](https://github.com/CTeX-org/ctex-kit/issues/873) 中给出的 workaround, 在 `\__codedoc_meta:n` 入口给参数包 `\hbox:n`. `\hbox` 隔离了内部的 XeTeX interchar transitions, Default→CJK transition 不会跨越 `\hbox` 边界触发, `\langle`/`\rangle` 与 CJK 字符之间不再有多余 `\CJKecglue`.

## Drain 补充

仅 hbox 包装会丢失 `\meta` 之前 CJK 与 `\meta` 之间的边界 ecglue: `\ensuremath` 的 math 节点把缓存的 CJK 标记 kern 遮蔽在自己之后, 下游 transition 探测不到 marker, 原本的 `\CJKecglue` 也跟着丢 (`中文 \meta{中文}` 之间的 outer ecglue 丢失).

与 #880 / #910 同型, 在 `\__codedoc_meta:n` 入口调用 `\@@_drain_ecglue_verb:` 排空 marker + 补 `\CJKecglue`, 恢复 outer 左侧边界 ecglue. 复用 verb 版本 drain (else 分支保留 `\g_@@_last_node_tl`): `\meta` 出口仍走 token-level interchar.

`\rangle` 之后到外部字符的 ecglue 仍由 `\meta` 末尾 `\ensuremath` 退出后的 Default→CJK transition 正常处理.

## 节点级证据

\`中文 \meta{中文} 西文\` (前/后均有 source space) **修复前**:
\`\`\`
中文 (CJK marker kern preserved)
\mathon h \mathoff
\glue 3.50961       <- ★ inner ecglue (\langle 与 键之间)
中文 (FandolFang)
\mathon i \mathoff
\glue 3.50961       <- outer right ecglue
西文
\`\`\`
hbox 78.45273pt. **inner ecglue 多余**.

**修复后**:
\`\`\`
中文
\glue 3.50961       <- ★ outer left ecglue (drain emit)
\mathon h \mathoff
\hbox{中文}         <- inner content in hbox, no inner ecglue
\mathon i \mathoff
\glue 3.50961       <- outer right ecglue
西文
\`\`\`
hbox 78.45273pt **相同总宽**. **inner 紧贴, outer 两侧均有 ecglue**.

## 实现细节

补丁注册在 `at_end_preamble` (l3doc 是文档类, 早于 xeCJK 加载), 存在性检查 `\cs_if_exist:NT \__codedoc_meta:n` 保证非 l3doc 文档不受影响.

## 相关 issue

- #920: 本 PR 完整修复
- #919: \`\verb\` 右侧双倍 ecglue, 经实证在 XeTeX 单一原语集合下无法精准修复, 暂标 known-issue (详见 issue 评论).

## 测试

- 新增 \`xeCJK/testfiles/codedoc-meta-ecglue01\` 两个 test:
  - Test 1: patched 等价于 \`\$\langle\$\hbox{...}\$\rangle\$\`, 比未 patched 窄一个 2×ecglue (inner ecglue 消失)
  - Test 2: outer ecglue 在 \`\meta\` 前后保留
- 本地 \`make check-xeCJK\` 87/87 PASS
- 本地 \`make check-ctex\` 4 engine × 3 config PASS

仍属 v3.10.1 开发周期 (未发布).

Closes #920.
Refs #919.