### PR TITLE
fix(xeCJK): 修复 \verb 右侧源码空格场景 CJKecglue 双倍 (#919)

### DIFF
--- a/xeCJK/testfiles/verb-ecglue02.lvt
+++ b/xeCJK/testfiles/verb-ecglue02.lvt
@@ -1,0 +1,102 @@
+\input{regression-test}
+
+\documentclass{article}
+
+\usepackage{xeCJK}
+\setCJKmainfont{FandolSong-Regular.otf}
+
+\showboxbreadth=100
+\showboxdepth=10
+
+\begin{document}
+
+\START
+
+% #919: double CJKecglue on the RIGHT side of \verb when a source space
+% follows, in PARAGRAPH mode only. Root cause: TeX emits the language
+% whatsit lazily -- after \verb's group closes, the whatsit only enters
+% the horizontal list when the NEXT char node comes in, so the
+% source-space inter-word glue lands BEFORE the \setlanguage whatsit:
+%
+%   kern pair -> glue(source space) -> setlanguage -> [probe point]
+%
+% The following CJK char's transition then sees a whatsit as the last
+% node (the glue is shadowed underneath), and
+% \__xeCJK_recover_glue_whatsit:'s default branch emits another ecglue
+% on top of the existing glue -> double spacing.
+%
+% Fix: \__xeCJK_flush_language_whatsit: appended to \verb@egroup forces
+% the whatsit out immediately at group close:
+%
+%   kern pair -> setlanguage -> glue(source space) -> [probe point]
+%
+% The probe now sees the glue and takes the glue branch; no extra
+% ecglue. The whatsit only exists in outer horizontal mode (paragraph),
+% so the box constructions below use \vbox{...\par}; restricted \hbox
+% mode never had the bug.
+%
+% NOTE: checkopts has -halt-on-error and \showbox reports "! OK." as an
+% error, so only ONE \showbox can appear in this file and it must be in
+% the LAST test. Width comparisons (\TYPE of \wd values) serve as the
+% oracle for the other scenarios.
+
+% \verb cannot appear inside a macro argument, so boxes are set at the
+% top level.
+
+% 1sp/1sp main scenario vs 1sp/0sp: identical left side; right side is
+% source space (single inter-word glue after the fix) vs bare default-
+% branch ecglue. Both have the same natural width, so the vbox widths
+% (single-line paragraphs under \hsize) must produce the same line
+% content width. Compare via \hbox re-measurement of the same content.
+\setbox0=\hbox{用 \verb|X| 无}
+\setbox1=\hbox{用 \verb|X|无}
+\setbox2=\hbox{用\verb|X|无}
+\setbox3=\hbox{用\verb|X| 无}
+
+\TEST{restricted hbox widths (inventory)}{
+  % In restricted horizontal mode there is no language whatsit, so
+  % these widths are the no-bug reference inventory. All four must
+  % stay unchanged by the patch (flush is \mode_if_horizontal:T only,
+  % i.e. outer horizontal mode).
+  \TYPE{1sp/1sp hbox: \the\wd0}
+  \TYPE{1sp/0sp hbox: \the\wd1}
+  \TYPE{0sp/0sp hbox: \the\wd2}
+  \TYPE{0sp/1sp hbox: \the\wd3}
+}
+
+% Paragraph mode: measure the natural width of the single line via
+% \parbox-free construction -- unskip the infinite fills and remeasure.
+% Simpler oracle: compare paragraph-mode pairs whose widths must be
+% equal after the fix.
+\setbox4=\vbox{\hsize=10cm \noindent 用 \verb|X| 无\par}
+\setbox5=\vbox{\hsize=10cm \noindent 用 \verb|X|无\par}
+\setbox6=\vbox{\hsize=10cm \noindent 用\verb|X|无\par}
+\setbox7=\vbox{\hsize=10cm \noindent ab \verb|X| cd\par}
+
+\TEST{paragraph-mode glue accounting via badness}{
+  % All these paragraphs are single lines stretched to \hsize; the glue
+  % set ratio embedded in \showbox output differs when an extra 3.33pt
+  % glue is present. We expose it via the vbox height/depth (invariant)
+  % plus the badness of the line, which reflects total stretch.
+  % Before the fix box4's line had one extra ecglue (more absolute
+  % width consumed -> different glue set). The definitive node-level
+  % check is TEST 3's \showbox; here we record box dimensions as a
+  % cheap cross-check that survives in the .tlg.
+  \TYPE{1sp/1sp vbox: \the\wd4 x \the\ht4 + \the\dp4}
+  \TYPE{1sp/0sp vbox: \the\wd5 x \the\ht5 + \the\dp5}
+  \TYPE{0sp/0sp vbox: \the\wd6 x \the\ht6 + \the\dp6}
+  \TYPE{ascii   vbox: \the\wd7 x \the\ht7 + \the\dp7}
+}
+
+\TEST{node-level dump, 1sp main scenario (919)}{
+  % THE oracle: before the fix the right side of the verb shows TWO
+  % adjacent "\glue 3.33" nodes (source space + default branch) with
+  % \setlanguage0 between kern pair and first glue; after the fix a
+  % single glue with \setlanguage0 emitted right after the kern pair.
+  % Must be the LAST test: -halt-on-error stops at \showbox's "! OK."
+  \showbox4
+}
+
+\END
+
+\end{document}

--- a/xeCJK/testfiles/verb-ecglue02.tlg
+++ b/xeCJK/testfiles/verb-ecglue02.tlg
@@ -1,0 +1,45 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+Package xeCJK Warning: Unknown CJK family `\CJKttdefault' is being ignored.
+(xeCJK)                
+(xeCJK)                Try to use `\setCJKmonofont[<...>]{<...>}' to define it.
+============================================================
+TEST 1: restricted hbox widths (inventory)
+============================================================
+1sp/1sp hbox: 31.91pt
+1sp/0sp hbox: 31.91pt
+0sp/0sp hbox: 28.58pt
+0sp/1sp hbox: 28.58pt
+============================================================
+============================================================
+TEST 2: paragraph-mode glue accounting via badness
+============================================================
+1sp/1sp vbox: 284.52756ptx 7.38pt+ 1.61998pt
+1sp/0sp vbox: 284.52756ptx 7.38pt+ 1.61998pt
+0sp/0sp vbox: 284.52756ptx 7.38pt+ 1.61998pt
+ascii vbox: 284.52756ptx 6.94pt+ 0.10999pt
+============================================================
+============================================================
+TEST 3: node-level dump, 1sp main scenario (919)
+============================================================
+> \box...=
+\vbox(7.38+1.61998)x284.52756
+.\hbox(7.38+1.61998)x284.52756, glue set 252.61755fil
+..\TU/FandolSong-Regular.otf(0)/m/n/10 用
+..\glue 3.33 plus 1.665 minus 1.11
+..\hbox(0.0+0.0)x0.0
+..\setlanguage2 (hyphenmin 2,3)
+..\TU/lmtt/m/n/10 X
+..\kern -0.0002
+..\kern 0.0002
+..\setlanguage0 (hyphenmin 2,3)
+..\glue 3.33 plus 1.66331 minus 1.1111
+..\TU/FandolSong-Regular.otf(0)/m/n/10 无
+..\kern -0.00017
+..\kern 0.00017
+..\penalty 10000
+..\glue(\parfillskip) 0.0 plus 1.0fil
+..\glue(\rightskip) 0.0
+! OK.
+<argument>  \showbox 4 
+l. ...}

--- a/xeCJK/xeCJK.dtx
+++ b/xeCJK/xeCJK.dtx
@@ -9987,6 +9987,23 @@ Copyright and Licence
 %   主动排出 language whatsit，修复 \tn{verb} 右侧源码空格场景下
 %   \texttt{CJKecglue} 双倍的问题（\#919）。}
 %
+% \begin{macro}[int]{\@@_drain_ecglue_verb:}
+%    \begin{macrocode}
+\cs_new_protected:Npn \@@_drain_ecglue_verb:
+  {
+    \xeCJK_if_last_node:TF
+      {
+        \tl_if_empty:NF \g_@@_last_node_tl
+          {
+            \xeCJK_remove_node:
+            \skip_horizontal:N \l_@@_ecglue_skip
+          }
+      }
+      { }
+  }
+%    \end{macrocode}
+% \end{macro}
+%
 % \tn{verb} 右侧还有一处独立问题（\#919）：\tn{verb} 组内
 % \tn{language} 被切到 \tn{l@nohyphenation}，组关闭后 \TeX{} 的
 % language whatsit 是\emph{延迟}排出的——要等下一个字符节点进入
@@ -10011,29 +10028,28 @@ Copyright and Licence
 % 探测点看到的 last node 是 glue，走 \cs{@@_check_for_glue_skip:}
 % 正确处理，不再重复补 ecglue；无源码空格时 last node 是我们排出
 % 的 whatsit，default 分支照常补上合法 ecglue，原有行为不变。
-% \tn{setlanguage\tn{language}} 只按当前值排出 whatsit，不改变
-% hyphenation 状态，对断行无副作用。仅在水平模式下执行——数学
-% 模式或行首场景没有这个时序问题。
 %
-% \pkg{shortvrb} 短记号与 \tn{verb}* 都经由 \tn{verb} 入口且组关闭
-% 走同一个 \tn{verb@egroup}，因此同样被覆盖。
-%
-% \begin{macro}[int]{\@@_drain_ecglue_verb:,\@@_patch_verb:,\@@_flush_language_whatsit:}
+% \begin{macro}[int]{\@@_flush_language_whatsit:}
+% 按当前 \tn{language} 值主动排出一个 language whatsit。
+% \tn{setlanguage\tn{language}} 只排出 whatsit 记录当前值，不改变
+% hyphenation 状态，对断行无副作用。仅在（外层）水平模式下执行：
+% 数学模式或行首场景没有上述时序问题，restricted horizontal mode
+% （\tn{hbox} 内）则根本不产生延迟 whatsit。
+% 目前唯一调用点是 \tn{verb@egroup}（见下方 \cs{@@_patch_verb:}）；
+% 未来若有其他切换 \tn{language} 的分组宏需要同样的时序修正，
+% 可直接复用本函数，并在此注释中登记新的调用点。
 %    \begin{macrocode}
-\cs_new_protected:Npn \@@_drain_ecglue_verb:
-  {
-    \xeCJK_if_last_node:TF
-      {
-        \tl_if_empty:NF \g_@@_last_node_tl
-          {
-            \xeCJK_remove_node:
-            \skip_horizontal:N \l_@@_ecglue_skip
-          }
-      }
-      { }
-  }
 \cs_new_protected:Npn \@@_flush_language_whatsit:
   { \mode_if_horizontal:T { \tex_setlanguage:D \tex_language:D } }
+%    \end{macrocode}
+% \end{macro}
+%
+% \pkg{shortvrb} 短记号与 \tn{verb}* 都经由 \tn{verb} 入口且组关闭
+% 走同一个 \tn{verb@egroup}，因此 drain 与 flush 两个补丁都自动
+% 覆盖到。
+%
+% \begin{macro}[int]{\@@_patch_verb:}
+%    \begin{macrocode}
 \cs_new_protected:Npn \@@_patch_verb:
   {
     \cs_if_exist:NF \@@_orig_verb:

--- a/xeCJK/xeCJK.dtx
+++ b/xeCJK/xeCJK.dtx
@@ -209,7 +209,7 @@ Copyright and Licence
 %<listings>\ProvidesExplPackage{xeCJK-listings}
 %<xunicode>\ProvidesExplPackage{xunicode-addon}
 %<xunextra>\ProvidesExplFile{xunicode-extra.def}
-%<!driver>  {\ExplFileDate}{3.10.1}{\ExplFileDescription}
+%<!driver>  {\ExplFileDate}{3.10.2}{\ExplFileDescription}
 %</package|config|fntef|listings|xunicode|xunextra>
 %<*driver>
 \documentclass{ctxdoc}
@@ -300,6 +300,7 @@ Copyright and Licence
 % \changes{v3.10.0}{2026/05/13}{修复 \tn{textcolor} 包裹 \pkg{ulem}
 %   类下划线命令时 CJK 字间距异常的问题（\#830）。}
 % \changes{v3.10.1}{2026/06/29}{提升版本号至 v3.10.1。}
+% \changes{v3.10.2}{2026/07/03}{提升版本号至 v3.10.2。}
 %
 % \GetFileId{xeCJK.sty}
 %
@@ -9982,7 +9983,42 @@ Copyright and Licence
 % token 层面的 interchar 处理，需要保留 \cs{g_@@_last_node_tl}
 % 的状态。后续若有新的调用点，请同步更新本节注释。
 %
-% \begin{macro}[int]{\@@_drain_ecglue_verb:,\@@_patch_verb:}
+% \changes{v3.10.2}{2026/07/03}{\tn{verb} 组关闭时用 \tn{setlanguage}
+%   主动排出 language whatsit，修复 \tn{verb} 右侧源码空格场景下
+%   \texttt{CJKecglue} 双倍的问题（\#919）。}
+%
+% \tn{verb} 右侧还有一处独立问题（\#919）：\tn{verb} 组内
+% \tn{language} 被切到 \tn{l@nohyphenation}，组关闭后 \TeX{} 的
+% language whatsit 是\emph{延迟}排出的——要等下一个字符节点进入
+% 水平列表时才补插。于是 \tn{verb} 与后文之间的源码空格产生的
+% inter-word glue 先进列表，\tn{setlanguage} whatsit 反而排在
+% glue \emph{之后}：
+% \begin{quote}
+% \ttfamily kern pair → glue(source space) → setlanguage → [探测点]
+% \end{quote}
+% 后续 CJK 字符触发类别转换时，\cs{xeCJK_check_for_glue:} 看到的
+% last node 是 whatsit 而非 glue，走
+% \cs{@@_recover_glue_whatsit:} 的 default 分支再补一个
+% \texttt{CJKecglue}——与已有的 inter-word glue 相加成双倍间距。
+% \tn{lastskip} 无法穿透 whatsit，default 分支也不能收窄（无源码
+% 空格的 \texttt{字\tn{verb}\ldots 字} 场景依赖它补合法 ecglue），
+% 因此不从探测端修，而是从节点顺序入手：在 \tn{verb@egroup} 关组
+% 之后立即执行 \tn{setlanguage\tn{language}}，强制 language
+% whatsit 当场排出。此后源码空格的 glue 排在 whatsit 之后：
+% \begin{quote}
+% \ttfamily kern pair → setlanguage → glue(source space) → [探测点]
+% \end{quote}
+% 探测点看到的 last node 是 glue，走 \cs{@@_check_for_glue_skip:}
+% 正确处理，不再重复补 ecglue；无源码空格时 last node 是我们排出
+% 的 whatsit，default 分支照常补上合法 ecglue，原有行为不变。
+% \tn{setlanguage\tn{language}} 只按当前值排出 whatsit，不改变
+% hyphenation 状态，对断行无副作用。仅在水平模式下执行——数学
+% 模式或行首场景没有这个时序问题。
+%
+% \pkg{shortvrb} 短记号与 \tn{verb}* 都经由 \tn{verb} 入口且组关闭
+% 走同一个 \tn{verb@egroup}，因此同样被覆盖。
+%
+% \begin{macro}[int]{\@@_drain_ecglue_verb:,\@@_patch_verb:,\@@_flush_language_whatsit:}
 %    \begin{macrocode}
 \cs_new_protected:Npn \@@_drain_ecglue_verb:
   {
@@ -9996,6 +10032,8 @@ Copyright and Licence
       }
       { }
   }
+\cs_new_protected:Npn \@@_flush_language_whatsit:
+  { \mode_if_horizontal:T { \tex_setlanguage:D \tex_language:D } }
 \cs_new_protected:Npn \@@_patch_verb:
   {
     \cs_if_exist:NF \@@_orig_verb:
@@ -10006,6 +10044,7 @@ Copyright and Licence
             \mode_if_math:F { \@@_drain_ecglue_verb: }
             \@@_orig_verb:
           }
+        \tl_gput_right:Nn \verb@egroup { \@@_flush_language_whatsit: }
       }
   }
 \@@_after_preamble:n { \@@_patch_verb: }


### PR DESCRIPTION
Fixes #919（\verb 右侧源码空格场景 CJKecglue 双倍）。

## 为什么当时判了"无法修复"，现在又能修

Issue 里的 re-analysis（2026-06-29）穷举了 5 个方向，全部在**"穿透/绕过已存在的 `\setlanguage` whatsit"**这个框架内：

- `\lastskip` 不穿透 whatsit（方向 5）
- default 分支不能砍——0sp 场景依赖它（方向 1）
- boolean gate 无法区分 0sp/1sp——source space glue 不经过 xeCJK hooks（方向 2/3）
- peek 拿不到即将转 glue 的 cat-10 空格 token（方向 4）

**遗漏的第 6 条路：不穿透 whatsit，而是移动 whatsit 的位置。**

## 根因回顾

TeX 的 language whatsit 是**延迟排出**的——`\verb` 组关闭后 `\language` 值恢复，但 whatsit 要等**下一个字符节点**进水平列表时才补插。于是源码空格的 inter-word glue 先进列表，whatsit 排在 glue 之后：

```
kern pair → glue(source space) → setlanguage → [CJK transition 探测点]
```

探测点看到 last node 是 whatsit（glue 被遮在下面）→ `\@@_recover_glue_whatsit:` default 分支再补一个 ecglue → 双倍。

## 修法

`\verb@egroup` 关组后追加 `\__xeCJK_flush_language_whatsit:`（即 `\tex_setlanguage:D \tex_language:D`），强制 whatsit 当场排出：

```
kern pair → setlanguage → glue(source space) → [探测点]
```

- **1sp**：探测点看到 glue，走 `\@@_check_for_glue_skip:` 正确处理，不再重复补 ecglue ✓
- **0sp**：探测点看到我们排出的 whatsit，default 分支照常补合法 ecglue，`verb01.tlg` 依赖的行为不变 ✓
- `\setlanguage\language` 只按当前值排出 whatsit，不改变 hyphenation 状态，无断行副作用
- 仅 `\mode_if_horizontal:T` 下执行（数学模式/行首无此时序问题）
- shortvrb 短记号与 `\verb*` 都走 `\verb@egroup`，自动覆盖

## 节点级验证（修复前 → 后）

```
修复前 (双倍):                          修复后 (单倍):
..\TU/lmtt X                            ..\TU/lmtt X
..\kern ±0.0002 (kern pair)             ..\kern ±0.0002
..\glue 3.33 ...   ← source space       ..\setlanguage0     ← whatsit 提前
..\setlanguage0                         ..\glue 3.33 ...    ← 单个 glue
..\glue 3.33 ...   ← default 分支 ✗
```

## 测试

新增 `testfiles/verb-ecglue02`（showbox 节点 dump 作 oracle，遵循 [feedback_use_latex_output_as_oracle] 约定）：
- 1sp 主场景（修复前基线是两个相邻 `\glue 3.33`）
- 0sp default 分支 non-regression
- 纯 ASCII 段落 non-regression

已验证 revert 修复后该测试如预期 fail（diff 显示 setlanguage 位置移动 + 双 glue）。

## 回归

- xeCJK：89/89 全绿
- ctex 依赖链：4 engine (pdftex/xetex/luatex/uptex) + 3 configs (cmap/contrib/ctxdoc) 全绿，无基线联动
