### PR TITLE
chore(ctex): bump version to 2.6.3 and stamp sources

### DIFF
--- a/ctex/build.lua
+++ b/ctex/build.lua
@@ -1,5 +1,5 @@
 module              = "ctex"
-version             = "2.6.2"
+version             = "2.6.3"
 
 --[==========================================================================[--
     Configuration: Check, Tag, Pack, Upload     Do NOT Modify if Unnecessary

--- a/ctex/ctex-auxpkg.dtx
+++ b/ctex/ctex-auxpkg.dtx
@@ -111,7 +111,7 @@
 %<*!driver>
 %<!dict>\NeedsTeXFormat{LaTeX2e}[2026/06/01]
 %<!dict>\RequirePackage{expl3}
-%<+!driver>\GetIdInfo $Id: ctex-auxpkg.dtx 2.6.2 2026-07-04 20:30:27 +0800 6357331c Liam <liamhuang0205@gmail.com>$
+%<+!driver>\GetIdInfo $Id: ctex-auxpkg.dtx 2.6.3 2026-07-08 18:13:24 +0800 8c6212ee Mingyu Hsia <myhsia@outlook.com>$
 %<ctexcap>  {Chinese adapter in LaTeX (CTEX)}
 %<ctexcap>\ProvidesExplPackage{ctexcap}
 %<ctexhook>  {Document and package hooks (CTEX)}

--- a/ctex/ctex-engine.dtx
+++ b/ctex/ctex-engine.dtx
@@ -109,7 +109,7 @@
 % -----------------------------------------------------------------------
 %
 %<*!driver>
-%<+!driver>\GetIdInfo $Id: ctex-engine.dtx 2.6.2 2026-07-06 20:43:36 +0800 dbfd7c43 Mingyu Hsia <myhsia@outlook.com>$
+%<+!driver>\GetIdInfo $Id: ctex-engine.dtx 2.6.3 2026-07-13 22:01:28 +0800 91d37826 Liam <liamhuang0205@gmail.com>$
 %<pdftex>  {(pdf)LaTeX adapter (CTEX)}
 %<pdftex>\ProvidesExplFile{ctex-engine-pdftex.def}
 %<xetex>  {XeLaTeX adapter (CTEX)}

--- a/ctex/ctex-fontset.dtx
+++ b/ctex/ctex-fontset.dtx
@@ -117,7 +117,7 @@
   \edef \ExplFileDescription{#8}}%
 %</fd|zhmap>
 %<*!spa>
-%<+!driver>\GetIdInfo $Id: ctex-fontset.dtx 2.6.2 2026-07-06 02:16:01 +0800 5dd4f341 Liam <liamhuang0205@gmail.com>$
+%<+!driver>\GetIdInfo $Id: ctex-fontset.dtx 2.6.3 2026-07-08 18:13:24 +0800 8c6212ee Mingyu Hsia <myhsia@outlook.com>$
 %</!spa>
 %<*fontset>
 %<windows>  {Windows fonts definition (CTEX)}

--- a/ctex/ctex-kernel.dtx
+++ b/ctex/ctex-kernel.dtx
@@ -112,7 +112,7 @@
 %<class|style>\NeedsTeXFormat{LaTeX2e}[2026/06/01]
 %<class>\input{ctexbackend.cfg}
 %<class|style>\RequirePackage{expl3}
-%<+!driver>\GetIdInfo $Id: ctex-kernel.dtx 2.6.2 2026-07-06 20:43:36 +0800 dbfd7c43 Mingyu Hsia <myhsia@outlook.com>$
+%<+!driver>\GetIdInfo $Id: ctex-kernel.dtx 2.6.3 2026-07-08 18:13:24 +0800 8c6212ee Mingyu Hsia <myhsia@outlook.com>$
 %<ctex>  {Chinese adapter in LaTeX (CTEX)}
 %<ctex>\ProvidesExplPackage{ctex}
 %<ctexsize>  {Chinese font size definition (CTEX)}

--- a/ctex/ctex-scheme.dtx
+++ b/ctex/ctex-scheme.dtx
@@ -109,7 +109,7 @@
 % -----------------------------------------------------------------------
 %
 %<*!driver>
-%<+!driver>\GetIdInfo $Id: ctex-scheme.dtx 2.6.2 2026-07-04 20:30:27 +0800 6357331c Liam <liamhuang0205@gmail.com>$
+%<+!driver>\GetIdInfo $Id: ctex-scheme.dtx 2.6.3 2026-07-08 18:13:24 +0800 8c6212ee Mingyu Hsia <myhsia@outlook.com>$
 %<name&GBK>  {Caption with encoding GBK (CTEX)}
 %<name&GBK>\ProvidesExplFile{ctex-name-gbk.cfg}
 %<name&UTF8>  {Caption with encoding UTF-8 (CTEX)}

--- a/ctex/ctex.dtx
+++ b/ctex/ctex.dtx
@@ -423,7 +423,7 @@ This work has the LPPL maintenance status `maintained`.
 \fi
 %</internal>
 %<*driver>
-%<+!driver>\GetIdInfo $Id: ctex.dtx 2.6.2 2026-07-08 17:12:10 +0800 097bc3d5 Mingyu Hsia <myhsia@outlook.com>$
+%<+!driver>\GetIdInfo $Id: ctex.dtx 2.6.3 2026-07-13 19:34:27 +0800 8fb55ee0 Liam <liamhuang0205@gmail.com>$
 %<!driver>{Documentation: Chinese adapter in LaTeX (CTEX)}
 \documentclass{ctxdoc}
 \xeCJKsetup{PoZheHaoLigature}
@@ -483,7 +483,7 @@ This work has the LPPL maintenance status `maintained`.
 %   Grave accent  \`     Left brace    \{     Vertical bar  \|
 %   Right brace   \}     Tilde         \~}
 %
-% \GetFileId[097bc3d5]{ctex.sty}
+% \GetFileId[91d37826]{ctex.sty}
 %
 % \title{\bfseries \CTeX{} 宏集手册}
 % \author{\href{http://www.ctex.org}{CTEX.ORG}}


### PR DESCRIPTION
## 目的

为发布 `ctex-v2.6.3-rc1` 做版本前置：按 #937 SOP 把 `ctex/build.lua` 的 version bump 到 `2.6.3`，并用 `l3build tag` 回写 6 个 dtx 的 `$Id:$` stamp 与 `\GetFileId` shorthash。

## 变更内容

- `ctex/build.lua`：`version = "2.6.2"` → `"2.6.3"`（单一事实源）
- `ctex/*.dtx`：`l3build tag` 自动回写 stamp 至 `2.6.3`（含 `ctex.dtx` 的 `\GetFileId[91d37826]`）

## 验证

- 二次运行 `l3build tag` diff 不变，幂等守卫生效
- `check-tag.yml` 门禁将在本 PR 验证 stamp 同步

## 后续

merge 后执行 `make tag ctex-v2.6.3-rc1 && git push origin ctex-v2.6.3-rc1` 触发 release.yml（三方校验 `strip_rc(tag) == build.lua == stamp`）。

Refs #381, #937
