### PR TITLE
fix(scripts): 保护 `\changes` 里的数学环境; 添加正则 `\LaTeX3`; 处理 `\catcode` 内的 backtick; 添加正则 `\env`; 添加正则 shortvrb 中的 `|...|` 与 `"..."`; 消除因换行导致 CJK 字符之间的空隙

### DIFF
--- a/scripts/extract-changes.py
+++ b/scripts/extract-changes.py
@@ -95,7 +95,7 @@ def extract(dtx_path: str, target_ver: str) -> list[str]:
             r"([\u4e00-\u9fff\u3000-\u303f\uff00-\uffef\u2014\u2026])"
             r"\s+(?=[\u4e00-\u9fff\u3000-\u303f\uff00-\uffef\u2014\u2026])",
             r"\1", text)
-        # 安全还原数学公式环境 $...$ 到清洗完毕后的逻辑文本中
+        # 抽取并保护数学公式环境 $...$, 防止其中的特殊命令被后续的 Markdown 转换规则误伤
         math_blocks = []
         def _save_math(m):
             block = m.group(0)

--- a/scripts/extract-changes.py
+++ b/scripts/extract-changes.py
@@ -111,9 +111,17 @@ def extract(dtx_path: str, target_ver: str) -> list[str]:
         text = re.sub(r"\\ApTeX(?:\\\s|\{\})?", "ApTeX ", text)
         text = re.sub(r"\\pTeX(?:\\\s|\{\})?", "pTeX ", text)
         text = re.sub(r"\\TeX(?:\\\s|\{\})?", "TeX ", text)
+        # 临时保护数学公式环境 $...$ 避免其中的数学命令被后面的通用剥离正则误杀
+        math_blocks = []
+        def _save_math(m):
+            math_blocks.append(m.group(0))
+            return f"\x02{len(math_blocks) - 1}\x03"
+        text = re.sub(r"\$(?:\\\$|[^$])+\$", _save_math, text)
         # 余下的 \xxx / \xxx{} 一律剥掉 (\changes 里其他命令通常是引用类,
         # 直接去掉名字不影响信息量).
         text = re.sub(r"\\[A-Za-z]+(?:\{\})?\s*", "", text)
+        # 还原数学公式环境 $...$
+        text = re.sub(r"\x02(\d+)\x03", lambda m: math_blocks[int(m.group(1))], text)
         # 还原 \cs / \tn 占位符 → `\<name>`.
         text = re.sub(r"\x00(.*?)\x01", r"`\\\1`", text)
         # 杂项: \<space> 当 inter-word, ~ 当 non-break space, 多空格压一.

--- a/scripts/extract-changes.py
+++ b/scripts/extract-changes.py
@@ -90,7 +90,12 @@ def extract(dtx_path: str, target_ver: str) -> list[str]:
             idx += 1
         text = "".join(result)
         text = re.sub(r"\s+", " ", text).strip()
-        # 抽取并保护数学公式环境 $...$，防止其中的特殊命令被后续的 Markdown 转换规则误伤
+        # 消除 CJK 字符及标点之间因换行引入的冗余空格
+        text = re.sub(
+            r"([\u4e00-\u9fff\u3000-\u303f\uff00-\uffef\u2014\u2026])"
+            r"\s+(?=[\u4e00-\u9fff\u3000-\u303f\uff00-\uffef\u2014\u2026])",
+            r"\1", text)
+        # 安全还原数学公式环境 $...$ 到清洗完毕后的逻辑文本中
         math_blocks = []
         def _save_math(m):
             block = m.group(0)
@@ -106,7 +111,8 @@ def extract(dtx_path: str, target_ver: str) -> list[str]:
         # 命令通杀正则把 \cs 自己也吃掉).
         text = re.sub(r"\\(?:cs|tn)\{((?:\\.|[^}])*)\}",
                       lambda m: "\x00" + m.group(1) + "\x01", text)
-        # 抽取并保护 shortvrb 的 |...|、"..." 以及 \texttt{...} 环境，防止其中的原生命令被后续的宏清理正则误伤
+        # 抽取并保护 shortvrb 的 |...|、"..." 以及 \texttt{...} 环境,
+        # 防止其中的原生命令被后续的宏清理正则误伤
         verbatim_blocks = []
         def _save_verbatim(m):
             content = m.group(1)
@@ -155,14 +161,16 @@ def extract(dtx_path: str, target_ver: str) -> list[str]:
         # (\changes 里其他命令通常是引用类, 直接去掉名字不影响信息量).
         text = re.sub(r"\\[A-Za-z]+(?:\{\})?\s*", "", text)
         # 杂项: \<space> 当 inter-word, ~ 当 non-break space, 多空格压一.
-        # （修改位置：移到占位符还原动作之前，防止洗掉已经还原出的 Markdown 行内代码内部的反斜杠与空格）
+        # 修改位置: 移到占位符还原动作之前, 防止洗掉已经还原出的
+        # Markdown 行内代码内部的反斜杠与空格
         text = re.sub(r"\\\s", " ", text)
         text = text.replace("~", " ")
         text = re.sub(r"  +", " ", text).strip()
         # 安全还原数学公式环境 $...$ 到清洗完毕后的逻辑文本中
         text = re.sub(r"\x02(\d+)\x03",
                       lambda m: math_blocks[int(m.group(1))], text)
-        # 合并并还原连续的 \cs / \tn / \texttt / shortvrb 占位符为单一的 Markdown 行内代码块
+        # 合并并还原连续的 \cs / \tn / \texttt / shortvrb
+        # 占位符为单一的 Markdown 行内代码块
         def _restore_combined_code(m):
             pieces = []
             # 迭代找出该连续块中的每一个代码占位符，恢复出对应的原始文本片段

--- a/scripts/extract-changes.py
+++ b/scripts/extract-changes.py
@@ -31,7 +31,7 @@ def to_inline_code(s: str) -> str:
     end_space = ' ' if s.endswith('`') else ''
     return f"{delimiter}{start_space}{s}{end_space}{delimiter}"
 
-# 返回类型为版本号和文本的元组列表
+# 从 dtx 中抽取指定版本的 \changes 条目，返回字符串列表
 def extract(dtx_path: str, target_ver: str) -> list[str]:
     # 显式指定 utf-8: 不依赖 locale.getpreferredencoding(). GH Actions
     # Ubuntu runner 默认是 UTF-8, 但本地调试 / 别的 runner 不一定. dtx

--- a/scripts/extract-changes.py
+++ b/scripts/extract-changes.py
@@ -118,7 +118,7 @@ def extract(dtx_path: str, target_ver: str) -> list[str]:
             content = m.group(1)
             # 还原 \textbackslash 并自动吃掉后面因 TeX 宏特性而产生的多余空格
             content = re.sub(r"\\textbackslash\s*", "\\\\", content)
-            # 清理代码块内部因配合 TeX 编译环境而残留的字符转义符（如 \& -> &, \_ -> _）
+            # 清理代码块内部因配合 TeX 编译环境而残留的字符转义符（如 \& -> &）
             content = re.sub(r"\\([&%#{}])", r"\1", content)
             verbatim_blocks.append(content)
             return f"\x04{len(verbatim_blocks) - 1}\x05"

--- a/scripts/extract-changes.py
+++ b/scripts/extract-changes.py
@@ -103,7 +103,7 @@ def extract(dtx_path: str, target_ver: str) -> list[str]:
         text = re.sub(r"\$(?:\\\$|[^$])+\$", _save_math, text)
         # 使用 (?:\\.|[^}])*，使其能够安全匹配包含 \} 的命令参数
         # \cs / \tn → `\<name>` (先用 \x00..\x01 临时占位, 避开后面 \\
-        # 命令通杀正则把 \cs自己也吃掉).
+        # 命令通杀正则把 \cs 自己也吃掉).
         text = re.sub(r"\\(?:cs|tn)\{((?:\\.|[^}])*)\}",
                       lambda m: "\x00" + m.group(1) + "\x01", text)
         # 抽取并保护 shortvrb 的 |...|、"..." 以及 \texttt{...} 环境，防止其中的原生命令被后续的宏清理正则误伤

--- a/scripts/extract-changes.py
+++ b/scripts/extract-changes.py
@@ -19,6 +19,19 @@ LaTeX 命令清洗规则与 release.yml 之前内联的 Python 完全一致.
 import glob, os, re, sys
 
 
+# 辅助函数：将文本转换为 Markdown 行内代码，自动处理内部的反引号（`）以防语法冲突
+def to_inline_code(s: str) -> str:
+    if '`' not in s:
+        return f"`{s}`"
+    # 计算内部最大连续反引号的数量
+    max_ticks = max(len(t) for t in re.findall(r'`+', s))
+    delimiter = '`' * (max_ticks + 1)
+    # 如果开头或结尾本身就是反引号，按照 Markdown 规范需补一个空格保护
+    start_space = ' ' if s.startswith('`') else ''
+    end_space = ' ' if s.endswith('`') else ''
+    return f"{delimiter}{start_space}{s}{end_space}{delimiter}"
+
+# 返回类型为版本号和文本的元组列表
 def extract(dtx_path: str, target_ver: str) -> list[str]:
     # 显式指定 utf-8: 不依赖 locale.getpreferredencoding(). GH Actions
     # Ubuntu runner 默认是 UTF-8, 但本地调试 / 别的 runner 不一定. dtx
@@ -77,11 +90,12 @@ def extract(dtx_path: str, target_ver: str) -> list[str]:
             idx += 1
         text = "".join(result)
         text = re.sub(r"\s+", " ", text).strip()
-        # 优先抽取并保护数学公式环境 $...$，防止其中的特殊命令被后续的 Markdown 转换规则误伤
+        # 抽取并保护数学公式环境 $...$，防止其中的特殊命令被后续的 Markdown 转换规则误伤
         math_blocks = []
         def _save_math(m):
             block = m.group(0)
-            # 洗练数学环境内部的特殊命令：剥离 \texttt 并将文本反斜杠 \textbackslash 规范化为数学反斜杠 \backslash
+            # 洗练数学环境内部的特殊命令：剥离 \texttt 并将
+            # \textbackslash 规范化为 \backslash
             block = re.sub(r"\\texttt\{((?:\\.|[^}])*)\}", r"\1", block)
             block = block.replace(r"\textbackslash", r"\backslash")
             math_blocks.append(block)
@@ -89,15 +103,31 @@ def extract(dtx_path: str, target_ver: str) -> list[str]:
         text = re.sub(r"\$(?:\\\$|[^$])+\$", _save_math, text)
         # 使用 (?:\\.|[^}])*，使其能够安全匹配包含 \} 的命令参数
         # \cs / \tn → `\<name>` (先用 \x00..\x01 临时占位, 避开后面 \\
-        # 命令通杀正则把 \cs 自己也吃掉).
+        # 命令通杀正则把 \cs自己也吃掉).
         text = re.sub(r"\\(?:cs|tn)\{((?:\\.|[^}])*)\}",
                       lambda m: "\x00" + m.group(1) + "\x01", text)
-        text = re.sub(r"\\(?:pkg|cls|file|texttt)\{((?:\\.|[^}])*)\}",
-                      r"`\1`", text)
-        # 处理 \opt 中可能出现的 != 
+        # 抽取并保护 shortvrb 的 |...|、"..." 以及 \texttt{...} 环境，防止其中的原生命令被后续的宏清理正则误伤
+        verbatim_blocks = []
+        def _save_verbatim(m):
+            content = m.group(1)
+            # 还原 \textbackslash 并自动吃掉后面因 TeX 宏特性而产生的多余空格
+            content = re.sub(r"\\textbackslash\s*", "\\\\", content)
+            # 清理代码块内部因配合 TeX 编译环境而残留的字符转义符（如 \& -> &, \_ -> _）
+            content = re.sub(r"\\([&%#{}])", r"\1", content)
+            verbatim_blocks.append(content)
+            return f"\x04{len(verbatim_blocks) - 1}\x05"
+        text = re.sub(r"\|([^|]+)\|", _save_verbatim, text)
+        text = re.sub(r'"([^"]+)"', _save_verbatim, text)
+        text = re.sub(r"\\texttt\{((?:\\.|[^}])*)\}", _save_verbatim, text)
+        # 转换为 md 行内代码，并增加对潜在内部反引号的防御
+        text = re.sub(r"\\(?:pkg|cls|file|env)\{((?:\\.|[^}])*)\}",
+                      lambda m: to_inline_code(m.group(1)), text)
+        # 处理 \opt 中可能出现的 !=
         text = re.sub(r"\\opt\{((?:\\.|[^}])*?)!=((?:\\.|[^}])*?)\}",
-                      r"`\1 = \2`", text)
-        text = re.sub(r"\\opt\{((?:\\.|[^}])*)\}",    r"`\1`",   text)
+                      lambda m: to_inline_code(f"{m.group(1)} = {m.group(2)}"),
+                      text)
+        text = re.sub(r"\\opt\{((?:\\.|[^}])*)\}",
+                      lambda m: to_inline_code(m.group(1)),   text)
         text = re.sub(r"\\textbf\{((?:\\.|[^}])*)\}", r"**\1**", text)
         text = re.sub(r"\\#", "#", text)
         # 将残留的 LaTeX 转义 `\{` 和 `\}` 还原为 md 里的常规 `{` 和 `}`
@@ -121,17 +151,31 @@ def extract(dtx_path: str, target_ver: str) -> list[str]:
         text = re.sub(r"\\ApTeX(?:\\\s|\{\})?", "ApTeX ", text)
         text = re.sub(r"\\pTeX(?:\\\s|\{\})?", "pTeX ", text)
         text = re.sub(r"\\TeX(?:\\\s|\{\})?", "TeX ", text)
-        # 余下的 \xxx / \xxx{} 一律剥掉 (\changes 里其他命令通常是引用类,
-        # 直接去掉名字不影响信息量).
+        # 余下的 \xxx / \xxx{} 一律剥掉
+        # (\changes 里其他命令通常是引用类, 直接去掉名字不影响信息量).
         text = re.sub(r"\\[A-Za-z]+(?:\{\})?\s*", "", text)
-        # 安全还原数学公式环境 $...$ 到清洗完毕后的逻辑文本中
-        text = re.sub(r"\x02(\d+)\x03", lambda m: math_blocks[int(m.group(1))], text)
-        # 还原 \cs / \tn 占位符 → `\<name>`.
-        text = re.sub(r"\x00(.*?)\x01", r"`\\\1`", text)
         # 杂项: \<space> 当 inter-word, ~ 当 non-break space, 多空格压一.
+        # （修改位置：移到占位符还原动作之前，防止洗掉已经还原出的 Markdown 行内代码内部的反斜杠与空格）
         text = re.sub(r"\\\s", " ", text)
         text = text.replace("~", " ")
         text = re.sub(r"  +", " ", text).strip()
+        # 安全还原数学公式环境 $...$ 到清洗完毕后的逻辑文本中
+        text = re.sub(r"\x02(\d+)\x03",
+                      lambda m: math_blocks[int(m.group(1))], text)
+        # 合并并还原连续的 \cs / \tn / \texttt / shortvrb 占位符为单一的 Markdown 行内代码块
+        def _restore_combined_code(m):
+            pieces = []
+            # 迭代找出该连续块中的每一个代码占位符，恢复出对应的原始文本片段
+            for sm in re.finditer(r"\x00([^\x01]*)\x01|\x04(\d+)\x05",
+                                  m.group(0)):
+                if sm.group(1) is not None:
+                    pieces.append("\\" + sm.group(1))
+                else:
+                    pieces.append(verbatim_blocks[int(sm.group(2))])
+            return to_inline_code("".join(pieces))
+        # 匹配一段或多段连续挨在一起的 \x00...\x01 或 \x04...\x05 占位符
+        text = re.sub(r"(?:\x00[^\x01]*\x01|\x04\d+\x05)+",
+                      _restore_combined_code, text)
         if text:
             entries.append(text)
     return entries

--- a/scripts/extract-changes.py
+++ b/scripts/extract-changes.py
@@ -77,7 +77,16 @@ def extract(dtx_path: str, target_ver: str) -> list[str]:
             idx += 1
         text = "".join(result)
         text = re.sub(r"\s+", " ", text).strip()
-
+        # 优先抽取并保护数学公式环境 $...$，防止其中的特殊命令被后续的 Markdown 转换规则误伤
+        math_blocks = []
+        def _save_math(m):
+            block = m.group(0)
+            # 洗练数学环境内部的特殊命令：剥离 \texttt 并将文本反斜杠 \textbackslash 规范化为数学反斜杠 \backslash
+            block = re.sub(r"\\texttt\{((?:\\.|[^}])*)\}", r"\1", block)
+            block = block.replace(r"\textbackslash", r"\backslash")
+            math_blocks.append(block)
+            return f"\x02{len(math_blocks) - 1}\x03"
+        text = re.sub(r"\$(?:\\\$|[^$])+\$", _save_math, text)
         # 使用 (?:\\.|[^}])*，使其能够安全匹配包含 \} 的命令参数
         # \cs / \tn → `\<name>` (先用 \x00..\x01 临时占位, 避开后面 \\
         # 命令通杀正则把 \cs 自己也吃掉).
@@ -111,16 +120,10 @@ def extract(dtx_path: str, target_ver: str) -> list[str]:
         text = re.sub(r"\\ApTeX(?:\\\s|\{\})?", "ApTeX ", text)
         text = re.sub(r"\\pTeX(?:\\\s|\{\})?", "pTeX ", text)
         text = re.sub(r"\\TeX(?:\\\s|\{\})?", "TeX ", text)
-        # 临时保护数学公式环境 $...$ 避免其中的数学命令被后面的通用剥离正则误杀
-        math_blocks = []
-        def _save_math(m):
-            math_blocks.append(m.group(0))
-            return f"\x02{len(math_blocks) - 1}\x03"
-        text = re.sub(r"\$(?:\\\$|[^$])+\$", _save_math, text)
         # 余下的 \xxx / \xxx{} 一律剥掉 (\changes 里其他命令通常是引用类,
         # 直接去掉名字不影响信息量).
         text = re.sub(r"\\[A-Za-z]+(?:\{\})?\s*", "", text)
-        # 还原数学公式环境 $...$
+        # 安全还原数学公式环境 $...$ 到清洗完毕后的逻辑文本中
         text = re.sub(r"\x02(\d+)\x03", lambda m: math_blocks[int(m.group(1))], text)
         # 还原 \cs / \tn 占位符 → `\<name>`.
         text = re.sub(r"\x00(.*?)\x01", r"`\\\1`", text)

--- a/scripts/extract-changes.py
+++ b/scripts/extract-changes.py
@@ -106,6 +106,7 @@ def extract(dtx_path: str, target_ver: str) -> list[str]:
         # LaTeX 系列 logo 命令的常见形态: \LaTeX, \LaTeX\<space>, \LaTeX{}.
         text = re.sub(r"\\LaTeXe(?:\\\s|\{\})?", "LaTeX2e ", text)
         text = re.sub(r"\\LaTeXiii(?:\\\s|\{\})?", "LaTeX3 ", text)
+        text = re.sub(r"\\LaTeX3(?:\\\s|\{\})?", "LaTeX3 ", text)
         text = re.sub(r"\\XeLaTeX(?:\\\s|\{\})?", "XeLaTeX ", text)
         text = re.sub(r"\\LuaLaTeX(?:\\\s|\{\})?", "LuaLaTeX ", text)
         text = re.sub(r"\\pdfLaTeX(?:\\\s|\{\})?", "pdfLaTeX ", text)

--- a/zhlineskip/zhlineskip.dtx
+++ b/zhlineskip/zhlineskip.dtx
@@ -249,7 +249,7 @@ The Current Maintainers of this work are **Ruixi Zhang** and **Mingyu Xia**.
 % \changes{v1.0a}{2018/08/03}
 %   {去掉了键值选项 \opt{captionleadingratio}。}
 % \changes{v1.0a}{2018/08/03}{重命名键值选项
-%   \opt{MicrosoftWordLineSpacingMultiple} 为\opt{MSLineSpacingMultiple}}
+%   \opt{MicrosoftWordLineSpacingMultiple} 为 \opt{MSLineSpacingMultiple}}
 % \changes{v1.0a}{2018/08/03}{对外提供两个新的宏：
 %   \tn{SetTextEnvironmentSinglespace} 与 \tn{SetMathEnvironmentSinglespace}，
 %   分别用于微调西文环境与数学环境的行距。}

--- a/zhmetrics/zhmCJK.dtx
+++ b/zhmetrics/zhmCJK.dtx
@@ -1386,8 +1386,8 @@ If you are interested in the process of development you may observe
 %    \end{macrocode}
 % \end{macro}
 % \begin{macro}{\setCJKromanfont}
-% \changes{v0.3}{2012/02/02}{新增。}
-% "\setCJKmainfont" 的别名。
+% \changes{v0.3}{2012/02/02}{新增 \cs{setCJKmainfont} 的别名。}
+% \cs{setCJKmainfont} 的别名。
 %    \begin{macrocode}
 \let\setCJKromanfont\setCJKmainfont
 \@onlypreamble\setCJKromanfont


### PR DESCRIPTION
- 执行 `python3 extract-changes.py "../xeCJK/xeCJK.dtx" "v3.10.0" > CHANGELOG.md` 后生成的 markdown 中存在

```md
- 修复拼错的命令名， `\cyreref` $$ `\cyrerev` 和 `\textDiamandSolid` $$ `\textDiamondSolid`。
```

数学环境内什么都没有, 俩 $$ 没空格直接 KaTeX / MathJax 报错:

```text
ParseError: KaTeX parse error: Undefined control sequence: \cyrerev at position 3: `\̲c̲y̲r̲e̲r̲e̲v̲` 和 `\textDiama…
```