### PR TITLE
chore(ctex): 将版本号更新为 2.6.4

### DIFF
--- a/ctex/build.lua
+++ b/ctex/build.lua
@@ -1,5 +1,5 @@
 module              = "ctex"
-version             = "2.6.3"
+version             = "2.6.4"
 
 --[==========================================================================[--
     Configuration: Check, Tag, Pack, Upload     Do NOT Modify if Unnecessary

--- a/ctex/ctex-auxpkg.dtx
+++ b/ctex/ctex-auxpkg.dtx
@@ -111,7 +111,7 @@
 %<*!driver>
 %<!dict>\NeedsTeXFormat{LaTeX2e}[2026/06/01]
 %<!dict>\RequirePackage{expl3}
-%<+!driver>\GetIdInfo $Id: ctex-auxpkg.dtx 2.6.3 2026-07-08 18:13:24 +0800 8c6212ee Mingyu Hsia <myhsia@outlook.com>$
+%<+!driver>\GetIdInfo $Id: ctex-auxpkg.dtx 2.6.4 2026-07-13 22:33:39 +0800 0c10b7b6 Liam <liamhuang0205@gmail.com>$
 %<ctexcap>  {Chinese adapter in LaTeX (CTEX)}
 %<ctexcap>\ProvidesExplPackage{ctexcap}
 %<ctexhook>  {Document and package hooks (CTEX)}

--- a/ctex/ctex-engine.dtx
+++ b/ctex/ctex-engine.dtx
@@ -109,7 +109,7 @@
 % -----------------------------------------------------------------------
 %
 %<*!driver>
-%<+!driver>\GetIdInfo $Id: ctex-engine.dtx 2.6.3 2026-07-13 22:01:28 +0800 91d37826 Liam <liamhuang0205@gmail.com>$
+%<+!driver>\GetIdInfo $Id: ctex-engine.dtx 2.6.4 2026-07-15 00:31:58 +0800 7fbcffa9 Mingyu Hsia <myhsia@outlook.com>$
 %<pdftex>  {(pdf)LaTeX adapter (CTEX)}
 %<pdftex>\ProvidesExplFile{ctex-engine-pdftex.def}
 %<xetex>  {XeLaTeX adapter (CTEX)}

--- a/ctex/ctex-fontset.dtx
+++ b/ctex/ctex-fontset.dtx
@@ -117,7 +117,7 @@
   \edef \ExplFileDescription{#8}}%
 %</fd|zhmap>
 %<*!spa>
-%<+!driver>\GetIdInfo $Id: ctex-fontset.dtx 2.6.3 2026-07-08 18:13:24 +0800 8c6212ee Mingyu Hsia <myhsia@outlook.com>$
+%<+!driver>\GetIdInfo $Id: ctex-fontset.dtx 2.6.4 2026-07-22 17:12:58 +0800 392183cf Liam <liamhuang0205@gmail.com>$
 %</!spa>
 %<*fontset>
 %<windows>  {Windows fonts definition (CTEX)}

--- a/ctex/ctex-kernel.dtx
+++ b/ctex/ctex-kernel.dtx
@@ -112,7 +112,7 @@
 %<class|style>\NeedsTeXFormat{LaTeX2e}[2026/06/01]
 %<class>\input{ctexbackend.cfg}
 %<class|style>\RequirePackage{expl3}
-%<+!driver>\GetIdInfo $Id: ctex-kernel.dtx 2.6.3 2026-07-08 18:13:24 +0800 8c6212ee Mingyu Hsia <myhsia@outlook.com>$
+%<+!driver>\GetIdInfo $Id: ctex-kernel.dtx 2.6.4 2026-07-14 13:39:03 +0800 a048307f Liam <liamhuang0205@gmail.com>$
 %<ctex>  {Chinese adapter in LaTeX (CTEX)}
 %<ctex>\ProvidesExplPackage{ctex}
 %<ctexsize>  {Chinese font size definition (CTEX)}

--- a/ctex/ctex-scheme.dtx
+++ b/ctex/ctex-scheme.dtx
@@ -109,7 +109,7 @@
 % -----------------------------------------------------------------------
 %
 %<*!driver>
-%<+!driver>\GetIdInfo $Id: ctex-scheme.dtx 2.6.3 2026-07-08 18:13:24 +0800 8c6212ee Mingyu Hsia <myhsia@outlook.com>$
+%<+!driver>\GetIdInfo $Id: ctex-scheme.dtx 2.6.4 2026-07-13 22:33:39 +0800 0c10b7b6 Liam <liamhuang0205@gmail.com>$
 %<name&GBK>  {Caption with encoding GBK (CTEX)}
 %<name&GBK>\ProvidesExplFile{ctex-name-gbk.cfg}
 %<name&UTF8>  {Caption with encoding UTF-8 (CTEX)}

--- a/ctex/ctex.dtx
+++ b/ctex/ctex.dtx
@@ -423,7 +423,7 @@ This work has the LPPL maintenance status `maintained`.
 \fi
 %</internal>
 %<*driver>
-%<+!driver>\GetIdInfo $Id: ctex.dtx 2.6.3 2026-07-13 19:34:27 +0800 8fb55ee0 Liam <liamhuang0205@gmail.com>$
+%<+!driver>\GetIdInfo $Id: ctex.dtx 2.6.4 2026-07-22 17:12:58 +0800 392183cf Liam <liamhuang0205@gmail.com>$
 %<!driver>{Documentation: Chinese adapter in LaTeX (CTEX)}
 \documentclass{ctxdoc}
 \xeCJKsetup{PoZheHaoLigature}
@@ -483,7 +483,7 @@ This work has the LPPL maintenance status `maintained`.
 %   Grave accent  \`     Left brace    \{     Vertical bar  \|
 %   Right brace   \}     Tilde         \~}
 %
-% \GetFileId[91d37826]{ctex.sty}
+% \GetFileId[392183cf]{ctex.sty}
 %
 % \title{\bfseries \CTeX{} 宏集手册}
 % \author{\href{http://www.ctex.org}{CTEX.ORG}}


### PR DESCRIPTION
`ctex-v2.6.4-rc1` 的 release run #29967568029 在三方版本校验阶段失败：git tag 对应 2.6.4，但 `ctex/build.lua` 和六个 `.dtx` 文件中的版本 stamp 仍为 2.6.3。

本 PR 将 `ctex/build.lua` 的版本更新为 2.6.4，并运行 `l3build tag` 回写全部 stamp 及手册页脚中的固化提交号。

验证：

- 连续运行 `l3build tag`，第二次不再产生新差异；
- `ctex/build.lua` 与六个 `.dtx` stamp 均为 2.6.4；
- `git diff --check` 通过。

合并后将把失败的 `ctex-v2.6.4-rc1` tag 移到新的合并提交，并强制更新远端 tag，重新触发同名 release。
