### PR TITLE
tag(zhlineskip): 下次发布 2026-07-07

### DIFF
--- a/zhlineskip/build.lua
+++ b/zhlineskip/build.lua
@@ -11,8 +11,8 @@
     `\changes` 记录, 不必手动碰 .dtx 的 GetIdInfo 行.
 --]==========================================================================]--
 module              = "zhlineskip"
-version             = "v1.0f"
-date                = "2026-06-28"
+version             = "v1.0g"
+date                = "2026-07-07"
 maintainer          = "Mingyu Xia"
 email               = "myhsia@outlook.com"
 summary             = "Line spacing for CJK documents"

--- a/zhlineskip/zhlineskip.dtx
+++ b/zhlineskip/zhlineskip.dtx
@@ -160,7 +160,7 @@ The Current Maintainers of this work are **Ruixi Zhang** and **Mingyu Xia**.
 %<package>\NeedsTeXFormat{LaTeX2e}[2026/06/01]
 %<package>\RequirePackage{expl3}
 %<*package>
-%<+!driver>\GetIdInfo $Id: zhlineskip.dtx v1.0f 2026-06-28 Mingyu Xia<myhsia@outlook.com>$
+%<+!driver>\GetIdInfo $Id: zhlineskip.dtx v1.0g 2026-07-07 Mingyu Xia<myhsia@outlook.com>$
 %<package>  {Line spacing for CJK documents}
 %<package>\ProvidesExplPackage {\ExplFileName}
 %<!driver>  {\ExplFileDate} {\ExplFileVersion} {\ExplFileDescription}


### PR DESCRIPTION
等确保 docext 在这个 CI 里被更新后再发布, 新的 docext 修复了手册对宏包过长选项溢出的问题