### PR TITLE
docs(llmdoc): 重锚 #965 squash merge 提交

### DIFF
--- a/llmdoc/state/sync.md
+++ b/llmdoc/state/sync.md
@@ -1,6 +1,6 @@
 # llmdoc Sync State
 
-- watermark-commit: 07c39a3fe6c2b7b3d2c88872a2aaa2658612dbe1
-- watermark-subject: fix(xeCJK): 居中 CJKunderline 下划线
-- updated-at: 2026-07-12T08:39:11Z
+- watermark-commit: ed1e840004353b5d656640458ee99c22c0cd5135
+- watermark-subject: fix(xeCJK): 修正 CJKunderline 水平偏移 (#965)
+- updated-at: 2026-07-12T08:45:17Z
 - updated-by: /llmdoc:update


### PR DESCRIPTION
PR #965 squash merge 后，分支内记录的 watermark `07c39a3f` 不再是 master 的祖先。

本 PR 只将 `llmdoc/state/sync.md` 重锚到 #965 的 squash merge 提交 `ed1e8400`。合并本 PR 后该提交仍是新 master 的祖先，后续 `llmdoc:update` 可从有效基线继续。

Related to #965.