### PR TITLE
docs(xeCJK, ctex): 修复多处错字/语病/病句/逻辑错误问题

### DIFF
--- a/ctex/ctex-engine.dtx
+++ b/ctex/ctex-engine.dtx
@@ -187,7 +187,7 @@
 % 设置 \upTeX{} 字体映射，同时作用于 \tn{AtBeginDvi} 与
 % \tn{AtBeginShipoutFirst}。该宏对 \pdfTeX{} 和 \upTeX{} 均有用。
 % \tn{AtBeginDvi} 直接将 \tn{special} 保存到盒子中，
-% \tn{AtBeginShipoutFirst} 是保存到到宏中，并且不展开参数。
+% \tn{AtBeginShipoutFirst} 是保存到宏中，并且不展开参数。
 %
 % 可以使用 \LaTeX\ 2020/10/01 的钩子机制来统一设置。
 %     \begin{macrocode}
@@ -699,7 +699,7 @@
 % \end{macro}
 %
 % \begin{macro}[int]{\ctex_ignorespaces_case:N,\ctex_set_ignorespaces:}
-% 设置忽略空格的的方式。根据 \opt{space} 选项的值重定义 \tn{CJK@ignorespaces}，
+% 设置忽略空格的方式。根据 \opt{space} 选项的值重定义 \tn{CJK@ignorespaces}，
 % 并保存起来供 \tn{CJKhook} 备用。
 %    \begin{macrocode}
 \cs_new_protected:Npn \ctex_ignorespaces_case:N #1
@@ -861,7 +861,7 @@
 %    \begin{macrocode}
 \msg_new:nnn { ctex } { luatexja-loaded }
   {
-    Package~`luatexja'~can~not~be~loaded~before~`ctex'.\\
+    Package~`luatexja'~cannot~be~loaded~before~`ctex'.\\
     Loading~file~`#1'~will~abort!
   }
 \@ifpackageloaded { luatexja }

--- a/xeCJK/CHANGELOG.md
+++ b/xeCJK/CHANGELOG.md
@@ -435,8 +435,8 @@
 - 修正全角左标点后下划线与 `\CJKunderdot` 连用时结果不正常的问题。
 - 解决 `\CJKunderdot` 跨页使用时影响到页眉页脚的问题。
 - 完善对 `listings` 宏包的支持。
-- 解决 `listings` 坏境中代码行号输出不正确的问题，并解决在其中跨页时对页眉和页脚的影响。
-- 在 `listings` 坏境中对 `\charcode` 大于 $255$ 的字符根据其 `\catcode` 区分 `letter` 和 `other`。
+- 解决 `listings` 环境中代码行号输出不正确的问题，并解决在其中跨页时对页眉和页脚的影响。
+- 在 `listings` 环境中对 `\charcode` 大于 $255$ 的字符根据其 `\catcode` 区分 `letter` 和 `other`。
 
 ## [xeCJK-v3.2.2](https://github.com/CTeX-org/ctex-kit/releases/tag/xeCJK-v3.2.2)
 

--- a/xeCJK/xeCJK.dtx
+++ b/xeCJK/xeCJK.dtx
@@ -466,7 +466,7 @@ Copyright and Licence
 %     CJKecglue = \Arg{glue}
 %   \end{syntax}
 %   设置 CJK 文字与西文、CJK 文字与行内数学公式之间的间距，默认值是一个空格。使用这个
-%   选项设置的 \meta{glue} 最好也要用一定的弹性。请注意，这里设置的 \meta{glue} 只影响
+%   选项设置的 \meta{glue} 最好也要有一定的弹性。请注意，这里设置的 \meta{glue} 只影响
 %   \pkg{xeCJK} 根据需要自动添加的空白，源文件中直接输入的 CJK 文字与西文之间的空格不
 %   受影响（直接输出）。有时候 \pkg{xeCJK} 可能不能正确地调整间距，需要手动加空格。
 % \end{function}
@@ -486,7 +486,7 @@ Copyright and Licence
 %   \end{syntax}
 %   是否避免单个 CJK 文字单独占一个段落的最后一行。需要说明的是，这个选项只有在
 %   段末的最后一个字是 CJK 文字或者标点符号，并且倒数第二和第三个字都是文字才能
-%   正确处理处理孤字的问题。如果这倒数三个字有作为控制序列的参数的情况，那么一般
+%   正确处理孤字的问题。如果这倒数三个字有作为控制序列的参数的情况，那么一般
 %   来说也不能正确处理。
 % \end{function}
 %
@@ -611,7 +611,7 @@ Copyright and Licence
 %   \begin{syntax}
 %     LongPunct = \Arg{( — ⸺ ‥ … )}
 %   \end{syntax}
-%   设置长标点，例如破折号”——“与省略号”……”，允许在长标点前后
+%   设置长标点，例如破折号“——”与省略号“……”，允许在长标点前后
 %   断行，但是禁止在它们之间断行。同时属于 |NoBreakLongPunct|
 %   的长标点则禁止在其前面断行。长标点与其他标点相邻时，
 %   断点两侧还须满足通常的标点禁则：全角左标点不悬于行尾，
@@ -625,7 +625,7 @@ Copyright and Licence
 %   设置禁止在其前面断行的长标点。属于 |NoBreakLongPunct| 的字符必须同时属于
 %   |LongPunct|。与普通长标点不同，\pkg{xeCJK} 禁止在这类标点前面断行，但仍
 %   允许在其后面断行，并禁止在相同长标点之间断行。缺省值包含省略号
-%   “\textbf{‥}”和”\textbf{…}”。
+%   “\textbf{‥}”和“\textbf{…}”。
 % \end{function}
 %
 % \begin{function}[EXP]{MiddlePunct,MiddlePunct+,MiddlePunct-}
@@ -1079,13 +1079,13 @@ Copyright and Licence
 % \end{ctexexam}
 % 来设置字体。
 %
-% 为了方便起见，|fc-list| 命令也可以加上各种选项控制输出格式，例如如果只要列出
+% 为了方便起见，|fc-list| 命令也可以加上各种选项控制输出格式，例如，如果只要列出
 % 所有的中文字体的字体族名，可以用命令：
 % \begin{frameverb}
 %     fc-list -f "%{family}\n" :lang=zh  > zhfont.txt
 % \end{frameverb}
 % 这样就把字体列表保存在文件 \file{zhfont.txt} 中\footnote{由于汉字编码原因，
-% Windows 下总需要把字体列表输出的文件中防止乱码。}。这样列出的字体列表就比较
+% Windows 下总需要把字体列表输出到文件中以防止乱码。}。这样列出的字体列表就比较
 % 简明易用，如 Windows 下预装的中文字体：
 % \begin{frameverb}
 %   Arial Unicode MS
@@ -1134,7 +1134,7 @@ Copyright and Licence
 %   \xeCJKDeclareSubCJKBlock{SPUA}{ "E400 -> "E4DA , "E500 -> "E5E8 , "E600 -> "E6CE }
 %   \xeCJKDeclareSubCJKBlock{Ext-B}{ "20000 -> "2A6DF }
 %   \end{ctexexam}
-%   就声明了 |SPUA| 和 |Ext-B| 这两个个子分区。同时在 \ref{subsec:fontset}~节介绍的
+%   就声明了 |SPUA| 和 |Ext-B| 这两个子分区。同时在 \ref{subsec:fontset}~节介绍的
 %   CJK 字体设置命令的 \meta{font features} 里新建了 |SPUA| 和 |Ext-B| 这两个选项。
 %   新建的这两个选项的使用方法跟 \ref{subsec:fontset} 介绍的 |FallBack| 类似。可以
 %   通过它们来设置字体。
@@ -1154,8 +1154,8 @@ Copyright and Licence
 %
 % \begin{function}{\xeCJKCancelSubCJKBlock}
 %   \begin{syntax}
-%     \tn{xeCJKCancelSubCJKBlock}  \Arg{block_1, block_2, ...}
-%     \tn{xeCJKCancelSubCJKBlock} \Arg{block_1, block_2, ...}
+%     \tn{xeCJKCancelSubCJKBlock}   \Arg{block_1, block_2, ...}
+%     \tn{xeCJKCancelSubCJKBlock} * \Arg{block_1, block_2, ...}
 %   \end{syntax}
 %   在文档中取消对 |CJK| 分区的声明。带星号的命令还重置标点符号所属的字符类。
 % \end{function}
@@ -1215,7 +1215,7 @@ Copyright and Licence
 %     \tn{xeCJKsetwidth}  \Arg{标点列表} \Arg{length}
 %     \tn{xeCJKsetwidth} * \Arg{标点列表} \Arg{length}
 %   \end{syntax}
-%   \meta{标点列表}可以是单个标点，也可以是多个标点。例如，
+%   \meta{标点列表} 可以是单个标点，也可以是多个标点。例如，
 %   \begin{ctexexam}
 %   \xeCJKsetwidth{。？}{0.7em}
 %   \end{ctexexam}
@@ -1614,7 +1614,7 @@ Copyright and Licence
 %
 % \medskip
 %
-% 此外，\pkg{xeCJKfntef} 还提供了指定宽度，让汉字分散对齐的的环境
+% 此外，\pkg{xeCJKfntef} 还提供了指定宽度，让汉字分散对齐的环境
 % \env{CJKfilltwosides} 和 \env{CJKfilltwosides*}。
 %
 % \begin{function}[updated=2014-11-04]{CJKfilltwosides}
@@ -1654,7 +1654,7 @@ Copyright and Licence
 %   等宽字体的代码对齐等情形。需要注意的是，\tn{xeCJKVerbAddon} 对 \pkg{xeCJK} 的内
 %   部进行了比较大的修改，使用它之后，将禁止在 CJK 字符类之间自动换行，这与西文在
 %   抄录环境中的情况是一致的。所以不应该单独使用，应该放在分组里限制其作用域，否则
-%   是无效的。当然它可以和其他关于代码抄录的宏包配合使用。例如，可以使用于
+%   是无效的。当然它可以和其他关于代码抄录的宏包配合使用。例如，可以应用在
 %   \package{fancyvrb} 宏包的 \texttt{formatcom} 选项。此时设置的西文字体应该确实
 %   是等宽的以保证对齐。若西文等宽字体发生变动（包括字体大小），则需要在其后面使用
 %   \tn{xeCJKVerbAddon}，重新计算间距的宽度。\tn{xeCJKOffVerbAddon}
@@ -1676,7 +1676,7 @@ Copyright and Licence
 %   \env{lstlisting} 环境中分页）可能会影响到 \TeX 的输出例行程序（output routine）
 %   中的内容（比如页眉和页脚）。\tn{xeCJKShipoutHook} 用于恢复正文中的普通设置。
 %   \pkg{xeCJK} 已经处理了页眉和页脚的情况，其他的就需要根据情况自行调用。
-%   比如若使用 \pkg{eso-pic} 或者 \pkg{atbegshi} 实现文字水印，并且正文中使用了
+%   比如，若使用 \pkg{eso-pic} 或者 \pkg{atbegshi} 实现文字水印，并且正文中使用了
 %   以上所列的特殊形式，就需要在命令 \tn{AtBeginShipout} 的参数的最前面使用
 %   \tn{xeCJKShipoutHook}。
 % \end{function}
@@ -1695,7 +1695,7 @@ Copyright and Licence
 %
 % \pkg{xeCJK} 进行了一些处理，使得在使用 \XeTeX 时 \package{listings} 宏包可以
 % 支持 Unicode，因此在 \texttt{listings} 定义的代码环境中可以直接使用中文，不再
-% 需要通过 \texttt{escapechar}。
+% 需要使用 \texttt{escapechar}。
 %
 % 新版本（\texttt{3.x}）的 \pkg{xeCJK} 完全使用 \LaTeXiii{} 的语法来编写。
 % \LaTeXiii{} 放弃了 \tn{outer} 宏的概念，因此相关工具在
@@ -1718,7 +1718,7 @@ Copyright and Licence
 % 加上 \tn{relax} 来回避上面的错误。
 %
 % \pkg{xeCJK} 依赖 \XeTeX 的 \tn{XeTeXinterchartoks} 机制，与使用相同机制的宏包（例如
-% \pkg{polyglossia} 和 \pkg{xesearch}）可能会存在大小不一的冲突。
+% \pkg{polyglossia} 和 \pkg{xesearch}）可能会存在不同程度的冲突。
 % \pkg{xeCJK} 虽然为此作了一些处理，但与它们共同使用时应该小心。
 %
 % \subsection{CJK 文字与命令交互时的间距}
@@ -4232,7 +4232,7 @@ Copyright and Licence
 %   修复 \texttt{前\{中\} 后} 类型排版中多余的 \tn{CJKecglue}（\#831）。}
 % 当边界是 \tn{relax} 的时候，它可能是由 |\csname ...\endcsname| 的形式产生的，
 % 这样就可能出现问题\footnote{参见 \url{http://bbs.ctex.org/forum.php?mod=viewthread&tid=71563}。}。
-% 原来是都在未定义控制序列前都加上 \cs{exp_not:N}，现在是采用分组结束后手工恢复的方式。
+% 原来是都在未定义控制序列前都加上 \cs{exp_not:N}，现在则采用分组结束后手工恢复的方式。
 %    \begin{macrocode}
 \cs_new_protected:Npn \xeCJK_CJK_and_Boundary:w
   {
@@ -6562,7 +6562,7 @@ Copyright and Licence
 % \begin{macro}[int]{\@@_punct_if_full_margin_dash:N}
 % \changes{v3.10.2}{2026/07/04}{新增判断，配合破折号占两个汉字宽的
 %  空白补偿（\#382）。}
-% 判断标点 |#1| 是否为需要全空白补偿的破折号：即 \texttt{U+2014} 且未被
+% 判断标点 |#1| 是否为需要全空白补偿的破折号，即 \texttt{U+2014} 且未被
 % 归入 |PoZheHao| 类（没有启用破折号合字）。这类破折号在连用时，
 % 两个 \texttt{U+2014} 之间被挤压掉的空白恰好等于单个字符左右的总空白，
 % 因此在其两端各补偿一整份空白（而非一半），可以优先保证
@@ -8168,7 +8168,7 @@ Copyright and Licence
 % \end{macro}
 %
 % \begin{macro}{\@@_pass_args:nnnn}
-% 为了支持字体属性可选项在前在后两种语法，给出两个辅助工具，类似
+% 为了支持字体属性可选项在前和在后两种语法，给出两个辅助工具，类似
 % \package{fontspec} 的实现。自带展开功能，额外参数 |#4| 用于后处理。
 %    \begin{macrocode}
 \cs_new_protected:Npn \@@_pass_args:nnnn #1#2#3#4
@@ -8743,7 +8743,7 @@ Copyright and Licence
 % \begin{macro}{Verb}
 % \changes{v3.2.5}{2013/07/25}{微调定义。}
 % 如果设置为 \texttt{env}，则只在 \LaTeX 的抄录环境里使用 \tn{xeCJKVerbAddon}，^^A
-% 而不包括 \tn{verb}。对当前使用环境的判断基于在标准 \LaTeX 的坏境定义里使用
+% 而不包括 \tn{verb}。对当前使用环境的判断基于在标准 \LaTeX 的环境定义里使用
 % \tn{begingroup} 和 \tn{endgroup} 来分组。
 %    \begin{macrocode}
 \int_new:N \l_@@_verb_case_int
@@ -9460,7 +9460,7 @@ Copyright and Licence
 % \changes{v3.2.6}{2013/08/03}{考虑 \pkg{ulem} 对 \tn{MakeRobust} 的不当定义。}
 % \changes{v3.2.6}{2013/08/03}{考虑 \tn{math} 和 \tn{ensuremath}。}
 % \changes{v3.3.1}{2015/04/14}{兼容 \LaTeXe{} 2015。}
-% \tn{(} 的在 \LaTeXe 中的定义是
+% \tn{(} 在 \LaTeXe 中的定义是
 % \begin{verbatim}
 %   \def\({\relax\ifmmode\@badmath\else$\fi}
 % \end{verbatim}
@@ -9584,7 +9584,7 @@ Copyright and Licence
 %
 % \begin{macro}[int]{\xeCJK@fix@penalty}
 % \changes{v3.1.0}{2012/11/13}{采用通过不修改原语 \tn{/} 的方式对修复倾斜校正。}
-% 对 \LaTeXe 内核中的 \tn{fix@penalty} 被用于诸如 \tn{textit} 之类的文档
+% \LaTeXe 内核中的 \tn{fix@penalty} 被用于诸如 \tn{textit} 之类的文档
 % 字体转换命令的定义之中。这里对它进行补丁的目的是修复其中的倾斜校正，并使得这些
 % 文档命令与紧随其后的汉字之间可以正确的插入 \tn{CJKecglue} 或者忽略其中的空格。
 % 例如 \verb*|这是 \emph{强调} 文本|，第二个空格可以被忽略掉。如果使用 |xCJKecglue|
@@ -9729,7 +9729,7 @@ Copyright and Licence
 % \begin{macro}{\@@_patch_text_command:}
 % \begin{variable}{\c_@@_ambiguous_char_prop}
 % 单独处理宽度有分歧的几个标点：包括省略号、破折号、间隔号、引号等中西文混用的
-% 符号， 保证其命令形式输出的是西文字体。
+% 符号，保证其命令形式输出的是西文字体。
 % 如果 \pkg{xunicode} 宏包被载入，则通过 \pkg{xunicode-addon} 处理。
 %    \begin{macrocode}
 \prop_const_from_keyval:Nn \c_@@_ambiguous_char_prop
@@ -12250,7 +12250,7 @@ Copyright and Licence
 %
 % \begin{macro}{\@@_listings_initial_hook:}
 % \changes{v3.2.3}{2013/06/04}
-% {解决 \texttt{listings} 坏境中代码行号输出不正确的问题，并解决在其中跨页时对页眉
+% {解决 \texttt{listings} 环境中代码行号输出不正确的问题，并解决在其中跨页时对页眉
 %  和页脚的影响。}
 % \changes{v3.2.15}{2014/11/10}{修正 \texttt{breaklines} 无效的问题。}
 % \changes{v3.3.1}{2015/04/20}
@@ -12382,7 +12382,7 @@ Copyright and Licence
 % \end{macro}
 %
 % \begin{macro}{\@@_listings_process_Default:nN}
-% \changes{v3.2.3}{2013/06/08}{在 \texttt{listings} 坏境中对 \tn{charcode} 大于
+% \changes{v3.2.3}{2013/06/08}{在 \texttt{listings} 环境中对 \tn{charcode} 大于
 % $255$ 的字符根据其 \tn{catcode} 区分 \texttt{letter} 和 \texttt{other}。}
 % \changes{v3.3.1}{2015/01/27}{对 \pkg{listings} 的字符扩展不影响到其符号表中的
 % 七位或八位字符。}
@@ -12946,7 +12946,7 @@ Copyright and Licence
 % \end{macro}
 %
 % \begin{macro}{\@@_if_csname:nTF}
-% 判断 |#1| 是否可以作为控制序列的名字。这是因为 \pkg{xunicide} 使用了下面的定义。
+% 判断 |#1| 是否可以作为控制序列的名字。这是因为 \pkg{xunicode} 使用了下面的定义。
 % \begin{verbatim}
 %   \DeclareUTFcharacter[\UTFencname]{x0149}{'n}
 % \end{verbatim}
@@ -13389,7 +13389,7 @@ Copyright and Licence
 %
 % \begin{macro}{\@@_combine_circle:nnNNn,\@@_add_circle:nnNN,\@@_add_circle:nN}
 % 对圆圈中的数字或者字母适当缩小，以适合圆圈的大小。只有字体中存在
-% \texttt{U+25EF} 时，才使用这里的设置，否则还还是 \LaTeX\ 中的设置。
+% \texttt{U+25EF} 时，才使用这里的设置，否则还是 \LaTeX\ 中的设置。
 %    \begin{macrocode}
 \cs_new_protected:Npn \@@_combine_circle:nnNNn
   { \@@_text_combine:NnnNNn \@@_add_circle:nnNN }


### PR DESCRIPTION
- `坏境` -> `环境` 等低级错别字
- 多处 "叠词词", 如重复写 `的`
- 若干出全角引号用反
- 严重问题: `\xeCJKCancelSubCJKBlock` 函数的 `syntax` 对 star version 的描述中没有添加 `*`
- 以及一些中文语法错误 (淹没主语等)

\[Note\]: Checked by AI