### PR TITLE
ci(review): 复用共享 PR 审查工作流

### DIFF
--- a/.github/workflows/agentic-pr-review.yml
+++ b/.github/workflows/agentic-pr-review.yml
@@ -16,79 +16,13 @@ permissions:
 
 jobs:
   pr-review:
-    runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
-    env:
-      HAS_FEISHU_TOKEN: ${{ secrets.FEISHU_WEBHOOK_TOKEN != '' }}
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-
-      - name: Install pinned Claude Code CLI
-        id: setup_claude
-        run: |
-          CLAUDE_INSTALL_DIR="$RUNNER_TEMP/claude-code-2.1.80"
-          npm install --prefix "$CLAUDE_INSTALL_DIR" @anthropic-ai/claude-code@2.1.80
-          echo "path=$CLAUDE_INSTALL_DIR/node_modules/.bin/claude" >> $GITHUB_OUTPUT
-
-      - name: PR Review with Claude
-        id: review
-        uses: anthropics/claude-code-action@v1
-        env:
-          ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
-        with:
-          github_token: ${{ secrets.PAT_TOKEN || github.token }}
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          use_sticky_comment: true
-          allowed_non_write_users: "*"
-          path_to_claude_code_executable: ${{ steps.setup_claude.outputs.path }}
-          prompt: |
-            仓库: ${{ github.repository }}
-            仓库 URL: https://github.com/${{ github.repository }}
-
-            执行 `pr-review` skill 审查 PR #${{ github.event.pull_request.number }}，并使用 `gh pr comment` 发表审查评论。
-
-            Title: ${{ github.event.pull_request.title }}
-            Author: ${{ github.event.pull_request.user.login }}
-
-            审查完成后必须调用 `gh pr comment ${{ github.event.pull_request.number }} --body "..."` 发表审查结果。
-            注意: 所有代码链接必须使用 https://github.com/${{ github.repository }}/blob/main/... 格式。
-          claude_args: |
-            --model opus --allowedTools "Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Read,Glob,Grep,Task,Skill"
-            --json-schema '{"type":"object","properties":{"description":{"type":"string","description":"审查结论一句话摘要，如：代码良好，发现2个小问题"},"conclusion":{"type":"string","enum":["APPROVE","REQUEST_CHANGES","COMMENT"],"description":"审查结论"},"critical_count":{"type":"number","description":"阻塞问题数量"},"important_count":{"type":"number","description":"重要建议数量"},"suggestion_count":{"type":"number","description":"小问题数量"}},"required":["description","conclusion","critical_count","important_count","suggestion_count"]}'
-
-      - name: Output Structured Result
-        if: always()
-        run: |
-          echo "## PR Review Result" >> $GITHUB_STEP_SUMMARY
-          echo '```json' >> $GITHUB_STEP_SUMMARY
-          STRUCTURED_OUTPUT='${{ steps.review.outputs.structured_output }}'
-          echo "${STRUCTURED_OUTPUT}" >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-
-      - name: Notify Feishu
-        if: always() && env.HAS_FEISHU_TOKEN == 'true'
-        uses: actions/checkout@v7
-        with:
-          repository: Lightspeed-Intelligence/agentic-workflow-template
-          ref: main
-          token: ${{ secrets.PAT_TOKEN || github.token }}
-          path: .agentic-actions
-          sparse-checkout: .github/actions
-          sparse-checkout-cone-mode: false
-
-      - name: Send Feishu Notification
-        if: always() && env.HAS_FEISHU_TOKEN == 'true'
-        uses: ./.agentic-actions/.github/actions/feishu-notify
-        with:
-          webhook_token: ${{ secrets.FEISHU_WEBHOOK_TOKEN }}
-          title: "PR 审查: #${{ github.event.pull_request.number }}"
-          description: |
-            **${{ github.repository }}** PR #${{ github.event.pull_request.number }}
-            *${{ github.event.pull_request.title }}*
-          link_text: "🔗 查看 PR"
-          link_url: ${{ github.event.pull_request.html_url }}
-          status: ${{ job.status == 'success' && 'success' || 'warning' }}
+    uses: Lightspeed-Intelligence/agentic-workflow-template/.github/workflows/pr-review.yml@main
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      OPENAI_BASE_URL: ${{ secrets.OPENAI_BASE_URL }}
+      PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
+      FEISHU_WEBHOOK_TOKEN: ${{ secrets.FEISHU_WEBHOOK_TOKEN }}
+    with:
+      use_feishu_notify: false


### PR DESCRIPTION
## 背景

仓库目前在 `agentic-pr-review.yml` 中自行展开 Claude CLI 安装、PR 审查、结构化结果和飞书通知等步骤。这些逻辑已经由 `Lightspeed-Intelligence/agentic-workflow-template` 提供 reusable workflow，继续在本仓库维护会产生重复。

## 改动

- 将 `pr-review` job 改为调用共享的 `pr-review.yml@main`；
- 向共享工作流传递 Anthropic、OpenAI、PAT 和飞书相关 secrets；
- 显式设置 `use_feishu_notify: false`，本次迁移后不再发送飞书通知。

## 验证

- `git diff --check` 通过；
- PR 创建后由 GitHub Actions 实际验证 reusable workflow 的接口和权限配置。
