### PR TITLE
fix(release): announce=false 写空 announcement.md, 让 l3build 不炸

### DIFF
--- a/.github/workflows/release-ctan-upload.yml
+++ b/.github/workflows/release-ctan-upload.yml
@@ -364,6 +364,21 @@ jobs:
           name: announcement
           path: .
 
+      # announce=false 时 prepare-announcement job 没有生成 announcement.md
+      # artifact, 上一步被 skip. 这里 echo 个空文件占位 — l3build-upload.lua
+      # 的 file_contents() 注释说 "if filename is non nil and file readable
+      # return contents otherwise nil", 但实现 (L382-396) 是
+      # `assert(open(filename))`, 文件不存在直接抛错而非返回 nil; 进不到 L319
+      # 的 "Empty announcement: No ctan announcement will be made" 放行路径.
+      # (rc-2 实测: announce=false 跑 dry-run 在 file_contents 里直接 fail.)
+      # 写空文件让 l3build 能 open, 读到空串 trim 后 == "" 走 L319 放行.
+      # build-config.lua 的 announcement_file 默认仍是 "announcement.md", 不必改.
+      - name: Create empty announcement.md (announce=false path)
+        if: inputs.announce == false
+        run: |
+          : > announcement.md
+          echo "::notice::announce=false: 写空 announcement.md, l3build 走 \"Empty announcement\" 放行路径."
+
       - name: Download GH Release ctan zip
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -410,7 +425,9 @@ jobs:
         working-directory: ${{ needs.prepare-announcement.outputs.dir }}
         env:
           # CTAN announcement 文件相对 working-directory (..) 的位置.
-          # announce=false ⟹ 不存在该文件, l3build 也不会被传 --file.
+          # announce=true: prepare-announcement job 产出真 announcement.md
+          # announce=false: 上方 "Create empty announcement.md" step 写了空文件
+          # 两种情况 announcement.md 都存在, l3build --file 都能 open.
           ANN_FILE: ../announcement.md
           # ctex_kit_uploadconfig() 从 env 读 uploader / email, 这样 build.lua
           # 不需要把个人信息硬编码进 git, 本地跑 l3build upload 也是同一套.
@@ -422,19 +439,12 @@ jobs:
           # ctex_kit_env_or_nil() 把空串当成 nil, 不会写入空 note 字段.
           CTAN_NOTE: ${{ inputs.note }}
         run: |
-          # announce=true: --file 把 announcement.md 喂给 CTAN announcement 表单.
-          # announce=false: 不传 --file, l3build 走 uploadconfig.announcement_file
-          # 默认 "announcement.md" → file_contents 找不到文件 → announcement = nil
-          # → l3build-upload.lua "Empty announcement: No ctan announcement will be
-          # made" 放行 (不强制, 见 l3build-upload.lua L319-320).
+          # 不分支: --file 总是传 announcement.md (上方 step 保证文件存在).
+          # announce=false 时文件为空 → l3build file_contents 读到空串 →
+          # trim 后 == "" → 走 L319 "Empty announcement: No ctan announcement
+          # will be made" 放行路径.
           # --email 显式再传一次 (l3build CLI 接受, 兜底防 build.lua 里漏读 env).
-          ARGS=()
-          if [ "${{ inputs.announce }}" = "true" ]; then
-            ARGS+=(--file "$ANN_FILE")
-          else
-            echo "::notice::announce=false: 跳过 CTAN announcement (--file 不传)."
-          fi
-          ARGS+=(--email "${{ inputs.email }}")
+          ARGS=(--file "$ANN_FILE" --email "${{ inputs.email }}")
           if [ "${{ inputs.dry_run }}" = "true" ]; then
             ARGS+=(--dry-run)
             ANSWER=n   # 见下方注释


### PR DESCRIPTION
## 背景

PR #928 引入的 bug, 在 `xeCJK-v3.10.1-rc2` 的 dry-run 测试中暴露:
[run 28426362131](https://github.com/CTeX-org/ctex-kit/actions/runs/28426362131/job/84230342632).

## 根因

PR #928 假设: `announce=false` 时不传 `--file`, l3build 会走
`uploadconfig.announcement_file` 默认 `"announcement.md"` →
`file_contents` 找不到文件 → 返回 nil → L319 "Empty announcement:
No ctan announcement will be made" 放行.

实测错: l3build-upload.lua L382-396 的 `file_contents`:

```lua
-- if filename is non nil and file readable return contents otherwise nil
function file_contents (filename)
  if filename ~= nil then
    local f= assert(open(filename,"r"))   -- ← 文件不存在直接抛错, 不返回 nil
    ...
```

注释说"文件不存在返回 nil", 实现是 `assert(open(...))`, 文件不存在直接
抛 Lua 错. 进不到 L319 的 nil 放行路径. dry-run 跑出:

```
.../l3build-upload.lua:384: announcement.md: No such file or directory
```

## 修法

`announce=false` 时新增一个 step 写**空** `announcement.md` 占位.
l3build 能 open → 读到空串 → `trim(vs) == ""` → L318-320 走
"Empty announcement: No ctan announcement will be made" 放行
(announcement 字段在 L319 非强制).

副带把 `Run l3build upload` 的 ARGS 拼接简化: `--file` 总是传, 不再
条件分支, 因为 `announcement.md` 两种路径下都存在.

## Test plan

- [x] YAML syntax 校验
- [ ] 合并后用 `xeCJK-v3.10.1-rc2` 重跑 release-ctan-upload.yml
  (`announce=false + dry_run=true`) 验证 l3build 走到 "Empty
  announcement: No ctan announcement will be made" 而非 file_contents
  抛错
