### PR TITLE
fix(release): rc tag changes 提取 + xeCJK doc 编译 verb illegal + make tag target

### DIFF
--- a/.github/workflows/release-ctan-upload.yml
+++ b/.github/workflows/release-ctan-upload.yml
@@ -124,10 +124,17 @@ jobs:
           # 抽出所有 \changes{v<ver>}{...}{...} 条目 (含 \begin{macrocode} 前的
           # 续行) 写入 changes-context.txt 作为 LLM 的输入材料.
           # 注意: heredoc 必须用 quoted EOF + 零缩进 (python 对前导空格敏感).
+          #
+          # 与 release.yml 保持一致: RC / pre / alpha / beta tag 共享 base
+          # 版本的 \changes 条目, 先用 sed 剥离 prerelease 后缀再 grep.
+          # 当前实践中 rc tag 不进入 CTAN upload, 但保持两个 workflow 的
+          # 版本号处理逻辑一致, 减少未来误解.
+          BASE_VER=$(printf '%s' "${VER}" | sed -E 's/-(rc[0-9]+|pre[0-9]*|alpha[0-9]*|beta[0-9]*)$//')
+          export BASE_VER
           python3 > changes-context.txt <<'PYEOF'
           import os
           path = os.environ["DTX_PATH"]
-          ver  = os.environ["VER"]
+          ver  = os.environ["BASE_VER"]
           with open(path, encoding="utf-8", errors="replace") as f:
               lines = f.read().splitlines()
           marker = f"\\changes{{v{ver}}}"
@@ -155,7 +162,7 @@ jobs:
           print("\n\n".join(out))
           PYEOF
           if [ ! -s changes-context.txt ]; then
-              echo "::error::No \\changes{v${VER}} entries found in ${DTX_PATH}" >&2
+              echo "::error::No \\changes{v${BASE_VER}} entries found in ${DTX_PATH} (VER=${VER}, BASE_VER=${BASE_VER})" >&2
               exit 1
           fi
           wc -l changes-context.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -211,9 +211,15 @@ jobs:
 
         NOTES_FILE="release-notes.md"
 
+        # RC tags (e.g. 3.10.1-rc1, 3.10.1-rc2) share the same \changes entries
+        # as the base version (3.10.1), since RCs are pre-release builds of
+        # the same upcoming release. Strip the -rcN / -pre / -alpha / -beta
+        # suffix to look up \changes against the base version.
+        BASE_VER=$(printf '%s' "${VER}" | sed -E 's/-(rc[0-9]+|pre[0-9]*|alpha[0-9]*|beta[0-9]*)$//')
+
         # Try extracting from \changes entries
-        if grep -q "\\\\changes{v${VER}}" "${DIR}/${DTX}" 2>/dev/null; then
-          python3 - "${DIR}/${DTX}" "v${VER}" > "${NOTES_FILE}" << 'PYEOF'
+        if grep -q "\\\\changes{v${BASE_VER}}" "${DIR}/${DTX}" 2>/dev/null; then
+          python3 - "${DIR}/${DTX}" "v${BASE_VER}" > "${NOTES_FILE}" << 'PYEOF'
         import re, sys
         dtx_path, target_ver = sys.argv[1], sys.argv[2]
         with open(dtx_path) as f:

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,10 @@
 #             串行旧法 ~20min;小包通常几十秒)
 #   clean  —— l3build clean
 #
+# Release 流程:
+#   make tag <pkg>-v<ver>      —— 本地打 tag, 不 push. push 需手动 git push origin <tag>
+#                                 (push 后由 .github/workflows/release.yml 自动跑 ctan 打包 + GH Release)
+#
 # 另: hooks / check-pr-ci 是 git workflow 入口, build-gbk2uni 走子 Makefile.
 
 L3BUILD_PKGS := xeCJK ctex CJKpunct xCJK2uni xpinyin zhlineskip \
@@ -20,7 +24,7 @@ L3BUILD_PKGS := xeCJK ctex CJKpunct xCJK2uni xpinyin zhlineskip \
 
 VERBS := doc unpack ctan check clean
 
-.PHONY: help hooks check-pr-ci check-ctex-serial \
+.PHONY: help hooks check-pr-ci check-ctex-serial tag \
         $(VERBS) \
         $(foreach v,$(VERBS),$(v)-all) \
         $(foreach v,$(VERBS),$(addprefix $(v)-,$(L3BUILD_PKGS))) \
@@ -48,6 +52,9 @@ help:                       ## 显示此帮助
 	@echo "Git workflow:"
 	@echo "  make hooks                # 一次性安装 git hooks (.githooks)"
 	@echo "  make check-pr-ci          # 手动触发 PR CI watch + review 抓取"
+	@echo ""
+	@echo "Release:"
+	@echo "  make tag <pkg>-v<ver>     # 本地打 release tag, 不 push (e.g. make tag xeCJK-v3.10.1-rc2)"
 
 # ── git workflow ───────────────────────────────────────────────────────────
 hooks:                       ## 一次性安装 git hooks
@@ -56,6 +63,57 @@ hooks:                       ## 一次性安装 git hooks
 
 check-pr-ci:                 ## 手动触发 PR CI watch + review 抓取(同 pre-push self-wrapper 调用的)
 	./.githooks/check-pr-ci.sh
+
+# ── tag (release) ──────────────────────────────────────────────────────────
+# 用法: make tag <pkg>-v<ver>     (e.g. make tag xeCJK-v3.10.1-rc2)
+#
+# 打本地 annotated tag, 不 push. push 需手动 git push origin <tag> —— 这是
+# 故意设计, 让操作者在 push 前可以最后核对 tag 是否落在期望 commit、是否
+# 还有未提交的版本号 / \changes 改动. push 之后 release.yml 自动跑.
+#
+# 实现: tag target 把第二个 MAKECMDGOALS 当 tag 名, 用 noop pattern rule
+# 吃掉它避免 "No rule to make target xeCJK-v..." 报错.
+TAG_NAME := $(filter-out tag,$(MAKECMDGOALS))
+
+tag:                         ## 本地打 release tag (用法: make tag <pkg>-v<ver>)
+	@if [ -z "$(TAG_NAME)" ]; then \
+	  echo "用法: make tag <pkg>-v<ver>" >&2; \
+	  echo "  例如: make tag xeCJK-v3.10.1-rc2" >&2; \
+	  exit 1; \
+	fi
+	@case "$(TAG_NAME)" in \
+	  ctex-v*|xeCJK-v*|CJKpunct-v*|zhnumber-v*|xCJK2uni-v*|xpinyin-v*|zhmetrics-v*|zhmetrics-uptex-v*|zhspacing-v*|zhlineskip-v*) ;; \
+	  *) echo "✗ tag 名 '$(TAG_NAME)' 不匹配 release.yml 触发 pattern" >&2; \
+	     echo "  支持的 prefix: ctex-v / xeCJK-v / CJKpunct-v / zhnumber-v / xCJK2uni-v" >&2; \
+	     echo "                 xpinyin-v / zhmetrics-v / zhmetrics-uptex-v / zhspacing-v / zhlineskip-v" >&2; \
+	     exit 1 ;; \
+	esac
+	@if git rev-parse -q --verify "refs/tags/$(TAG_NAME)" >/dev/null 2>&1; then \
+	  echo "✗ tag '$(TAG_NAME)' 已存在本地. 先删: git tag -d $(TAG_NAME)" >&2; \
+	  exit 1; \
+	fi
+	git tag -a "$(TAG_NAME)" -m "$(TAG_NAME)"
+	@echo ""
+	@echo "✓ tag '$(TAG_NAME)' 已打在 $$(git rev-parse --short HEAD) ($$(git log -1 --format=%s | head -c 60))"
+	@echo ""
+	@echo "下一步 push 触发 release.yml (会自动 ctan 打包 + 上传 GH Release prerelease):"
+	@echo ""
+	@echo "    git push origin $(TAG_NAME)"
+	@echo ""
+	@echo "如果发现要重打:"
+	@echo "    git tag -d $(TAG_NAME)"
+	@echo ""
+
+# 让 MAKECMDGOALS 第二个 arg 不报 "No rule to make target".
+# 只在 tag 是当前 goal 且确实给了 tag 名时, 把 tag 名声明为 phony noop.
+# 这比通配 `%:` rule 安全, 不会触发 "overriding recipe for target ..." 警告.
+ifneq ($(filter tag,$(MAKECMDGOALS)),)
+ifneq ($(TAG_NAME),)
+.PHONY: $(TAG_NAME)
+$(TAG_NAME):
+	@:
+endif
+endif
 
 # ── 显式 -all 别名 (e.g. `make doc` = `make doc-all`) ──────────────────────
 $(VERBS): %: %-all

--- a/Makefile
+++ b/Makefile
@@ -65,29 +65,48 @@ check-pr-ci:                 ## 手动触发 PR CI watch + review 抓取(同 pre
 	./.githooks/check-pr-ci.sh
 
 # ── tag (release) ──────────────────────────────────────────────────────────
-# 用法: make tag <pkg>-v<ver>     (e.g. make tag xeCJK-v3.10.1-rc2)
+# 用法: make tag <pkg>-v<X>.<Y>.<Z>[-rc<N>]   (e.g. make tag xeCJK-v3.10.1-rc2)
+#
+# 合法 tag 格式 (严格校验, 不向后兼容历史不规范 tag):
+#   <pkg>-v<X>.<Y>.<Z>           例如  xeCJK-v3.10.1
+#   <pkg>-v<X>.<Y>.<Z>-rc<N>     例如  xeCJK-v3.10.1-rc2
+# <pkg> 必须是 L3BUILD_PKGS 之一 (与 release.yml tags trigger 对齐).
+# 三段语义化版本 (semver-lite), 可选 rc<N> 后缀. 其他形式 (2 段 / letter 后缀 /
+# alpha / beta / pre / date 串 / 缺 v 前缀等) 一律拒绝, 避免误打.
+#
+# 历史 tag (ctex-1.02c / xpinyin-v2.2 / zhmetrics-uptex-v1.0 / zhlineskip-v1.0f
+# / zhspacing-20160514) 与此规则不一致, 但只影响后续新打 tag, 不影响已存在
+# release 的可读性.
 #
 # 打本地 annotated tag, 不 push. push 需手动 git push origin <tag> —— 这是
 # 故意设计, 让操作者在 push 前可以最后核对 tag 是否落在期望 commit、是否
 # 还有未提交的版本号 / \changes 改动. push 之后 release.yml 自动跑.
 #
-# 实现: tag target 把第二个 MAKECMDGOALS 当 tag 名, 用 noop pattern rule
+# 实现: tag target 把第二个 MAKECMDGOALS 当 tag 名, 用 noop phony rule
 # 吃掉它避免 "No rule to make target xeCJK-v..." 报错.
+
+# 校验用的 pkg 列表 (与 release.yml tags trigger 对齐). 用 | 拼接成 regex
+# alternation, 注意 zhmetrics-uptex 必须排在 zhmetrics 前面, 否则 regex
+# 贪婪匹配会先吃掉 zhmetrics.
+TAG_PKGS_REGEX := ctex|xeCJK|CJKpunct|xCJK2uni|xpinyin|zhlineskip|zhmetrics-uptex|zhmetrics|zhnumber|zhspacing
+
 TAG_NAME := $(filter-out tag,$(MAKECMDGOALS))
 
-tag:                         ## 本地打 release tag (用法: make tag <pkg>-v<ver>)
+tag:                         ## 本地打 release tag (用法: make tag <pkg>-v<X>.<Y>.<Z>[-rc<N>])
 	@if [ -z "$(TAG_NAME)" ]; then \
-	  echo "用法: make tag <pkg>-v<ver>" >&2; \
-	  echo "  例如: make tag xeCJK-v3.10.1-rc2" >&2; \
+	  echo "用法: make tag <pkg>-v<X>.<Y>.<Z>[-rc<N>]" >&2; \
+	  echo "  例如: make tag xeCJK-v3.10.1" >&2; \
+	  echo "        make tag xeCJK-v3.10.1-rc2" >&2; \
 	  exit 1; \
 	fi
-	@case "$(TAG_NAME)" in \
-	  ctex-v*|xeCJK-v*|CJKpunct-v*|zhnumber-v*|xCJK2uni-v*|xpinyin-v*|zhmetrics-v*|zhmetrics-uptex-v*|zhspacing-v*|zhlineskip-v*) ;; \
-	  *) echo "✗ tag 名 '$(TAG_NAME)' 不匹配 release.yml 触发 pattern" >&2; \
-	     echo "  支持的 prefix: ctex-v / xeCJK-v / CJKpunct-v / zhnumber-v / xCJK2uni-v" >&2; \
-	     echo "                 xpinyin-v / zhmetrics-v / zhmetrics-uptex-v / zhspacing-v / zhlineskip-v" >&2; \
-	     exit 1 ;; \
-	esac
+	@if ! printf '%s' "$(TAG_NAME)" \
+	  | grep -qE '^($(TAG_PKGS_REGEX))-v[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)?$$'; then \
+	  echo "✗ tag 名 '$(TAG_NAME)' 不是合法 release tag" >&2; \
+	  echo "  合法格式: <pkg>-v<X>.<Y>.<Z>[-rc<N>]" >&2; \
+	  echo "  支持的 pkg: $(TAG_PKGS_REGEX)" >&2; \
+	  echo "  例如:     xeCJK-v3.10.1 / xeCJK-v3.10.1-rc2" >&2; \
+	  exit 1; \
+	fi
 	@if git rev-parse -q --verify "refs/tags/$(TAG_NAME)" >/dev/null 2>&1; then \
 	  echo "✗ tag '$(TAG_NAME)' 已存在本地. 先删: git tag -d $(TAG_NAME)" >&2; \
 	  exit 1; \

--- a/Makefile
+++ b/Makefile
@@ -65,18 +65,25 @@ check-pr-ci:                 ## 手动触发 PR CI watch + review 抓取(同 pre
 	./.githooks/check-pr-ci.sh
 
 # ── tag (release) ──────────────────────────────────────────────────────────
-# 用法: make tag <pkg>-v<X>.<Y>.<Z>[-rc<N>]   (e.g. make tag xeCJK-v3.10.1-rc2)
+# 用法: make tag <pkg>-v<ver>[-rc<N>]   (e.g. make tag xeCJK-v3.10.1-rc2)
 #
-# 合法 tag 格式 (严格校验, 不向后兼容历史不规范 tag):
-#   <pkg>-v<X>.<Y>.<Z>           例如  xeCJK-v3.10.1
-#   <pkg>-v<X>.<Y>.<Z>-rc<N>     例如  xeCJK-v3.10.1-rc2
+# 合法 tag 格式 (校验规则与历史 tag 习惯一致):
+#   <pkg>-v<X>.<Y>[.<Z>][<letter>][-rc<N>]
+#
+# 历史 tag (audit 全部 ~100 个 tag) 统计:
+#   - 3 段 (v3.10.0):           65 tags, 主流 (ctex / xeCJK / CJKpunct 现行)
+#   - 2 段 (v3.1):              17 tags (xpinyin / zhnumber 早期 / xCJK2uni / ctex 早期)
+#   - 2 段 + 字母 (v1.0f):       1 tag  (zhlineskip)
+#   - 无 v 前缀 (ctex-1.02c /
+#     jiazhu-beta /
+#     zhspacing-20160514):       6 tags, 远古遗留, 不再支持
+# 本规则覆盖前三类共 83 tags, 不覆盖远古无 v 前缀的 6 tags (jiazhu-beta /
+# xeCJK 孤立 / ctex-1.02c/d / zhspacing-date) —— 新打 tag 不应再走这些
+# 不规范模式.
+#
 # <pkg> 必须是 L3BUILD_PKGS 之一 (与 release.yml tags trigger 对齐).
-# 三段语义化版本 (semver-lite), 可选 rc<N> 后缀. 其他形式 (2 段 / letter 后缀 /
-# alpha / beta / pre / date 串 / 缺 v 前缀等) 一律拒绝, 避免误打.
-#
-# 历史 tag (ctex-1.02c / xpinyin-v2.2 / zhmetrics-uptex-v1.0 / zhlineskip-v1.0f
-# / zhspacing-20160514) 与此规则不一致, 但只影响后续新打 tag, 不影响已存在
-# release 的可读性.
+# <X>.<Y>[.<Z>] 是 2 段或 3 段数字; <letter> 是可选单字母 (e.g. v1.0f);
+# -rc<N> 中 N 也是数字, 用于 prerelease.
 #
 # 打本地 annotated tag, 不 push. push 需手动 git push origin <tag> —— 这是
 # 故意设计, 让操作者在 push 前可以最后核对 tag 是否落在期望 commit、是否
@@ -92,19 +99,20 @@ TAG_PKGS_REGEX := ctex|xeCJK|CJKpunct|xCJK2uni|xpinyin|zhlineskip|zhmetrics-upte
 
 TAG_NAME := $(filter-out tag,$(MAKECMDGOALS))
 
-tag:                         ## 本地打 release tag (用法: make tag <pkg>-v<X>.<Y>.<Z>[-rc<N>])
+tag:                         ## 本地打 release tag (用法: make tag <pkg>-v<ver>[-rc<N>])
 	@if [ -z "$(TAG_NAME)" ]; then \
-	  echo "用法: make tag <pkg>-v<X>.<Y>.<Z>[-rc<N>]" >&2; \
+	  echo "用法: make tag <pkg>-v<ver>[-rc<N>]" >&2; \
 	  echo "  例如: make tag xeCJK-v3.10.1" >&2; \
 	  echo "        make tag xeCJK-v3.10.1-rc2" >&2; \
+	  echo "        make tag zhlineskip-v1.0f" >&2; \
 	  exit 1; \
 	fi
 	@if ! printf '%s' "$(TAG_NAME)" \
-	  | grep -qE '^($(TAG_PKGS_REGEX))-v[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)?$$'; then \
+	  | grep -qE '^($(TAG_PKGS_REGEX))-v[0-9]+\.[0-9]+(\.[0-9]+)?[a-z]?(-rc[0-9]+)?$$'; then \
 	  echo "✗ tag 名 '$(TAG_NAME)' 不是合法 release tag" >&2; \
-	  echo "  合法格式: <pkg>-v<X>.<Y>.<Z>[-rc<N>]" >&2; \
+	  echo "  合法格式: <pkg>-v<X>.<Y>[.<Z>][<letter>][-rc<N>]" >&2; \
 	  echo "  支持的 pkg: $(TAG_PKGS_REGEX)" >&2; \
-	  echo "  例如:     xeCJK-v3.10.1 / xeCJK-v3.10.1-rc2" >&2; \
+	  echo "  例如:     xeCJK-v3.10.1 / xeCJK-v3.10.1-rc2 / zhlineskip-v1.0f / xpinyin-v3.1" >&2; \
 	  exit 1; \
 	fi
 	@if git rev-parse -q --verify "refs/tags/$(TAG_NAME)" >/dev/null 2>&1; then \

--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,11 @@ check-pr-ci:                 ## 手动触发 PR CI watch + review 抓取(同 pre
 # 贪婪匹配会先吃掉 zhmetrics.
 TAG_PKGS_REGEX := ctex|xeCJK|CJKpunct|xCJK2uni|xpinyin|zhlineskip|zhmetrics-uptex|zhmetrics|zhnumber|zhspacing
 
-TAG_NAME := $(filter-out tag,$(MAKECMDGOALS))
+# 只取第一个非 'tag' 的 goal 作为 tag 名. 用 firstword 是为了让
+# `make tag <tagname> clean` 这类多 goal 场景不把 clean 误当 tag 名,
+# 也避免下方 phony noop 规则把 clean 误声明为 noop 而潜在破坏 clean
+# 真实 recipe.
+TAG_NAME := $(firstword $(filter-out tag,$(MAKECMDGOALS)))
 
 tag:                         ## 本地打 release tag (用法: make tag <pkg>-v<ver>[-rc<N>])
 	@if [ -z "$(TAG_NAME)" ]; then \

--- a/xeCJK/xeCJK.dtx
+++ b/xeCJK/xeCJK.dtx
@@ -9932,7 +9932,7 @@ Copyright and Licence
 %
 % \changes{v3.10.1}{2026/06/29}{为 \LaTeX{} 核心命令 \tn{verb} 添加补丁，
 %   在进入 verb 内容前 drain 缓存的 \texttt{CJKecglue}，
-%   修复 CJK 文字与 \tn{verb}（或 \pkg{shortvrb} 的 \texttt{|...|}）
+%   修复 CJK 文字与 \tn{verb}（或 \pkg{shortvrb} 的短记号）
 %   之间间距丢失的问题（\#910）。}
 %
 % \LaTeXe{} 的 \tn{verb} 命令展开后包含 \tn{leavevmode\null}，

--- a/xeCJK/xeCJK.dtx
+++ b/xeCJK/xeCJK.dtx
@@ -9893,14 +9893,14 @@ Copyright and Licence
 % \pkg{url} 的 \tn{url} 命令通过 \tn{Url@FormatString} 进入数学模式
 % 排版 URL 字符串。
 % 数学模式 node 隔在 xeCJK 标记 kern 对和数学公式之间，
-% 又因 \XeTeX{} 在数学模式中不触发 interchar class 转换，
-% 标记 kern 对永远等不到匹配的 Boundary→\{CJK,Default\} 触发，
+% 又因 \XeTeX{} 在数学模式中不触发类别转换（interchar class），
+% 标记 kern 对永远等不到匹配的 Boundary$\to$\{CJK,Default\} 触发，
 % 缓存的 \texttt{CJKecglue} 因此在 CJK 与 \tn{url} 之间丢失。
-% 此处在进入数学模式前直接 drain 缓存间距：\tn{url} 排版的内容
-% 必然是西文，前方上下文为 CJK / CJK-space / CJK-widow / default
-% 中任意一种时均应使用 \texttt{CJKecglue}（西文边界间距）。
-% \tn{url} 数学模式结束至 CJK 文字之间的右侧间距由
-% \cs{xeCJK_check_for_glue:} 的 \cs{@@_if_last_math:} 路径自然处理。
+% 此处在进入数学模式前先 drain（排空）缓存间距：\tn{url} 排版的
+% 内容必然是西文，前方上下文为 CJK / CJK-space / CJK-widow / default
+% 中任意一种时均应补上 \texttt{CJKecglue}（西文边界间距）。
+% \tn{url} 数学模式结束到后续 CJK 文字之间的右侧间距，
+% 由 \cs{xeCJK_check_for_glue:} 的 \cs{@@_if_last_math:} 路径自然处理。
 %    \begin{macrocode}
 \cs_new_protected:Npn \@@_drain_ecglue:
   {

--- a/xeCJK/xeCJK.dtx
+++ b/xeCJK/xeCJK.dtx
@@ -9935,42 +9935,52 @@ Copyright and Licence
 %   修复 CJK 文字与 \tn{verb}（或 \pkg{shortvrb} 的短记号）
 %   之间间距丢失的问题（\#910）。}
 %
-% \LaTeXe{} 的 \tn{verb} 命令展开后包含 \tn{leavevmode\null}，
-% 其中 \tn{null} = \tn{hbox\{\}} 产生 \texttt{hbox(0+0)x0} 节点。
-% 此 0\,$\times$\,0 hbox 紧跟在 xeCJK 标记 kern 对之后，
-% 隔断了下游 Boundary$\to$\{Default, CJK\} 路径中 |\tex_lastkern:D| 探测，
-% 导致 \texttt{CJKecglue} 在 CJK 与 \tn{verb} 之间丢失。
-% 此处在进入原始 \tn{verb} 前直接 drain 缓存间距：\tn{verb} 排版的内容
-% 必然是西文 (catcode 12 字符)，前方上下文为 CJK 等情形均应使用
-% \texttt{CJKecglue}。\tn{verb} 内最后字符到 CJK 文字之间的右侧间距
-% 由 Default$\to$CJK 类别转换的 |\xeCJK_pre_inter_class_toks:nnn| 自动恢复，
-% 不需要额外处理。
+% \LaTeXe{} 的 \tn{verb} 命令展开后会执行 \tn{leavevmode\null}，
+% 其中 \tn{null} 等价于 \tn{hbox\{\}}，会产生一个
+% \texttt{hbox(0+0)x0} 节点。这个 $0\times0$ 的 hbox 紧跟在 \pkg{xeCJK}
+% 的标记 kern 对之后，会切断后续 Boundary$\to$\{Default, CJK\} 类别
+% 转换中 \cs{tex_lastkern:D} 的探测路径，导致 CJK 文字与 \tn{verb}
+% 之间应有的 \texttt{CJKecglue} 丢失。
 %
-% 数学模式下原 \tn{verb} 走 \tn{hbox} 分支（不展开 \tn{leavevmode\null}），
-% 标记 kern 不被 0\,$\times$\,0 hbox 遮蔽，因此跳过 patch。
+% 修复办法是在执行原始 \tn{verb} 之前先 drain 缓存的间距：因为
+% \tn{verb} 排版的内容必然是西文（catcode 12 字符），前文若为 CJK，
+% 那么这里就应该补上 \texttt{CJKecglue}。
+% 而 \tn{verb} 内最后一个字符到后续 CJK 文字之间的右侧间距，
+% 会由 Default$\to$CJK 类别转换中 \cs{xeCJK_pre_inter_class_toks:nnn}
+% 自动恢复，不需要额外处理。
 %
-% \pkg{shortvrb} 的 \tn{MakeShortVerb} 将分隔符设为 active 字符后展开到
-% \tn{verb}，自动跟随此 patch。\tn{verb}* 与 \tn{verb} 共用入口
-% （\tn{@ifstar} 在 \tn{bgroup} 之后扫描），也自动覆盖。
+% 数学模式下，原 \tn{verb} 走 \tn{hbox} 分支，不会展开
+% \tn{leavevmode\null}，标记 kern 不被 $0\times0$ 的 hbox 遮蔽，
+% 因此跳过这个 patch。
 %
-% 选择 \cs{@@_after_preamble:n} 而非 \cs{@@_package_hook:nn}（\tn{verb}
-% 是 \LaTeXe{} 核心命令，不来自宏包），并放在 preamble 之后以避免
-% 与其他 \tn{verb} 重定义（如 \pkg{cprotect}、\pkg{fancyvrb}）的时序冲突。
+% \pkg{shortvrb} 的 \tn{MakeShortVerb} 把分隔符设为 active 字符后
+% 展开到 \tn{verb}，会自动跟随这里的 patch。\tn{verb}* 与 \tn{verb}
+% 共用入口（\tn{@ifstar} 在 \tn{bgroup} 之后才扫描），因此也自动
+% 覆盖到。
 %
-% 这里不直接复用 \cs{@@_drain_ecglue:}（\#880 \tn{Url@FormatString} 用的
-% drain）：后者在没有 marker 时会主动 clear |\g_@@_last_node_tl|（为
-% math 模式吃 marker 的场景做防御）。但 \tn{verb} 不进 math 模式，
-% 入口前的 |\g_@@_last_node_tl| 是合法状态——\pkg{ctex} 模式下
-% \tn{verb} 内会切换 CJK 字体（\opt{FandolFang}），verb 内字符到
-% verb 外字符仍走 \texttt{CJK}$\to$\texttt{CJK} interchar 路径，
-% 需要 |\g_@@_last_node_tl| 保持其当前值才能正确出 \tn{CJKglue}。
-% 因此 verb 专用 drain 仅在确实有 marker 时撤掉并补 ecglue，
-% 没有 marker 时 else 分支故意留空——与 \cs{@@_drain_ecglue:} 的唯一
-% 差别即在此处，不调用 \cs{tl_gclear:N} 是为了不破坏入口前的合法状态。
+% 这里选择 \cs{@@_after_preamble:n} 而非 \cs{@@_package_hook:nn}，
+% 因为 \tn{verb} 是 \LaTeXe{} 核心命令，不来自宏包；放在 preamble
+% 之后注册，可以避开 \pkg{cprotect}、\pkg{fancyvrb} 等宏包对
+% \tn{verb} 重定义时的时序冲突。
 %
-% 此 drain 还被 \cs{@@_patch_codedoc_meta:}（\#920 \pkg{l3doc} \cs{meta}
-% 补丁）复用：\cs{meta} 出口同样有 token-level interchar，需要保留
-% |\g_@@_last_node_tl| 状态。新增 drain 调用点请同步更新本节注释。
+% 这里不直接复用 \cs{@@_drain_ecglue:}（\#880 中 \tn{Url@FormatString}
+% 使用的 drain 函数）：后者在没有标记时会主动清掉
+% \cs{g_@@_last_node_tl}，这是为 math 模式吃掉 marker 的场景做的防御。
+% 而 \tn{verb} 不会进入 math 模式，入口前的
+% \cs{g_@@_last_node_tl} 是合法状态——在 \pkg{ctex} 模式下，
+% \tn{verb} 内部会切换 CJK 字体（如 \opt{FandolFang}），\tn{verb}
+% 内字符到 \tn{verb} 外字符仍会走 CJK$\to$CJK 类别转换路径，
+% 此时需要保留 \cs{g_@@_last_node_tl} 的当前值，才能正确地输出
+% \tn{CJKglue}。
+% 因此 \tn{verb} 专用的 drain 只在确实存在标记时移除并补 ecglue，
+% 没有标记时 else 分支故意留空——与 \cs{@@_drain_ecglue:} 的唯一
+% 区别就在于此，不调用 \cs{tl_gclear:N} 是为了不破坏入口前的合法
+% 状态。
+%
+% 此 drain 函数同样被 \cs{@@_patch_codedoc_meta:}（\#920 中
+% \pkg{l3doc} \cs{meta} 补丁）复用：\cs{meta} 退出后仍然有
+% token 层面的 interchar 处理，需要保留 \cs{g_@@_last_node_tl}
+% 的状态。后续若有新的调用点，请同步更新本节注释。
 %
 % \begin{macro}[int]{\@@_drain_ecglue_verb:,\@@_patch_verb:}
 %    \begin{macrocode}
@@ -10006,40 +10016,42 @@ Copyright and Licence
 %   添加补丁，将参数内容包入 \cs{hbox:n}，
 %   修复 \cs{meta} 内首字符前出现多余 \texttt{CJKecglue} 的问题（\#920）。}
 %
-% \pkg{l3doc} 类的 \cs{__codedoc_meta:n} 排版 \cs{meta} 命令的参数：
-% 由 \cs{__codedoc_meta_original:n} 输出 \texttt{\$\textbackslash langle\$}（数学节点）、
-% 内容、\texttt{\$\textbackslash rangle\$}。
-% 当内容首字符是 CJK 时，\texttt{Default\textrightarrow CJK} 类别转换的
-% \cs{xeCJK_pre_inter_class_toks:nnn} 自动 prepend \cs{CJKecglue}，
-% 在 \texttt{\$\textbackslash langle\$} 与首 CJK 字符之间产生多余间距。
+% \pkg{l3doc} 类用 \cs{__codedoc_meta:n} 排版 \cs{meta} 命令的参数：
+% 内部由 \cs{__codedoc_meta_original:n} 依次输出 \cs{ensuremath}\verb*-{-\cs{langle}\verb*-}-
+% 数学节点、参数内容、以及对称的 \cs{ensuremath}\verb*-{-\cs{rangle}\verb*-}-。
+% 当参数内容的首字符是 CJK 时，Default$\to$CJK 类别转换中的
+% \cs{xeCJK_pre_inter_class_toks:nnn} 会自动加上 \cs{CJKecglue}，
+% 这会在 $\langle$ 与首个 CJK 字符之间产生多余的间距。
 %
-% 此处采用与 myhsia 在 \pkg{hyperref}/\pkg{hypdoc} 兼容议题中提出的
-% \texttt{hbox} 包装方案：将 \cs{__codedoc_meta:n} 的参数包入
-% \cs{hbox:n}，\cs{hbox} 隔离了内部的 \XeTeX{} interchar transitions，
-% 使得 \texttt{Default\textrightarrow CJK} transition 不会跨越 \texttt{hbox}
-% 边界触发，从而避免插入多余 \cs{CJKecglue}。
+% 这里采用 myhsia 在 \pkg{hyperref} / \pkg{hypdoc} 兼容议题中提出的
+% \texttt{hbox} 包装方案：把 \cs{__codedoc_meta:n} 的参数装进
+% \cs{hbox:n}。hbox 隔离了内部的 \XeTeX{} 类别转换，
+% Default$\to$CJK 转换不会跨越 hbox 边界触发，从而避免插入多余的
+% \cs{CJKecglue}。
 %
-% 仅 hbox 包装会丢失 \cs{meta} 之前 CJK 与 \cs{meta} 之间的边界 ecglue：
-% \cs{__codedoc_meta_original:n} 入口的 \cs{ensuremath} math 节点把
-% 缓存的 CJK 标记 kern 遮蔽在自己之后，下游 transition 探测不到
-% marker，原本的 \texttt{CJKecglue} 也跟着丢。
-% 与 \pkg{url}（\#880）、\cs{verb}（\#910，参见 \cs{@@_patch_verb:}）同型，
-% 此处在 \cs{__codedoc_meta:n} 入口调用 \cs{@@_drain_ecglue_verb:} 排空
-% marker 并补 \cs{CJKecglue}，恢复 outer 左侧边界的 ecglue；复用
-% \texttt{verb} 版本 drain（else 分支不清 \cs{g_@@_last_node_tl}）：
-% \cs{meta} 出口仍走 token-level interchar，需要保留 tl 状态。
-% \cs{@@_drain_ecglue_verb:} 的注释也列出此调用点。
+% 但仅用 hbox 包装会带来另一个副作用：\cs{meta} 之前的 CJK 与
+% \cs{meta} 之间的边界 ecglue 会丢失——\cs{__codedoc_meta_original:n}
+% 入口的 \cs{ensuremath} math 节点把缓存的 CJK 标记 kern 遮在自己
+% 之后，后续类别转换探测不到这个标记，原本应有的 \texttt{CJKecglue}
+% 也跟着丢失。
+% 与 \pkg{url}（\#880）、\tn{verb}（\#910，参见 \cs{@@_patch_verb:}）
+% 同型，这里在 \cs{__codedoc_meta:n} 入口调用 \cs{@@_drain_ecglue_verb:}
+% 移除标记并补上 \cs{CJKecglue}，恢复左侧的边界 ecglue。
+% 复用 \tn{verb} 版本的 drain（else 分支不清 \cs{g_@@_last_node_tl}）是
+% 因为 \cs{meta} 退出后仍然要经过 token 层面的类别转换，需要保留
+% \cs{g_@@_last_node_tl} 的当前状态。
+% \cs{@@_drain_ecglue_verb:} 的注释也列出了本处调用点，二者保持
+% 双向引用。
 %
 % \cs{rangle} 之后到外部字符的 ecglue 仍由 \cs{__codedoc_meta:n}
-% 末尾 \cs{ensuremath} 退出后的 \texttt{Default\textrightarrow CJK}
-% transition 正常处理。
+% 末尾 \cs{ensuremath} 退出后的 Default$\to$CJK 类别转换正常处理。
 %
-% 由于 \cs{__codedoc_meta:n} 与 \cs{Arg}、\cs{oarg}、\cs{parg} 等共用，
-% 此补丁也间接修复后者的类似问题。
+% \cs{__codedoc_meta:n} 同时被 \cs{Arg}、\cs{oarg}、\cs{parg} 等命令
+% 共用，此补丁也间接修复后者的相同问题。
 %
-% 选择 \cs{@@_at_end_preamble:n} 而非 \cs{@@_package_hook:nn}：
-% \pkg{l3doc} 是文档类，文档类加载早于 \pkg{xeCJK}，需要在 preamble 结束时
-% 才能确定 \cs{__codedoc_meta:n} 是否定义。
+% 这里选择 \cs{@@_at_end_preamble:n} 而非 \cs{@@_package_hook:nn}，
+% 原因在于 \pkg{l3doc} 是文档类，文档类加载早于 \pkg{xeCJK}，
+% 需要等到 preamble 结束时才能判定 \cs{__codedoc_meta:n} 是否定义。
 %
 % \begin{macro}[int]{\@@_patch_codedoc_meta:}
 %    \begin{macrocode}


### PR DESCRIPTION
## 背景

打 \`xeCJK-v3.10.1-rc1\` tag 后, release.yml 跑挂. 分析 GH Actions log (run 28414671824) 看到两个 issue + 顺手加一个 ergonomics 改进.

## 修复 1: xeCJK doc 编译 \`\verb illegal in argument\`

\`\`\`
l.365 ...pkg {shortvrb} 的 \texttt {\pfill \...|}
                                                 ） 之间间距丢失的问题（\#910）。|hdclin...
! LaTeX Error: \verb illegal in argument.
\`\`\`

l3doc 文档类用 \`\MakeShortVerb{|}\` 把 \`|\` 设为 active 等价 \`\verb\`. xeCJK.dtx \`\changes{v3.10.1}{...}\` 中描述 #910 的句子里写了 \`\texttt{|...|}\`, l3doc 把它展开为 \`\texttt{\verb|...|}\`, \`\verb\` 在 macro 参数内非法, 整个 xeCJK.pdf 编译失败, \`l3build ctan\` 退出码 1, release 挂掉.

修复: 改写为 \"或 \pkg{shortvrb} 的短记号\", 不用 \`|\` 避开 active.

## 修复 2: rc tag 拿不到 \\changes

release.yml 的 release notes 提取逻辑:

\`\`\`yaml
if grep -q "\\\\changes{v${VER}}" "${DIR}/${DTX}"; then
  python3 ... > release-notes.md
fi
\`\`\`

打 \`xeCJK-v3.10.1-rc1\` 时 \`VER=3.10.1-rc1\`, grep \`\changes{v3.10.1-rc1}\` 永远匹配不到 dtx 内的 \`\changes{v3.10.1}{...}\`, 走 git log fallback. rc 本质是同一个 upcoming release 的 pre-release build, 共享 \\changes 才合理.

修复: 加 \`BASE_VER\` 用 sed 去掉 \`-(rc[0-9]+|pre|alpha|beta)\` 后缀, 用 \`BASE_VER\` 去 grep + 喂 python.

## 改进: \`make tag <pkg>-v<ver>\`

之前打 tag 走的是手敲 \`git tag\` + \`git push\`. 顺手加 Makefile target 减少误操作:

- 打本地 annotated tag, **不 push** (操作者最后核对后手动 push)
- prefix 白名单校验 (与 release.yml \`tags:\` trigger pattern 对齐)
- 已存在 tag 拒绝重打
- 成功后输出 push / 删 tag 命令

## 验证

- 本地 \`l3build doc\` + \`l3build ctan\` 都跑通, 没再报 verb illegal
- xecjk-ctan.zip + xecjk.tds.zip 正确生成
- \`make tag xeCJK-vTEST\` / \`make tag foo-bar\` (拒绝) / 已有 tag 重打 (拒绝) 都 cover

Refs xeCJK-v3.10.1-rc1 (failed release: GH Actions run 28414671824).