### PR TITLE
fix(scripts): 防止 `extract-changes.py` 将 `\}` 识别为 close delimiter

### DIFF
--- a/scripts/extract-changes.py
+++ b/scripts/extract-changes.py
@@ -56,7 +56,17 @@ def extract(dtx_path: str, target_ver: str) -> list[str]:
         # 用花括号深度匹配剥掉结尾 }, 容忍 text 内的嵌套 {}.
         depth = 1
         result: list[str] = []
-        for ch in text:
+        # 跳过 LaTeX 转义 \{ 和 \}，避免增减 depth
+        idx = 0
+        while idx < len(text):
+            ch = text[idx]
+            if ch == "\\":
+                # 如果是检测到 \{ 或 \}，作为整体存入，不改变花括号深度
+                if idx + 1 < len(text) and text[idx + 1] in ("{", "}"):
+                    result.append(ch)
+                    result.append(text[idx + 1])
+                    idx += 2
+                    continue
             if ch == "{":
                 depth += 1
             elif ch == "}":
@@ -64,18 +74,26 @@ def extract(dtx_path: str, target_ver: str) -> list[str]:
                 if depth == 0:
                     break
             result.append(ch)
+            idx += 1
         text = "".join(result)
         text = re.sub(r"\s+", " ", text).strip()
+
+        # 使用 (?:\\.|[^}])*，使其能够安全匹配包含 \} 的命令参数
         # \cs / \tn → `\<name>` (先用 \x00..\x01 临时占位, 避开后面 \\
         # 命令通杀正则把 \cs 自己也吃掉).
-        text = re.sub(r"\\(?:cs|tn)\{([^}]*)\}", lambda m: "\x00" + m.group(1) + "\x01", text)
-        text = re.sub(r"\\(?:pkg|cls|file|texttt)\{([^}]*)\}", r"`\1`", text)
-        # `zhmakeindex` 会自动把 `\opt` 命令中可能出现的 `!=` 更换为 `=`
-        text = re.sub(r"\\opt\{([^}]*)!=([^}]*)\}", r"`\1 = \2`", text)
-        # 再处理不含 `!=` 的 `\opt`
-        text = re.sub(r"\\opt\{([^}]*)\}", r"`\1`", text)
-        text = re.sub(r"\\textbf\{([^}]*)\}", r"**\1**", text)
+        text = re.sub(r"\\(?:cs|tn)\{((?:\\.|[^}])*)\}",
+                      lambda m: "\x00" + m.group(1) + "\x01", text)
+        text = re.sub(r"\\(?:pkg|cls|file|texttt)\{((?:\\.|[^}])*)\}",
+                      r"`\1`", text)
+        # 处理 \opt 中可能出现的 != 
+        text = re.sub(r"\\opt\{((?:\\.|[^}])*?)!=((?:\\.|[^}])*?)\}",
+                      r"`\1 = \2`", text)
+        text = re.sub(r"\\opt\{((?:\\.|[^}])*)\}",    r"`\1`",   text)
+        text = re.sub(r"\\textbf\{((?:\\.|[^}])*)\}", r"**\1**", text)
         text = re.sub(r"\\#", "#", text)
+        # 将残留的 LaTeX 转义 `\{` 和 `\}` 还原为 md 里的常规 `{` 和 `}`
+        text = re.sub(r"\\\{", "{", text)
+        text = re.sub(r"\\\}", "}", text)
         # LaTeX 系列 logo 命令的常见形态: \LaTeX, \LaTeX\<space>, \LaTeX{}.
         text = re.sub(r"\\LaTeXe(?:\\\s|\{\})?", "LaTeX2e ", text)
         text = re.sub(r"\\LaTeXiii(?:\\\s|\{\})?", "LaTeX3 ", text)


### PR DESCRIPTION
在 [xeCJK-v3.10.0](https://github.com/CTeX-org/ctex-kit/releases/tag/xeCJK-v3.10.0) 中, notes 有一条显示为
```md
当显式 `\`
```
对应 xeCJK.dtx 中
```tex
% \changes{v3.10.0}{2026/05/12}{当显式 \texttt{\}} 触发 CJK→Boundary 转换时，
%   设置 \cs{g_@@_glue_check_pending_bool} 以启用后续的 glue 检查，
%   修复 \texttt{前\{中\} 后} 类型排版中多余的 \tn{CJKecglue}（\#831）。}
```
这是因为 `\texttt{\}}` 中的 `\}` 被识别为 close delimiter.

处理方法为在正则中包含它们, 并采用一个描述括号深度的计数器: 如果遇到 `\}` 则计数器不改变, 最后还原为 md 里的常规 `{` 和 `}`.

此举可增强 robustness: 有计数器给 "兜底儿"