### PR TITLE
feat(release): release-ctan-upload 加 announce input, 允许跳过公告

### DIFF
--- a/.github/workflows/release-ctan-upload.yml
+++ b/.github/workflows/release-ctan-upload.yml
@@ -71,6 +71,15 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          # checkout tag tree 是为了拿到旧版本的 dtx (新版 dtx 已经迭代过,
+          # \changes{v<ver>} 标记不在 HEAD).
+          #
+          # known limitation: 此 PR 合并前的旧 tag (< 2026-06-30) 不含
+          # scripts/extract-changes.py, 重跑会在 "Extract v<ver> changes
+          # block" step 报 FileNotFoundError. 这些 tag (xeCJK-v3.10.0 /
+          # zhlineskip-v1.0f 等) 已经 upload 过, 通常不需要再触发.
+          # 真要重跑就先 checkout master 拿脚本, 或临时把脚本内容
+          # 粘到 step run: 里.
           ref: ${{ inputs.tag }}
 
       - name: Parse tag

--- a/.github/workflows/release-ctan-upload.yml
+++ b/.github/workflows/release-ctan-upload.yml
@@ -38,6 +38,14 @@ on:
         required: true
         type: boolean
         default: true
+      announce:
+        description: '是否生成 + 投递英文 announcement. minor changes
+          (typo / 注释 / 小补丁) 可设 false 跳过 announcement, 节省 LLM
+          调用并避免 CTAN 邮件列表噪声. false 时整个 prepare-announcement
+          的 LLM 步骤跳过, l3build upload 不传 --file.'
+        required: true
+        type: boolean
+        default: true
 
 permissions:
   contents: write
@@ -117,6 +125,7 @@ jobs:
 
       - name: Extract v<ver> changes block
         id: changes
+        if: inputs.announce
         env:
           DTX_PATH: ${{ steps.parse.outputs.dir }}/${{ steps.parse.outputs.dtx }}
           VER: ${{ steps.parse.outputs.ver }}
@@ -169,6 +178,7 @@ jobs:
 
       - name: Fetch previous CTAN announcement for tone reference
         id: prev_ann
+        if: inputs.announce
         env:
           PKG_MODULE: ${{ steps.parse.outputs.module }}
         run: |
@@ -188,6 +198,7 @@ jobs:
 
       - name: Install pinned Claude Code CLI
         id: setup_claude
+        if: inputs.announce
         run: |
           CLAUDE_INSTALL_DIR="$RUNNER_TEMP/claude-code-2.1.80"
           npm install --prefix "$CLAUDE_INSTALL_DIR" @anthropic-ai/claude-code@2.1.80
@@ -195,6 +206,7 @@ jobs:
 
       - name: Generate English announcement (LLM)
         id: announce
+        if: inputs.announce
         uses: anthropics/claude-code-action@v1
         env:
           ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
@@ -232,6 +244,7 @@ jobs:
             --json-schema '{"type":"object","properties":{"announcement":{"type":"string","description":"完整 announcement 英文文本"},"summary":{"type":"string","description":"一句话摘要 (给 GH Actions step summary 用)"}},"required":["announcement","summary"]}'
 
       - name: Verify announcement.md exists
+        if: inputs.announce
         env:
           # 把 structured_output 通过 env 安全传入 (避免 GH Actions 表达式直接
           # 插值到 shell 字符串造成的引号转义/命令注入风险). 仅用于失败时打日志.
@@ -257,6 +270,7 @@ jobs:
           echo '```' >> $GITHUB_STEP_SUMMARY
 
       - name: Upload announcement artifact
+        if: inputs.announce
         uses: actions/upload-artifact@v7
         with:
           name: announcement
@@ -331,6 +345,7 @@ jobs:
           cache: false
 
       - name: Download announcement artifact
+        if: inputs.announce
         uses: actions/download-artifact@v8
         with:
           name: announcement
@@ -381,7 +396,8 @@ jobs:
       - name: Run l3build upload
         working-directory: ${{ needs.prepare-announcement.outputs.dir }}
         env:
-          # CTAN announcement 文件相对 working-directory (..) 的位置
+          # CTAN announcement 文件相对 working-directory (..) 的位置.
+          # announce=false ⟹ 不存在该文件, l3build 也不会被传 --file.
           ANN_FILE: ../announcement.md
           # ctex_kit_uploadconfig() 从 env 读 uploader / email, 这样 build.lua
           # 不需要把个人信息硬编码进 git, 本地跑 l3build upload 也是同一套.
@@ -393,9 +409,18 @@ jobs:
           # ctex_kit_env_or_nil() 把空串当成 nil, 不会写入空 note 字段.
           CTAN_NOTE: ${{ inputs.note }}
         run: |
-          # --file 把 announcement.md 喂给 CTAN announcement 表单.
+          # announce=true: --file 把 announcement.md 喂给 CTAN announcement 表单.
+          # announce=false: 不传 --file, l3build 走 uploadconfig.announcement_file
+          # 默认 "announcement.md" → file_contents 找不到文件 → announcement = nil
+          # → l3build-upload.lua "Empty announcement: No ctan announcement will be
+          # made" 放行 (不强制, 见 l3build-upload.lua L319-320).
           # --email 显式再传一次 (l3build CLI 接受, 兜底防 build.lua 里漏读 env).
-          ARGS=(--file "$ANN_FILE")
+          ARGS=()
+          if [ "${{ inputs.announce }}" = "true" ]; then
+            ARGS+=(--file "$ANN_FILE")
+          else
+            echo "::notice::announce=false: 跳过 CTAN announcement (--file 不传)."
+          fi
           ARGS+=(--email "${{ inputs.email }}")
           if [ "${{ inputs.dry_run }}" = "true" ]; then
             ARGS+=(--dry-run)
@@ -438,6 +463,7 @@ jobs:
           echo "- **CTAN Path**: ${{ needs.prepare-announcement.outputs.ctan_path }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Uploader**: ${{ inputs.uploader }} <${{ inputs.email }}>" >> $GITHUB_STEP_SUMMARY
           echo "- **Mode**: ${{ inputs.dry_run == true && 'DRY-RUN' || 'LIVE' }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Announcement**: ${{ inputs.announce == true && 'sent' || 'skipped' }}" >> $GITHUB_STEP_SUMMARY
           if [ -n "$NOTE" ]; then
             {
               echo "- **Note to CTAN**:"

--- a/.github/workflows/release-ctan-upload.yml
+++ b/.github/workflows/release-ctan-upload.yml
@@ -125,7 +125,7 @@ jobs:
 
       - name: Extract v<ver> changes block
         id: changes
-        if: inputs.announce
+        if: inputs.announce == true
         env:
           DTX_PATH: ${{ steps.parse.outputs.dir }}/${{ steps.parse.outputs.dtx }}
           VER: ${{ steps.parse.outputs.ver }}
@@ -178,7 +178,7 @@ jobs:
 
       - name: Fetch previous CTAN announcement for tone reference
         id: prev_ann
-        if: inputs.announce
+        if: inputs.announce == true
         env:
           PKG_MODULE: ${{ steps.parse.outputs.module }}
         run: |
@@ -198,7 +198,7 @@ jobs:
 
       - name: Install pinned Claude Code CLI
         id: setup_claude
-        if: inputs.announce
+        if: inputs.announce == true
         run: |
           CLAUDE_INSTALL_DIR="$RUNNER_TEMP/claude-code-2.1.80"
           npm install --prefix "$CLAUDE_INSTALL_DIR" @anthropic-ai/claude-code@2.1.80
@@ -206,7 +206,7 @@ jobs:
 
       - name: Generate English announcement (LLM)
         id: announce
-        if: inputs.announce
+        if: inputs.announce == true
         uses: anthropics/claude-code-action@v1
         env:
           ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
@@ -244,7 +244,7 @@ jobs:
             --json-schema '{"type":"object","properties":{"announcement":{"type":"string","description":"完整 announcement 英文文本"},"summary":{"type":"string","description":"一句话摘要 (给 GH Actions step summary 用)"}},"required":["announcement","summary"]}'
 
       - name: Verify announcement.md exists
-        if: inputs.announce
+        if: inputs.announce == true
         env:
           # 把 structured_output 通过 env 安全传入 (避免 GH Actions 表达式直接
           # 插值到 shell 字符串造成的引号转义/命令注入风险). 仅用于失败时打日志.
@@ -270,7 +270,7 @@ jobs:
           echo '```' >> $GITHUB_STEP_SUMMARY
 
       - name: Upload announcement artifact
-        if: inputs.announce
+        if: inputs.announce == true
         uses: actions/upload-artifact@v7
         with:
           name: announcement
@@ -345,7 +345,7 @@ jobs:
           cache: false
 
       - name: Download announcement artifact
-        if: inputs.announce
+        if: inputs.announce == true
         uses: actions/download-artifact@v8
         with:
           name: announcement

--- a/.github/workflows/release-ctan-upload.yml
+++ b/.github/workflows/release-ctan-upload.yml
@@ -130,51 +130,29 @@ jobs:
           DTX_PATH: ${{ steps.parse.outputs.dir }}/${{ steps.parse.outputs.dtx }}
           VER: ${{ steps.parse.outputs.ver }}
         run: |
-          # 抽出所有 \changes{v<ver>}{...}{...} 条目 (含 \begin{macrocode} 前的
-          # 续行) 写入 changes-context.txt 作为 LLM 的输入材料.
-          # 注意: heredoc 必须用 quoted EOF + 零缩进 (python 对前导空格敏感).
-          #
           # 与 release.yml 保持一致: RC / pre / alpha / beta tag 共享 base
           # 版本的 \changes 条目, 先用 sed 剥离 prerelease 后缀再 grep.
           # 当前实践中 rc tag 不进入 CTAN upload, 但保持两个 workflow 的
           # 版本号处理逻辑一致, 减少未来误解.
           BASE_VER=$(printf '%s' "${VER}" | sed -E 's/-(rc[0-9]+|pre[0-9]*|alpha[0-9]*|beta[0-9]*)$//')
-          export BASE_VER
-          python3 > changes-context.txt <<'PYEOF'
-          import os
-          path = os.environ["DTX_PATH"]
-          ver  = os.environ["BASE_VER"]
-          with open(path, encoding="utf-8", errors="replace") as f:
-              lines = f.read().splitlines()
-          marker = f"\\changes{{v{ver}}}"
-          out, i = [], 0
-          while i < len(lines):
-              if marker in lines[i]:
-                  buf = [lines[i].lstrip("% ").rstrip()]
-                  # 续行: `% ` 开头且不开新 \changes / macrocode block / 空行
-                  j = i + 1
-                  while j < len(lines):
-                      s = lines[j]
-                      if not s.startswith("%"): break
-                      stripped = s.lstrip("% ").rstrip()
-                      if (stripped.startswith("\\changes")
-                              or stripped.startswith("\\begin{macrocode}")
-                              or stripped.startswith("\\end{macrocode}")
-                              or stripped == ""):
-                          break
-                      buf.append("  " + stripped)
-                      j += 1
-                  out.append("\n".join(buf))
-                  i = j
-              else:
-                  i += 1
-          print("\n\n".join(out))
-          PYEOF
-          if [ ! -s changes-context.txt ]; then
+          # 复用 scripts/extract-changes.py 出已清洗的 markdown bullet 列表
+          # (与 GH Release body 完全等同) 写到 release-notes.md. 这是 LLM
+          # 的**唯一**事实源 — prompt 强制它只翻译这份列表, 不准外推.
+          #
+          # 为什么不让 LLM 直接读 \changes 原文: zhlineskip-v1.0f 实测 LLM
+          # 凭空脑补出 dtx 里不存在的 "split env 修复" / "LaTeX3 重写" 两段
+          # (CTAN announcement vs GH Release body 不一致, myhsia 在 PR #928
+          # 评论中指出). 把"提取 + 命令清洗" 落实到机械脚本后, 命令清洗规则
+          # 与 release.yml 100% 共用, 两个产物的事实层一定一致.
+          python3 scripts/extract-changes.py "${DTX_PATH}" "v${BASE_VER}" > release-notes.md
+          if [ ! -s release-notes.md ]; then
               echo "::error::No \\changes{v${BASE_VER}} entries found in ${DTX_PATH} (VER=${VER}, BASE_VER=${BASE_VER})" >&2
               exit 1
           fi
-          wc -l changes-context.txt
+          echo "--- release-notes.md (LLM input) ---"
+          cat release-notes.md
+          echo "---"
+          wc -l release-notes.md
 
       - name: Fetch previous CTAN announcement for tone reference
         id: prev_ann
@@ -215,30 +193,56 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           path_to_claude_code_executable: ${{ steps.setup_claude.outputs.path }}
           prompt: |
-            你是 LaTeX 包发布工程师, 任务是为 CTAN 上传准备英文 announcement.
+            你是 LaTeX 包发布工程师, 任务是把已抽好的中文 release notes
+            **忠实翻译**为英文 CTAN announcement.
 
             包: ${{ steps.parse.outputs.pkg }}
             版本: v${{ steps.parse.outputs.ver }}
             标签: ${{ inputs.tag }}
 
-            **请先 Read 两个本地文件作为材料**:
-            - `changes-context.txt`: v${{ steps.parse.outputs.ver }} 的全部 `\changes` 中文条目 (主材料)
-            - `prev-announcement.txt`: 上一版 CTAN announcement 英文 (风格参考, 可能为空)
+            ## 输入材料
 
-            要求:
-            - 输出**英文** announcement, 300-500 词
-            - 风格简洁 / 技术性, 参考 prev-announcement.txt 的口吻 (若有)
-            - 分类: NEW FEATURES / BUG FIXES / BREAKING CHANGES / DEPRECATIONS
-              其中空类直接略掉, 不留标题
-            - 每条一句概括 + (#issue) 引用 (若 \changes 提及 #)
-            - 末尾两行: source + issue tracker URL
-              https://github.com/CTeX-org/ctex-kit
-              https://github.com/CTeX-org/ctex-kit/issues
-            - **不要直译** \changes 的中文, 要按 LaTeX 包发布的英文表达整理总结
-            - 用 Write 工具把最终 announcement 写到 `announcement.md` (与
-              changes-context.txt 同目录)
+            **请先 Read 两个本地文件**:
+            - `release-notes.md`: **唯一**的事实源, 已抽取并清洗好的
+              v${{ steps.parse.outputs.ver }} 中文 release notes
+              (markdown bullet 列表, 与 GH Release body 字面相等)
+            - `prev-announcement.txt`: 上一版 CTAN announcement 英文,
+              **仅用于风格 / 措辞参考**, 不是事实源 (可能为空)
 
-            写完后通过 structured_output 返回该 announcement 的全文.
+            ## 硬约束 (违反会被审核打回)
+
+            1. **不允许新增任何 release-notes.md 里没有的事实**. 不准
+               脑补 bug fix / feature / 重构 / 依赖变更 — 即便你"觉得
+               应该有". release-notes.md 里只有 1 条, 你的 announcement
+               就只能写 1 条对应的英文.
+            2. **不允许把多个原条目合并成"概览式"段落**. 一条中文 →
+               一条英文, 一一对应. 严禁出现"This release also includes
+               internal improvements such as ..." 这类没有出处的总结.
+            3. **不允许把 release-notes.md 之外的 PR / commit / issue
+               信息当事实写入**. (#NNN) 引用只在原条目已含 #NNN 时保留.
+            4. 翻译要技术准确. 拿不准就**保留原中文术语**而不是猜测.
+            5. 如果 release-notes.md 只有 1-2 条小改动 (typo / 注释 /
+               单 bug fix), announcement 就该是 50-100 词的小段, **不要
+               强行凑长**.
+
+            ## 输出格式
+
+            - 顶部 1-2 句 lead-in (描述本次发布是什么类型的改动, 例如
+              "This release fixes one bug." / "This release introduces
+              one breaking change in option naming."), 内容必须由
+              release-notes.md 直接推得.
+            - 然后按需分类: NEW FEATURES / BUG FIXES / BREAKING CHANGES
+              / DEPRECATIONS. 每条对应 release-notes.md 一条. 空类不留
+              标题.
+            - 末尾两行 (固定):
+              Source code: https://github.com/CTeX-org/ctex-kit
+              Issue tracker: https://github.com/CTeX-org/ctex-kit/issues
+            - 字数随 release-notes.md 条目数自适应 (1 条 ~50 词,
+              5 条 ~200 词, 10+ 条可到 400 词), **不要强行凑 300-500 词**.
+            - 用 Write 工具写到 `announcement.md` (与 release-notes.md
+              同目录).
+
+            写完后通过 structured_output 返回 announcement 全文.
           claude_args: |
             --model opus --allowedTools "Read,Write,Bash(cat:*),Bash(ls:*),Bash(wc:*)"
             --json-schema '{"type":"object","properties":{"announcement":{"type":"string","description":"完整 announcement 英文文本"},"summary":{"type":"string","description":"一句话摘要 (给 GH Actions step summary 用)"}},"required":["announcement","summary"]}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -217,73 +217,11 @@ jobs:
         # suffix to look up \changes against the base version.
         BASE_VER=$(printf '%s' "${VER}" | sed -E 's/-(rc[0-9]+|pre[0-9]*|alpha[0-9]*|beta[0-9]*)$//')
 
-        # Try extracting from \changes entries
+        # Try extracting from \changes entries. 共用 scripts/extract-changes.py
+        # 与 release-ctan-upload.yml 一致, 防 \changes → markdown 的清洗规则
+        # 在两个 workflow 间漂移.
         if grep -q "\\\\changes{v${BASE_VER}}" "${DIR}/${DTX}" 2>/dev/null; then
-          python3 - "${DIR}/${DTX}" "v${BASE_VER}" > "${NOTES_FILE}" << 'PYEOF'
-        import re, sys
-        dtx_path, target_ver = sys.argv[1], sys.argv[2]
-        with open(dtx_path) as f:
-            lines = f.readlines()
-        tag = '\\changes{' + target_ver + '}'
-        entries = []
-        i = 0
-        while i < len(lines):
-            line = lines[i]
-            if tag not in line:
-                i += 1
-                continue
-            # Extract content after the third {
-            m = re.search(r'\\changes\{[^}]*\}\{[^}]*\}\{', line)
-            if not m:
-                i += 1
-                continue
-            text = line[m.end():]
-            # Collect continuation lines (start with '% ')
-            i += 1
-            while i < len(lines) and re.match(r'^%\s+\S', lines[i]) and '\\changes{' not in lines[i] and '\\begin{' not in lines[i]:
-                text += ' ' + lines[i].lstrip('% ').rstrip('\n')
-                i += 1
-            # Strip trailing }
-            depth = 1
-            result = []
-            for ch in text:
-                if ch == '{': depth += 1
-                elif ch == '}':
-                    depth -= 1
-                    if depth == 0:
-                        break
-                result.append(ch)
-            text = ''.join(result)
-            text = re.sub(r'\s+', ' ', text).strip()
-            text = re.sub(r'\\(?:cs|tn)\{([^}]*)\}', lambda m: '\x00' + m.group(1) + '\x01', text)
-            text = re.sub(r'\\(?:opt|pkg|cls|file|texttt)\{([^}]*)\}', r'`\1`', text)
-            text = re.sub(r'\\textbf\{([^}]*)\}', r'**\1**', text)
-            text = re.sub(r'\\#', '#', text)
-            text = re.sub(r'\\LaTeXe(?:\\\s|\{\})?', 'LaTeX2e ', text)
-            text = re.sub(r'\\LaTeXiii(?:\\\s|\{\})?', 'LaTeX3 ', text)
-            text = re.sub(r'\\XeLaTeX(?:\\\s|\{\})?', 'XeLaTeX ', text)
-            text = re.sub(r'\\LuaLaTeX(?:\\\s|\{\})?', 'LuaLaTeX ', text)
-            text = re.sub(r'\\pdfLaTeX(?:\\\s|\{\})?', 'pdfLaTeX ', text)
-            text = re.sub(r'\\upLaTeX(?:\\\s|\{\})?', 'upLaTeX ', text)
-            text = re.sub(r'\\LaTeX(?:\\\s|\{\})?', 'LaTeX ', text)
-            text = re.sub(r'\\XeTeX(?:\\\s|\{\})?', 'XeTeX ', text)
-            text = re.sub(r'\\LuaTeX(?:\\\s|\{\})?', 'LuaTeX ', text)
-            text = re.sub(r'\\pdfTeX(?:\\\s|\{\})?', 'pdfTeX ', text)
-            text = re.sub(r'\\upTeX(?:\\\s|\{\})?', 'upTeX ', text)
-            text = re.sub(r'\\TeX(?:\\\s|\{\})?', 'TeX ', text)
-            text = re.sub(r'\\[A-Za-z]+(?:\{\})?\s*', '', text)
-            text = re.sub(r'\x00(.*?)\x01', r'`\\\1`', text)
-            text = re.sub(r'\\\s', ' ', text)
-            text = text.replace('~', ' ')
-            text = re.sub(r'  +', ' ', text).strip()
-            if text:
-                entries.append(text)
-        seen = set()
-        for e in entries:
-            if e not in seen:
-                seen.add(e)
-                print(f"- {e}")
-        PYEOF
+          python3 scripts/extract-changes.py "${DIR}/${DTX}" "v${BASE_VER}" > "${NOTES_FILE}"
         fi
 
         # Fallback: use git log between previous tag and current tag

--- a/scripts/extract-changes.py
+++ b/scripts/extract-changes.py
@@ -20,7 +20,10 @@ import sys
 
 
 def extract(dtx_path: str, target_ver: str) -> list[str]:
-    with open(dtx_path) as f:
+    # 显式指定 utf-8: 不依赖 locale.getpreferredencoding(). GH Actions
+    # Ubuntu runner 默认是 UTF-8, 但本地调试 / 别的 runner 不一定. dtx
+    # 偶发的损坏字节走 errors="replace" 不阻塞抽取.
+    with open(dtx_path, encoding="utf-8", errors="replace") as f:
         lines = f.readlines()
 
     tag = "\\changes{" + target_ver + "}"

--- a/scripts/extract-changes.py
+++ b/scripts/extract-changes.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Extract \\changes{v<ver>}{...}{...} entries from a .dtx file and emit
+markdown bullet list to stdout.
+
+Usage:
+    extract-changes.py <dtx_path> <version_with_v_prefix>
+
+Example:
+    extract-changes.py xeCJK/xeCJK.dtx v3.10.0
+
+设计意图: release.yml 用它生成 GH Release body, release-ctan-upload.yml
+用它生成 CTAN announcement 的事实材料 (不再让 LLM 直接读 \\changes,
+避免 LLM 凭空脑补 release notes 里没有的变更, zhlineskip-v1.0f 就是这
+样多写出 split env 修复 / LaTeX3 重写两段不存在的内容).
+
+LaTeX 命令清洗规则与 release.yml 之前内联的 Python 完全一致.
+"""
+import re
+import sys
+
+
+def extract(dtx_path: str, target_ver: str) -> list[str]:
+    with open(dtx_path) as f:
+        lines = f.readlines()
+
+    tag = "\\changes{" + target_ver + "}"
+    entries: list[str] = []
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        if tag not in line:
+            i += 1
+            continue
+        # 抽 \changes{v<ver>}{<date>}{<text...>} 的第三个 {} 内容.
+        m = re.search(r"\\changes\{[^}]*\}\{[^}]*\}\{", line)
+        if not m:
+            i += 1
+            continue
+        text = line[m.end():]
+        # 续行: 以 `% ` 开头, 且不开新的 \changes / macrocode block.
+        i += 1
+        while (
+            i < len(lines)
+            and re.match(r"^%\s+\S", lines[i])
+            and "\\changes{" not in lines[i]
+            and "\\begin{" not in lines[i]
+        ):
+            text += " " + lines[i].lstrip("% ").rstrip("\n")
+            i += 1
+        # 用花括号深度匹配剥掉结尾 }, 容忍 text 内的嵌套 {}.
+        depth = 1
+        result: list[str] = []
+        for ch in text:
+            if ch == "{":
+                depth += 1
+            elif ch == "}":
+                depth -= 1
+                if depth == 0:
+                    break
+            result.append(ch)
+        text = "".join(result)
+        text = re.sub(r"\s+", " ", text).strip()
+        # \cs / \tn → `\<name>` (先用 \x00..\x01 临时占位, 避开后面 \\
+        # 命令通杀正则把 \cs 自己也吃掉).
+        text = re.sub(r"\\(?:cs|tn)\{([^}]*)\}", lambda m: "\x00" + m.group(1) + "\x01", text)
+        text = re.sub(r"\\(?:opt|pkg|cls|file|texttt)\{([^}]*)\}", r"`\1`", text)
+        text = re.sub(r"\\textbf\{([^}]*)\}", r"**\1**", text)
+        text = re.sub(r"\\#", "#", text)
+        # LaTeX 系列 logo 命令的常见形态: \LaTeX, \LaTeX\<space>, \LaTeX{}.
+        text = re.sub(r"\\LaTeXe(?:\\\s|\{\})?", "LaTeX2e ", text)
+        text = re.sub(r"\\LaTeXiii(?:\\\s|\{\})?", "LaTeX3 ", text)
+        text = re.sub(r"\\XeLaTeX(?:\\\s|\{\})?", "XeLaTeX ", text)
+        text = re.sub(r"\\LuaLaTeX(?:\\\s|\{\})?", "LuaLaTeX ", text)
+        text = re.sub(r"\\pdfLaTeX(?:\\\s|\{\})?", "pdfLaTeX ", text)
+        text = re.sub(r"\\upLaTeX(?:\\\s|\{\})?", "upLaTeX ", text)
+        text = re.sub(r"\\LaTeX(?:\\\s|\{\})?", "LaTeX ", text)
+        text = re.sub(r"\\XeTeX(?:\\\s|\{\})?", "XeTeX ", text)
+        text = re.sub(r"\\LuaTeX(?:\\\s|\{\})?", "LuaTeX ", text)
+        text = re.sub(r"\\pdfTeX(?:\\\s|\{\})?", "pdfTeX ", text)
+        text = re.sub(r"\\upTeX(?:\\\s|\{\})?", "upTeX ", text)
+        text = re.sub(r"\\TeX(?:\\\s|\{\})?", "TeX ", text)
+        # 余下的 \xxx / \xxx{} 一律剥掉 (\changes 里其他命令通常是引用类,
+        # 直接去掉名字不影响信息量).
+        text = re.sub(r"\\[A-Za-z]+(?:\{\})?\s*", "", text)
+        # 还原 \cs / \tn 占位符 → `\<name>`.
+        text = re.sub(r"\x00(.*?)\x01", r"`\\\1`", text)
+        # 杂项: \<space> 当 inter-word, ~ 当 non-break space, 多空格压一.
+        text = re.sub(r"\\\s", " ", text)
+        text = text.replace("~", " ")
+        text = re.sub(r"  +", " ", text).strip()
+        if text:
+            entries.append(text)
+    return entries
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print(f"usage: {sys.argv[0]} <dtx_path> <version>", file=sys.stderr)
+        return 2
+    dtx_path, target_ver = sys.argv[1], sys.argv[2]
+    entries = extract(dtx_path, target_ver)
+    seen: set[str] = set()
+    for e in entries:
+        if e in seen:
+            continue
+        seen.add(e)
+        print(f"- {e}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 背景

minor changes (typo / 注释 / 小补丁) 不一定值得发 CTAN announcement — 邮件列表噪声 + 占 LLM API quota. 加个 boolean input 让维护者手动控制.

## 改动

新增 \`announce\` workflow_dispatch input, \`type: boolean, default: true\`. 默认行为完全不变.

\`announce=false\` 路径:

**prepare-announcement job** (7 个 announcement 相关 step 全部 \`if: inputs.announce\`):

- \`Extract v<ver> changes block\`
- \`Fetch previous CTAN announcement for tone reference\`
- \`Install pinned Claude Code CLI\`
- \`Generate English announcement (LLM)\`
- \`Verify announcement.md exists\`
- \`Upload announcement artifact\`

**upload-ctan job**:

- \`Download announcement artifact\` step 跳过
- \`Run l3build upload\` 内 \`ARGS\` 不拼 \`--file\`. 走 \`uploadconfig.announcement_file\` 默认 \`announcement.md\` → \`file_contents\` 找不到文件 → \`announcement = nil\` → l3build-upload.lua "Empty announcement: No ctan announcement will be made" 放行 (L319-320 非强制路径, 不报错)

**Summary** 加 \`Announcement: sent/skipped\` 一行, 便于审计.

## 兼容性

- 现有调用 (不带 \`announce\` input) 行为不变 (default=true)
- 现有 \`build-config.lua\` 的 \`uploadconfig.announcement_file = "announcement.md"\` 默认值无需改动 — 文件不存在时 l3build 走 nil 路径

## Test plan

- [x] YAML syntax 校验 (\`python3 -c "import yaml; yaml.safe_load(...)"\`)
- [ ] 下次 minor patch 发布走一遍 \`announce=false + dry_run=true\` 验证 l3build 不抱怨 announcement 缺失