### PR TITLE
fix(scripts): extract-changes 支持分行书写的 \changes 条目

### DIFF
--- a/scripts/extract-changes.py
+++ b/scripts/extract-changes.py
@@ -34,13 +34,12 @@ def extract(dtx_path: str, target_ver: str) -> list[str]:
         if tag not in line:
             i += 1
             continue
-        # 抽 \changes{v<ver>}{<date>}{<text...>} 的第三个 {} 内容.
-        m = re.search(r"\\changes\{[^}]*\}\{[^}]*\}\{", line)
-        if not m:
-            i += 1
-            continue
-        text = line[m.end():]
+        # 先把续行拼接成完整逻辑行, 再抽第三个 {} 的内容: \changes 的
+        # 版本/日期与正文可能分行书写 (dtx 常见折行风格, 如
+        # `% \changes{v3.10.2}{2026/07/05}` + `% {正文...}`), 不能要求
+        # 三个 { 都出现在 tag 所在的物理行上.
         # 续行: 以 `% ` 开头, 且不开新的 \changes / macrocode block.
+        text = line.rstrip("\n")
         i += 1
         while (
             i < len(lines)
@@ -50,6 +49,10 @@ def extract(dtx_path: str, target_ver: str) -> list[str]:
         ):
             text += " " + lines[i].lstrip("% ").rstrip("\n")
             i += 1
+        m = re.search(r"\\changes\{[^}]*\}\s*\{[^}]*\}\s*\{", text)
+        if not m:
+            continue
+        text = text[m.end():]
         # 用花括号深度匹配剥掉结尾 }, 容忍 text 内的嵌套 {}.
         depth = 1
         result: list[str] = []


### PR DESCRIPTION
## 问题

`scripts/extract-changes.py` 要求 `\changes{ver}{date}{text}` 的三个 `{` 全部出现在同一物理行，而 dtx 常见折行风格把正文另起一行：

```
% \changes{v3.10.2}{2026/07/05}
% {长标点与其他标点之间折行时检查断点两侧的禁则：…（#456）。}
```

这类条目被**静默丢弃**——v3.10.2-rc3 的 release notes 因此漏掉了 #456 修复条目。

## 修复

先把续行拼接成完整逻辑行，再做三段 `{}` 匹配；版本/日期/正文之间允许空白。

## 验证（正反场景）

| 版本 | 旧输出 | 新输出 | 变化 |
|---|---|---|---|
| v3.10.2 | 10 条 | 11 条 | **#456 条目找回** |
| v3.10.0 | 47 条 | 52 条 | 找回 5 条历史漏抽（#827、#859、NoBreakLongPunct×2、浪线 LongPunct），**零删除**（diff 无 `<` 行） |
| v3.10.1 / v3.9.1 / v3.8.0 | — | — | 输出逐字节不变 |

合入后将手工补齐 rc3 release notes 中缺失的 #456 条目。