### PR TITLE
docs(xeCJK): 对齐 syntax 环境下的代码缩进

### DIFF
--- a/xeCJK/xeCJK.dtx
+++ b/xeCJK/xeCJK.dtx
@@ -813,8 +813,10 @@ Copyright and Licence
 % \begin{function}[added=2026-07-22]{experiment/boundary-register}
 %   \begin{syntax}
 %     experiment/boundary-register =
-% \verb||  \{ command  = \meta{control sequence},
-% \verb||    strategy = \meta{strategy}, mode = \meta{mode} \}
+%   \  \{
+%   \    command  = \meta{control sequence},
+%   \    strategy = \meta{strategy}, mode = \meta{mode}
+%   \  \}
 %   \end{syntax}
 %   这是一个面向熟悉 \TeX{} 节点和命令实现的用户的实验性接口。它把
 %   \pkg{xeCJK} 尚未处理的命令接入命令边界框架，使命令包装前后的可见内容

--- a/xeCJK/xeCJK.dtx
+++ b/xeCJK/xeCJK.dtx
@@ -813,8 +813,8 @@ Copyright and Licence
 % \begin{function}[added=2026-07-22]{experiment/boundary-register}
 %   \begin{syntax}
 %     experiment/boundary-register =
-%       \{ command = \meta{control sequence},
-%          strategy = \meta{strategy}, mode = \meta{mode} \}
+%   "  {" command  = \meta{control sequence},
+%   "   " strategy = \meta{strategy}, mode = \meta{mode} "}"
 %   \end{syntax}
 %   这是一个面向熟悉 \TeX{} 节点和命令实现的用户的实验性接口。它把
 %   \pkg{xeCJK} 尚未处理的命令接入命令边界框架，使命令包装前后的可见内容

--- a/xeCJK/xeCJK.dtx
+++ b/xeCJK/xeCJK.dtx
@@ -813,8 +813,8 @@ Copyright and Licence
 % \begin{function}[added=2026-07-22]{experiment/boundary-register}
 %   \begin{syntax}
 %     experiment/boundary-register =
-%   "  {" command  = \meta{control sequence},
-%   "   " strategy = \meta{strategy}, mode = \meta{mode} "}"
+% \verb||  \{ command  = \meta{control sequence},
+% \verb||    strategy = \meta{strategy}, mode = \meta{mode} \}
 %   \end{syntax}
 %   这是一个面向熟悉 \TeX{} 节点和命令实现的用户的实验性接口。它把
 %   \pkg{xeCJK} 尚未处理的命令接入命令边界框架，使命令包装前后的可见内容


### PR DESCRIPTION
- 由于 `"` 和 `|` 被此文档和 ctxdoc 禁用, 所以使用更原始的 `\verb||` 去激活 `syntax` 环境的类 `verbatim` 行为