### PR TITLE
docs(llmdoc): re-anchor after PR 980

### DIFF
--- a/llmdoc/state/sync.md
+++ b/llmdoc/state/sync.md
@@ -1,6 +1,6 @@
 # llmdoc Sync State
 
-- watermark-commit: 4db3d2572e1e87dfd2262138a5a391b0a3982bdf
+- watermark-commit: 91d37826391a677afa00b2442d73ed84777ab2ab
 - watermark-subject: fix(ctex): record CJKfntef guard for v2.6.3
-- updated-at: 2026-07-13T14:03:42Z
+- updated-at: 2026-07-13T14:15:21Z
 - updated-by: /llmdoc:update


### PR DESCRIPTION
PR #980 used rebase merge, rewriting its source commit from `4db3d257` to `91d37826`. The llmdoc watermark therefore still referenced a non-ancestor feature-branch commit.

This follow-up changes only `llmdoc/state/sync.md`:

- re-anchors `watermark-commit` to merged source commit `91d37826`;
- preserves the matching source subject;
- refreshes the update timestamp.

The target commit is already an ancestor of `master`, so this watermark remains valid when this documentation-only commit is rebased.
