### PR TITLE
docs(llmdoc): 记录 gh-assets 长期 orphan 分支约定

### DIFF
--- a/llmdoc/index.md
+++ b/llmdoc/index.md
@@ -16,6 +16,7 @@
 - `llmdoc/reference/build-and-test.md` — `l3build`、共享构建配置、根 `Makefile` 本地任务入口（#888）、`ctex` 180 个主回归测试的覆盖簇、多引擎基线策略、LuaTeX 预热、CI/CD（含 `check-doc.yml` 文档编译门禁 #935 + fontconfig alias 对 XeTeX 无效的稳定教训）、CI 字体策略（含 #878 `xunicode-symbols.tex` 五级逐字符字体回退链最低保证）、agentic 工作流来源与频率约束（#874/#876）、LaTeX2e 2026-06-01 格式依赖声明（#883）、本地 TL usertree 同步双步流程（#873/#880）。
 - `llmdoc/reference/coding-conventions.md` — expl3 命名、e-type 优先约定、`@@` 私有空间、`.choices:nn` 用 `#1` 替代 `\l_keys_choice_str`（#806 / #881）、catcode-class regex 的匹配优势与替换端 codepoint 局限（#378 / #879）、作用域语义、docstrip 标签、`\CTEX@` 遗留接口与文档排版基础设施。
 - `llmdoc/reference/ctex-fontset-mac.md` — `ctex` 中 `fontset=mac` / `macnew` / `macold` 的选择逻辑、macOS 15+ 检测后备、XeTeX/LuaTeX 字体探测差异与回退语义。
+- `llmdoc/reference/repo-git-conventions.md` — 仓库级 git 分支组织约定：长期 orphan 分支 `gh-assets` 集中托管 issue/PR 讨论静态资源，目录组织与引用格式，添加新资产的安全操作方式（worktree / plumbing，禁止主工作区 `checkout --orphan`），迁移旧引用的收尾步骤。
 
 ## guides
 
@@ -43,6 +44,7 @@
 - `llmdoc/memory/decisions/931-biblatex-let-shadow.md` — 决策: #931 biblatex 补丁点选 `\let` 目标 `\blx@pagetracker` 且 hook 时机改用 `\@@_at_end_preamble:n`——补丁点必须挂到宏包内部 `\let` 拷贝的目标而非源，且必须在 `\let` 执行后装 patch，`\@@_package_hook:nn` 对 nested style-load 场景不够晚。
 - `llmdoc/memory/decisions/935-check-doc-vs-ctan.md` — 决策: #935 新增 PR 门禁 `check-doc.yml` 用 `l3build doc` 而非 `l3build ctan`。后者内部硬编码调 `l3build check` (整套 regression) 与 test.yml 完全重复; 前者是纯 typeset (docinit + typesetpdf), 精确对应"文档 dtx→PDF 可编译性"维度. 牺牲 tdslocations 打包路径验证 (低频问题, release.yml 兜底).
 - `llmdoc/memory/decisions/382-dash-width-and-ligature-opt-in.md` — 决策: #382 破折号宽度修复分两阶段——公式修正（`\@@_long_punct_kerning:N` 三路取大 kern + `\xeCJK_punct_margin_process:NN` 全份 margin 补偿）默认生效, OpenType 合字支持通过 `PoZheHao` 字符类 `PoZheHaoLigature` opt-in; margin 选择新增专用条件 `\@@_punct_if_full_margin_dash:N` 而非改变目标宽度基准; 合字选择用户显式开关而非自动探测字体特性。
+- `llmdoc/memory/decisions/859-gh-assets-orphan-branch.md` — 决策: 建立长期 orphan 分支 `gh-assets` 集中托管 issue/PR 讨论静态资源, 取代按事件建临时分支（`tmp-859-assets` / `tmp-456-assets`, 均已删除）; 添加新资产须用 worktree 或纯 plumbing 流, 禁止主工作区 `git checkout --orphan` 以避免 `git clean` 波及未跟踪文件。
 - `llmdoc/memory/doc-gaps.md` — 已知文档与实现缺口追踪。
 - `llmdoc/memory/reflections/717-experiment-cjkecglue.md` — 反思: #717 用 `ctex / experiment` 子路径统一暴露实验性 `CJKecglue` 接口，并记录 xeCJK 参数桥接、xkanjiskip 缓存同步与四引擎基线策略。
 - `llmdoc/memory/reflections/715-hyperref-driverfallback.md` — 反思: TYPE 展开陷阱、l3build 命令拦截测试技巧。

--- a/llmdoc/memory/decisions/859-gh-assets-orphan-branch.md
+++ b/llmdoc/memory/decisions/859-gh-assets-orphan-branch.md
@@ -1,0 +1,26 @@
+# 决策：建立长期 orphan 分支 `gh-assets` 取代按事件建临时分支
+
+## 决策
+
+新建远端长期 orphan 分支 `origin/gh-assets`，集中托管 issue/PR 讨论中引用的静态资源（截图、示意图、MWE 等），取代此前"每个 issue 一个临时分支"的做法（`tmp-859-assets` / `tmp-456-assets`，均已删除）。约定细节见 `llmdoc/reference/repo-git-conventions.md`。
+
+## 背景
+
+GitHub issue/PR 评论里若引用仓库某分支下文件的 raw URL（`https://raw.githubusercontent.com/.../<branch>/<path>`），一旦该分支被删除，历史评论中的图片/文件引用会立即失效——评论本身不会报错，但图片位置会变成 404。此前的做法是为每个 issue 单独建一个临时分支（如 `tmp-859-assets`）存图，讨论结束后连同分支一起清理，导致历史评论中的引用逐渐失效。
+
+## 决策内容
+
+1. **一个长期 orphan 分支，而非按 issue 建分支**：`gh-assets` 与主代码历史完全隔离（无 parent），只承载资源文件，永不删除。
+2. **目录组织按 issue 号分区**：`issues/<n>/<file>`，保留可追溯性但不再依赖分支边界。
+3. **迁移已有临时分支的内容**：把 `tmp-859-assets`、`tmp-456-assets` 中的文件迁移进 `gh-assets/issues/859/`、`gh-assets/issues/456/`，改完所有引用旧 URL 的评论后删除两个临时分支。
+4. **添加资产必须用 worktree 或 plumbing，不直接在主工作区 `checkout --orphan`**：`--orphan` 切换分支后若配合 `git clean` 会清掉主工作区未跟踪文件——这在建立本分支时实际发生过一次险情（`git clean` 误删了 `.claude/` 下的文件，未造成不可恢复损失但足以作为前车之鉴）。安全替代方案：`git worktree add <tmp-dir> gh-assets` 隔离操作，或纯 plumbing 流（`hash-object` + `update-index --cacheinfo` + `write-tree` + `commit-tree` + `update-ref`，全程不触碰工作区/索引）。本次两个 commit（`ae0ab5fb` 建分支、`e84d0577` 补收遗漏文件）均用 plumbing 流构造。
+
+## 影响范围
+
+- 未来任何需要在 issue/PR 评论中贴图/贴 MWE 的场景，应放入 `gh-assets/issues/<n>/`，不再新建临时分支。
+- 已有 `.claude/` 等本地开发目录属于未跟踪文件，任何涉及 orphan 分支切换/清理的操作都需要先确认不会波及主工作区。
+
+## 相关
+
+- Stable：`llmdoc/reference/repo-git-conventions.md`
+- Commits：`ae0ab5fb`（建分支迁移 #859/#456 资源）、`e84d0577`（补收 #859 遗漏的 MWE `.tex`）

--- a/llmdoc/reference/repo-git-conventions.md
+++ b/llmdoc/reference/repo-git-conventions.md
@@ -1,0 +1,43 @@
+# 仓库级 git 分支组织约定
+
+## `gh-assets`：长期静态资源分支
+
+### 性质与用途
+
+`gh-assets` 是远端 `origin/gh-assets` 上的一个 **orphan 分支**——无 parent commit，与 `master` 及各包代码历史完全隔离。分支根目录有 `README.md` 说明用法。
+
+用途：长期存放 issue / PR 讨论中引用的静态资源（对比截图、示意图、MWE `.tex` 等）。GitHub issue/PR 评论中若以仓库分支的 raw URL 引用图片，分支一旦被删除引用就会失效；因此这类资源必须落在一个**不会被删**的长期分支，而不是随事件建立、随手清理的临时分支。
+
+### 目录组织与引用格式
+
+- 目录组织：`issues/<issue 号>/<文件名>`，按关联 issue 归档。
+- 引用格式：`https://raw.githubusercontent.com/CTeX-org/ctex-kit/gh-assets/issues/<issue 号>/<文件名>`。
+
+现有内容：`issues/859/`（#859 标点测量对比图 5 张 + 1 个 MWE `.tex`）、`issues/456/`（#456 禁则修复前后对比图）。这两批分别取代了此前的临时分支 `tmp-859-assets` / `tmp-456-assets`（均已删除）。
+
+### 添加新资产的安全操作方式
+
+**不要**在主工作区直接 `git checkout --orphan gh-assets`——`--orphan` 切换后若配合 `git clean` 清理，会波及主工作区当前未跟踪的文件（实际发生过一次险情：`git clean` 误删了 `.claude/` 下的文件）。orphan 分支操作必须与主工作区隔离，安全做法二选一：
+
+1. **`git worktree`**：`git worktree add /tmp/gh-assets gh-assets`，在独立目录中操作、commit、push，用完 `git worktree remove /tmp/gh-assets`。
+2. **纯 plumbing 流**：全程不 checkout、不触碰工作区索引，用底层命令直接构造 commit：
+   - `git hash-object -w <file>` 写 blob
+   - `GIT_INDEX_FILE=<tmpfile> git update-index --add --cacheinfo 100644,<blob-sha>,<path>` 在临时索引里挂载
+   - `git write-tree`（在该临时 `GIT_INDEX_FILE` 下）生成 tree
+   - `git commit-tree <tree-sha> -p <parent-sha> -m "..."` 生成 commit
+   - `git update-ref refs/heads/gh-assets <commit-sha>`，再 `git push origin gh-assets`
+
+两种方式均不影响主工作区当前分支的索引与未跟踪文件。
+
+### commit message 约定
+
+仓库 commit-msg hook 要求 `type(scope): subject` 格式；assets 类提交固定用 `chore(assets): ...`。
+
+### 迁移已有资源时的收尾步骤
+
+若把资源从临时分支迁移到 `gh-assets`（或未来任何一次分支重命名/迁移），必须同步完成：
+
+1. 编辑所有引用旧 URL 的 issue/PR 评论：`gh api repos/<owner>/<repo>/issues/comments/<comment-id> -X PATCH -F body=@<file>`。
+2. 用 `curl -w '%{http_code}'` 抽查新 URL 返回 200 后，才能删除旧分支。
+
+顺序不可颠倒——旧分支删除后旧评论若还未改完，图片链接会立即失效。


### PR DESCRIPTION
记录新建立的仓库工程约定：orphan 分支 `gh-assets` 长期托管 issue/PR 讨论引用的静态资源（目录组织 `issues/<n>/<file>`），取代按事件创建临时分支的做法。`tmp-859-assets` / `tmp-456-assets` 的资产已迁入并更新全部评论引用，两个临时分支已删除。

- 新增 `llmdoc/reference/repo-git-conventions.md`：分支用途、引用格式、安全添加资产的两种方式（worktree / plumbing 流）
- 新增 `llmdoc/memory/decisions/859-gh-assets-orphan-branch.md`：决策依据与主工作区 `--orphan` 操作险情记录
- `index.md` 同步

纯文档变更，无代码影响。