### PR TITLE
build(make): 从 pattern 规则排除 check-ctex, 消除 overriding recipe 警告

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,14 +180,15 @@ clean-all: $(addprefix clean-,$(L3BUILD_PKGS)) clean-gbk2uni
 # ── 单包 target: $(verb)-$(pkg) → cd $(pkg) && l3build $(verb) ─────────────
 # 用 pattern rule 写法, 一条规则覆盖全部 verb × pkg 笛卡儿积.
 #
-# 注: check 的 ctex / xeCJK 等"大包"的 pattern 规则会被下方的 per-pkg
-# override (check-ctex 走 scripts/check-parallel.sh 多 engine 并行).
-# 其他小包仍走默认串行规则.
+# 注: check-ctex 从 pattern 规则中 filter-out, 由下方专属规则接管
+# (走 scripts/check-parallel.sh 多 engine 并行). 若不排除, 两处 recipe
+# 会触发 make 的 "overriding recipe for target 'check-ctex'" 警告.
+# 其他包仍走默认串行规则.
 define L3BUILD_PKG_RULES
 $(addprefix doc-,    $(1)): doc-%:    ; cd $$* && l3build doc
 $(addprefix unpack-, $(1)): unpack-%: ; cd $$* && l3build unpack
 $(addprefix ctan-,   $(1)): ctan-%:   ; cd $$* && l3build ctan
-$(addprefix check-,  $(1)): check-%:  ; cd $$* && l3build check
+$(addprefix check-,  $(filter-out ctex,$(1))): check-%: ; cd $$* && l3build check
 $(addprefix clean-,  $(1)): clean-%:  ; cd $$* && l3build clean
 endef
 $(eval $(call L3BUILD_PKG_RULES,$(L3BUILD_PKGS)))


### PR DESCRIPTION
## 问题

`L3BUILD_PKG_RULES` 宏为 `L3BUILD_PKGS` 全部包生成 `check-%` 静态 pattern 规则（含 `check-ctex`），而其后又有 `check-ctex` 专属规则（走 `scripts/check-parallel.sh` 4-engine 并行）。两处 recipe 重复定义，导致每次 `make` 调用（任意 target）都打印：

```
Makefile:202: warning: overriding recipe for target 'check-ctex'
Makefile:193: warning: ignoring old recipe for target 'check-ctex'
```

## 修复

在宏内生成 check 规则时 `$(filter-out ctex,$(1))`，让 `check-ctex` 由专属并行规则独占，并同步更新注释说明。

## 验证

`make -n` dry-run 确认警告消失且各 target recipe 不变：

- `check-ctex` → `scripts/check-parallel.sh`（并行，不变）
- `check-xeCJK` / `check-zhnumber` 等 → pattern 规则串行 `l3build check`（不变）
- `check-all` → 正确聚合（含并行 `check-ctex`）
- `check-ctex-serial` / `doc-ctex` / `tag` 校验 → 不受影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)
