### PR TITLE
doc(zhlineskip): 文档字体和 ctex|xeCJK 同步

### DIFF
--- a/zhlineskip/build.lua
+++ b/zhlineskip/build.lua
@@ -11,7 +11,7 @@
     `\changes` 记录, 不必手动碰 .dtx 的 GetIdInfo 行.
 --]==========================================================================]--
 module              = "zhlineskip"
-version             = "v1.0g"
+version             = "v1.0h"
 date                = "2026-06-30"
 maintainer          = "Mingyu Xia"
 email               = "myhsia@outlook.com"
@@ -63,7 +63,7 @@ function update_tag(file, content, tagname, tagdate)
     --   `<(.-)>`-> 捕获 email
     content = string.gsub(content,
       "%%<%+!driver>\\GetIdInfo $Id: " .. module .. ".dtx " ..
-      "v%d+%.%d+%w %d+%-%d+%-%d+ (.-)<(.-)>",
+      "v%d+%.%w+ %d+%-%d+%-%d+ (.-)<(.-)>",
       "%%<+!driver>\\GetIdInfo $Id: "  .. module .. ".dtx " ..
       tagname .. " " .. tagdate .. " " .. maintainer .. "<" .. email .. ">")
   end

--- a/zhlineskip/zhlineskip.dtx
+++ b/zhlineskip/zhlineskip.dtx
@@ -160,7 +160,7 @@ The Current Maintainers of this work are **Ruixi Zhang** and **Mingyu Xia**.
 %<package>\NeedsTeXFormat{LaTeX2e}[2026/06/01]
 %<package>\RequirePackage{expl3}
 %<*package>
-%<+!driver>\GetIdInfo $Id: zhlineskip.dtx v1.0g 2026-06-30 Mingyu Xia<myhsia@outlook.com>$
+%<+!driver>\GetIdInfo $Id: zhlineskip.dtx v1.0h 2026-06-30 Mingyu Xia<myhsia@outlook.com>$
 %<package>  {Line spacing for CJK documents}
 %<package>\ProvidesExplPackage {\ExplFileName}
 %<!driver>  {\ExplFileDate} {\ExplFileVersion} {\ExplFileDescription}
@@ -211,19 +211,11 @@ The Current Maintainers of this work are **Ruixi Zhang** and **Mingyu Xia**.
   AutoFakeSlant     = .111
 ]
 \setCJKmainfont{Noto Serif CJK SC}[
-  UprightFont       = * Medium,
-  ItalicFont        = * Black,
-  BoldFont          = * Bold
+  Language   = Chinese Simplified,
+  ItalicFont = LXGWWenKaiGBLite-Regular.ttf
 ]
-% Sans/Mono 不显式 UprightFont. fontspec 默认让 fontconfig 模糊匹配
-% Regular weight (Noto OTC 集合里没有单独 "Regular" 暴露名). 显式
-% `* Regular` 反而让 fontconfig 查不到. xeCJK 也是直接 `Noto Sans CJK SC`.
-\setCJKsansfont{Noto Sans CJK SC}[
-  BoldFont          = * Bold
-]
-\setCJKmonofont{Noto Sans CJK SC}[
-  BoldFont          = * Bold
-]
+\setCJKsansfont{Noto Sans CJK SC}[Language = Chinese Simplified]
+\setCJKmonofont{LXGWZhuqueFangsong-Regular.ttf}[Language = Chinese Simplified]
 \frenchspacing
 \usepackage{zhlineskip}
 \newenvironment{english}{\addvspace\medskipamount}
@@ -263,6 +255,7 @@ The Current Maintainers of this work are **Ruixi Zhang** and **Mingyu Xia**.
 %   分别用于微调西文环境与数学环境的行距。}
 % \changes{v1.0a}{2018/08/03}{其余优化与改动只涉及到含 \texttt{@} 的内部宏，
 %   例如：宏命名更加规范、利用 \texttt{sp} 长度做计算。}
+% \changes{v1.0h}{2026/07/06}{文档等宽字体改用朱雀仿宋，意大利体改用霞鹜文楷 GB Lite。}
 %
 % \begin{documentation}
 %


### PR DESCRIPTION
文档等宽字体改用朱雀仿宋, 意大利体改用霞鹜文楷 GB Lite, 由于文档复杂度低, 目前没有破折号所以这条暂不同步, 更新版本号; lua regex tag 把 `%d+%w` 更新为更加 general 的 `%w+`.