### PR TITLE
bug(extract): 补充规则

### DIFF
--- a/scripts/extract-changes.py
+++ b/scripts/extract-changes.py
@@ -76,12 +76,18 @@ def extract(dtx_path: str, target_ver: str) -> list[str]:
         text = re.sub(r"\\LuaLaTeX(?:\\\s|\{\})?", "LuaLaTeX ", text)
         text = re.sub(r"\\pdfLaTeX(?:\\\s|\{\})?", "pdfLaTeX ", text)
         text = re.sub(r"\\upLaTeX(?:\\\s|\{\})?", "upLaTeX ", text)
+        text = re.sub(r"\\ApLaTeX(?:\\\s|\{\})?", "ApLaTeX ", text)
+        text = re.sub(r"\\pLaTeX(?:\\\s|\{\})?", "pLaTeX ", text)
         text = re.sub(r"\\LaTeX(?:\\\s|\{\})?", "LaTeX ", text)
         text = re.sub(r"\\XeTeX(?:\\\s|\{\})?", "XeTeX ", text)
         text = re.sub(r"\\LuaTeX(?:\\\s|\{\})?", "LuaTeX ", text)
         text = re.sub(r"\\pdfTeX(?:\\\s|\{\})?", "pdfTeX ", text)
         text = re.sub(r"\\upTeX(?:\\\s|\{\})?", "upTeX ", text)
+        text = re.sub(r"\\ApTeX(?:\\\s|\{\})?", "ApTeX ", text)
+        text = re.sub(r"\\pTeX(?:\\\s|\{\})?", "pTeX ", text)
         text = re.sub(r"\\TeX(?:\\\s|\{\})?", "TeX ", text)
+        # `zhmakeindex` 会自动把 `!=` (多见于 `\opt` 命令中) 更换为 `=`
+        text = re.sub(r"!=", "=", text)
         # 余下的 \xxx / \xxx{} 一律剥掉 (\changes 里其他命令通常是引用类,
         # 直接去掉名字不影响信息量).
         text = re.sub(r"\\[A-Za-z]+(?:\{\})?\s*", "", text)

--- a/scripts/extract-changes.py
+++ b/scripts/extract-changes.py
@@ -66,9 +66,11 @@ def extract(dtx_path: str, target_ver: str) -> list[str]:
         # \cs / \tn → `\<name>` (先用 \x00..\x01 临时占位, 避开后面 \\
         # 命令通杀正则把 \cs 自己也吃掉).
         text = re.sub(r"\\(?:cs|tn)\{([^}]*)\}", lambda m: "\x00" + m.group(1) + "\x01", text)
-        text = re.sub(r"\\(?:|pkg|cls|file|texttt)\{([^}]*)\}", r"`\1`", text)
+        text = re.sub(r"\\(?:pkg|cls|file|texttt)\{([^}]*)\}", r"`\1`", text)
         # `zhmakeindex` 会自动把 `\opt` 命令中可能出现的 `!=` 更换为 `=`
         text = re.sub(r"\\opt\{([^}]*)!=([^}]*)\}", r"`\1 = \2`", text)
+        # 再处理不含 `!=` 的 `\opt`
+        text = re.sub(r"\\opt\{([^}]*)\}", r"`\1`", text)
         text = re.sub(r"\\textbf\{([^}]*)\}", r"**\1**", text)
         text = re.sub(r"\\#", "#", text)
         # LaTeX 系列 logo 命令的常见形态: \LaTeX, \LaTeX\<space>, \LaTeX{}.

--- a/scripts/extract-changes.py
+++ b/scripts/extract-changes.py
@@ -66,7 +66,9 @@ def extract(dtx_path: str, target_ver: str) -> list[str]:
         # \cs / \tn → `\<name>` (先用 \x00..\x01 临时占位, 避开后面 \\
         # 命令通杀正则把 \cs 自己也吃掉).
         text = re.sub(r"\\(?:cs|tn)\{([^}]*)\}", lambda m: "\x00" + m.group(1) + "\x01", text)
-        text = re.sub(r"\\(?:opt|pkg|cls|file|texttt)\{([^}]*)\}", r"`\1`", text)
+        text = re.sub(r"\\(?:|pkg|cls|file|texttt)\{([^}]*)\}", r"`\1`", text)
+        # `zhmakeindex` 会自动把 `\opt` 命令中可能出现的 `!=` 更换为 `=`
+        text = re.sub(r"\\opt\{([^}]*)!=([^}]*)\}", r"`\1 = \2`", text)
         text = re.sub(r"\\textbf\{([^}]*)\}", r"**\1**", text)
         text = re.sub(r"\\#", "#", text)
         # LaTeX 系列 logo 命令的常见形态: \LaTeX, \LaTeX\<space>, \LaTeX{}.
@@ -86,8 +88,6 @@ def extract(dtx_path: str, target_ver: str) -> list[str]:
         text = re.sub(r"\\ApTeX(?:\\\s|\{\})?", "ApTeX ", text)
         text = re.sub(r"\\pTeX(?:\\\s|\{\})?", "pTeX ", text)
         text = re.sub(r"\\TeX(?:\\\s|\{\})?", "TeX ", text)
-        # `zhmakeindex` 会自动把 `!=` (多见于 `\opt` 命令中) 更换为 `=`
-        text = re.sub(r"!=", "=", text)
         # 余下的 \xxx / \xxx{} 一律剥掉 (\changes 里其他命令通常是引用类,
         # 直接去掉名字不影响信息量).
         text = re.sub(r"\\[A-Za-z]+(?:\{\})?\s*", "", text)


### PR DESCRIPTION
bug(extract): tag `ctex v2.6.1` 描述中因 `.dtx` 使用了 `\opt{... != ...}`, python 没替换, 所以添加规则; 同时扩充 p(La)TeX 以及 ClerkMa 的 Ap(La)TeX 规则