### PR TITLE
docs: 统一手册标题页构建日期及格式

### DIFF
--- a/ctex/ctex.dtx
+++ b/ctex/ctex.dtx
@@ -487,7 +487,7 @@ This work has the LPPL maintenance status `maintained`.
 %
 % \title{\bfseries \CTeX{} 宏集手册}
 % \author{\href{http://www.ctex.org}{CTEX.ORG}}
-% \date{\filedate\qquad\fileversion\thanks{\ctexkitrev{\filehash}.}}
+% \date{\today\qquad\fileversion\thanks{\ctexkitrev{\filehash}.}}
 % \maketitle
 %
 % \begin{abstract}

--- a/ctex/ctex.dtx
+++ b/ctex/ctex.dtx
@@ -487,7 +487,7 @@ This work has the LPPL maintenance status `maintained`.
 %
 % \title{\bfseries \CTeX{} 宏集手册}
 % \author{\href{http://www.ctex.org}{CTEX.ORG}}
-% \date{\today\qquad\fileversion\thanks{\ctexkitrev{\filehash}.}}
+% \date{\ctexkitbuilddate\qquad\fileversion\thanks{\ctexkitrev{\filehash}.}}
 % \maketitle
 %
 % \begin{abstract}

--- a/llmdoc/memory/decisions/937-version-single-source-l3build-tag.md
+++ b/llmdoc/memory/decisions/937-version-single-source-l3build-tag.md
@@ -83,7 +83,7 @@ stamp 均写 base version。校验与 release-notes 提取用同款 sed 剥后�
 - `support/ctxdoc.cls`：`\GetFileId` 签名从 `{ m }` 改为 `{ O{} m }`，
   可选参数接收固化的 hash：`\tl_set:Nn \filehash {#1}` 再
   `\GetFileInfo {#2}`。版本仍走 `\GetFileInfo` 路径；标题日期后来改用
-  `\today`，不再取 `\filedate`，见下方补充。
+  `\ctexkitbuilddate`，不再取 `\filedate`，见下方补充。
 - `ctex/ctex.dtx` 手册导言区写死 `\GetFileId[097bc3d5]{ctex.sty}`，
   hash 直接固化在 dtx 源码里，不在编译时求值。
 - `ctex/build.lua` 的 `update_tag`：只在处理 module 主 dtx（`ctex.dtx`）
@@ -120,8 +120,9 @@ CTAN 解压场景才能发现。这与本决策 `update_tag` 版本 stamp"打包
 `ctex` 拆分后，标题页从 `ctex.sty` 取得的 `\filedate` 实际只对应
 `ctex-kernel.dtx` 的 stamp，不能代表整份手册或所有拆分源文件的更新日期。
 正式 PDF 已统一由 GitHub Actions 构建，且标题另列版本号，因此 `ctex` 与
-`xeCJK` 的标题日期统一改用 `\today`：版本号标识内容，日期只表示 PDF 的构建日。
-revision hash 仍按本决策在 `l3build tag` 阶段固化，不受此调整影响。
+`xeCJK` 的标题日期统一改用 `\ctexkitbuilddate`，按 `YYYY/MM/DD` 格式排印
+构建当天日期：版本号标识内容，日期只表示 PDF 的构建日。revision hash 仍按
+本决策在 `l3build tag` 阶段固化，不受此调整影响。
 
 ## 适用范围
 

--- a/llmdoc/memory/decisions/937-version-single-source-l3build-tag.md
+++ b/llmdoc/memory/decisions/937-version-single-source-l3build-tag.md
@@ -82,7 +82,8 @@ stamp 均写 base version。校验与 release-notes 提取用同款 sed 剥后�
 - `\sys_get_shell` / `--shell-escape` 依赖**完全移除**。
 - `support/ctxdoc.cls`：`\GetFileId` 签名从 `{ m }` 改为 `{ O{} m }`，
   可选参数接收固化的 hash：`\tl_set:Nn \filehash {#1}` 再
-  `\GetFileInfo {#2}`（date/version 仍走原 `\GetFileInfo` 路径不变）。
+  `\GetFileInfo {#2}`。版本仍走 `\GetFileInfo` 路径；标题日期后来改用
+  `\today`，不再取 `\filedate`，见下方补充。
 - `ctex/ctex.dtx` 手册导言区写死 `\GetFileId[097bc3d5]{ctex.sty}`，
   hash 直接固化在 dtx 源码里，不在编译时求值。
 - `ctex/build.lua` 的 `update_tag`：只在处理 module 主 dtx（`ctex.dtx`）
@@ -113,6 +114,14 @@ CTAN 解压场景才能发现。这与本决策 `update_tag` 版本 stamp"打包
   脚 shorthash」，把 git + `--shell-escape` 变成 CTAN 用户重编的运行时
   硬依赖，四环境实测在典型 CTAN 场景下导致 Emergency stop，比原症状
   `-1` 更差；改为 `l3build tag` 阶段固化写入。
+
+## 后续补充：标题日期改为 PDF 构建日期
+
+`ctex` 拆分后，标题页从 `ctex.sty` 取得的 `\filedate` 实际只对应
+`ctex-kernel.dtx` 的 stamp，不能代表整份手册或所有拆分源文件的更新日期。
+正式 PDF 已统一由 GitHub Actions 构建，且标题另列版本号，因此 `ctex` 与
+`xeCJK` 的标题日期统一改用 `\today`：版本号标识内容，日期只表示 PDF 的构建日。
+revision hash 仍按本决策在 `l3build tag` 阶段固化，不受此调整影响。
 
 ## 适用范围
 

--- a/llmdoc/reference/build-and-test.md
+++ b/llmdoc/reference/build-and-test.md
@@ -488,7 +488,7 @@ CTAN 打包现已完全由 `.github/workflows/release.yml` 自动化驱动。原
 - 包头使用 `\ExplFileDate`、`\ExplFileVersion`
 - 变更历史使用 `\changes{版本号}{日期}{说明}`
 
-调查在 `ctex/ctex.dtx` 中确认了这套机制。文档排版时，这些信息会进入最终文档输出。
+调查在 `ctex/ctex.dtx` 中确认了这套机制。文档排版时，版本与变更信息会进入最终文档输出；`ctex.pdf` 与 `xeCJK.pdf` 的标题日期则统一使用 `\today`，表示 GitHub Actions 生成正式 PDF 的日期，不再借用某个 `.sty` 的源文件 stamp 日期。
 
 ## 版本单一事实源与 l3build tag（zhlineskip / ctex）
 
@@ -499,6 +499,7 @@ CTAN 打包现已完全由 `.github/workflows/release.yml` 自动化驱动。原
 - 本地手跑 `cd <pkg> && l3build tag`，包级重写的 `update_tag`（`ctex/build.lua` / `zhlineskip/build.lua`）把 version 回写进 stamp。**ctex 的 update_tag 带幂等守卫**：stamp 版本已等于 version 时原样保留（不动 date/sha），否则"回写产生新 commit → 新 sha → 又要回写"永不收敛。
 - 注意 `make tag <pkg>-vX.Y.Z` 是打 **git tag**（触发 release.yml），与 `l3build tag`（回写源文件 stamp）是两回事。
 - ctex 的 `update_tag` 在处理主 `ctex.dtx` 时还会额外固化手册首页页脚的 shorthash：取 `git log -1 --format='%h' *.dtx` 回写进 `ctex.dtx` 里的 `\GetFileId[<hash>]{ctex.sty}`（消费方是 `support/ctxdoc.cls` 的 `\GetFileId { O{} m }`，可选参数即固化 hash）。运行时**不**依赖 `\sys_get_shell` / `--shell-escape` 现取 git 信息——曾经的运行时方案已被否决，详见决策 [[937-version-single-source-l3build-tag]] 「手册页脚 shorthash」小节。
+- `\GetFileId` 仍为标题页提供版本号和 revision hash，但不再提供标题日期。`ctex` 拆分后，`ctex.sty` 的 `\filedate` 只反映 `ctex-kernel.dtx` 的 stamp，可能早于手册和其他拆分源文件；因此 `ctex` 与 `xeCJK` 的标题日期统一改用 `\today`。正式 PDF 由 GitHub Actions 集中构建，版本号负责标识内容，日期只表示该 PDF 的构建日。
 
 ### 发版 SOP（ctex 拆分后）
 

--- a/llmdoc/reference/build-and-test.md
+++ b/llmdoc/reference/build-and-test.md
@@ -488,7 +488,7 @@ CTAN 打包现已完全由 `.github/workflows/release.yml` 自动化驱动。原
 - 包头使用 `\ExplFileDate`、`\ExplFileVersion`
 - 变更历史使用 `\changes{版本号}{日期}{说明}`
 
-调查在 `ctex/ctex.dtx` 中确认了这套机制。文档排版时，版本与变更信息会进入最终文档输出；`ctex.pdf` 与 `xeCJK.pdf` 的标题日期则统一使用 `\today`，表示 GitHub Actions 生成正式 PDF 的日期，不再借用某个 `.sty` 的源文件 stamp 日期。
+调查在 `ctex/ctex.dtx` 中确认了这套机制。文档排版时，版本与变更信息会进入最终文档输出；`ctex.pdf` 与 `xeCJK.pdf` 的标题日期则统一使用 `\ctexkitbuilddate`，以 `YYYY/MM/DD` 格式表示 GitHub Actions 生成正式 PDF 的日期，不再借用某个 `.sty` 的源文件 stamp 日期。
 
 ## 版本单一事实源与 l3build tag（zhlineskip / ctex）
 
@@ -499,7 +499,7 @@ CTAN 打包现已完全由 `.github/workflows/release.yml` 自动化驱动。原
 - 本地手跑 `cd <pkg> && l3build tag`，包级重写的 `update_tag`（`ctex/build.lua` / `zhlineskip/build.lua`）把 version 回写进 stamp。**ctex 的 update_tag 带幂等守卫**：stamp 版本已等于 version 时原样保留（不动 date/sha），否则"回写产生新 commit → 新 sha → 又要回写"永不收敛。
 - 注意 `make tag <pkg>-vX.Y.Z` 是打 **git tag**（触发 release.yml），与 `l3build tag`（回写源文件 stamp）是两回事。
 - ctex 的 `update_tag` 在处理主 `ctex.dtx` 时还会额外固化手册首页页脚的 shorthash：取 `git log -1 --format='%h' *.dtx` 回写进 `ctex.dtx` 里的 `\GetFileId[<hash>]{ctex.sty}`（消费方是 `support/ctxdoc.cls` 的 `\GetFileId { O{} m }`，可选参数即固化 hash）。运行时**不**依赖 `\sys_get_shell` / `--shell-escape` 现取 git 信息——曾经的运行时方案已被否决，详见决策 [[937-version-single-source-l3build-tag]] 「手册页脚 shorthash」小节。
-- `\GetFileId` 仍为标题页提供版本号和 revision hash，但不再提供标题日期。`ctex` 拆分后，`ctex.sty` 的 `\filedate` 只反映 `ctex-kernel.dtx` 的 stamp，可能早于手册和其他拆分源文件；因此 `ctex` 与 `xeCJK` 的标题日期统一改用 `\today`。正式 PDF 由 GitHub Actions 集中构建，版本号负责标识内容，日期只表示该 PDF 的构建日。
+- `\GetFileId` 仍为标题页提供版本号和 revision hash，但不再提供标题日期。`ctex` 拆分后，`ctex.sty` 的 `\filedate` 只反映 `ctex-kernel.dtx` 的 stamp，可能早于手册和其他拆分源文件；因此 `ctex` 与 `xeCJK` 的标题日期统一改用 `\ctexkitbuilddate`，按 `YYYY/MM/DD` 格式排印构建当天日期。正式 PDF 由 GitHub Actions 集中构建，版本号负责标识内容，日期只表示该 PDF 的构建日。
 
 ### 发版 SOP（ctex 拆分后）
 

--- a/support/ctxdoc.cls
+++ b/support/ctxdoc.cls
@@ -1002,6 +1002,7 @@
   \ExplSyntaxOff
   \MakePercentIgnore}{}
 \def\ctexkit{\href{https://github.com/CTeX-org/ctex-kit/}{\texttt{ctex-kit}}}
+\def\ctexkitbuilddate{\number\year/\two@digits\month/\two@digits\day}
 \def\ctexkitrev#1{%
   \href{https://github.com/CTeX-org/ctex-kit/commit/#1}{\texttt{ctex-kit} rev. #1}}
 \appto\GlossaryParms{%

--- a/xeCJK/xeCJK.dtx
+++ b/xeCJK/xeCJK.dtx
@@ -320,7 +320,7 @@ Copyright and Licence
 %
 % \title{\bfseries\pkg{xeCJK} 宏包}
 % \author{\href{http://www.ctex.org}{CTEX.ORG}}
-% \date{\filedate\qquad\fileversion\thanks{\ctexkitrev{\ExplFileVersion}.}}
+% \date{\today\qquad\fileversion\thanks{\ctexkitrev{\ExplFileVersion}.}}
 % \maketitle
 %
 % \tableofcontents

--- a/xeCJK/xeCJK.dtx
+++ b/xeCJK/xeCJK.dtx
@@ -320,7 +320,7 @@ Copyright and Licence
 %
 % \title{\bfseries\pkg{xeCJK} 宏包}
 % \author{\href{http://www.ctex.org}{CTEX.ORG}}
-% \date{\today\qquad\fileversion\thanks{\ctexkitrev{\ExplFileVersion}.}}
+% \date{\ctexkitbuilddate\qquad\fileversion\thanks{\ctexkitrev{\ExplFileVersion}.}}
 % \maketitle
 %
 % \tableofcontents


### PR DESCRIPTION
## 变更说明

`ctex.pdf` 与 `xeCJK.pdf` 的标题日期统一从源文件的 `\filedate` 改为 PDF 构建日期，并固定按 `YYYY/MM/DD` 格式排印。版本号与 `ctex-kit rev.` revision hash 保持不变。

两份手册共用 `support/ctxdoc.cls` 中的 `\ctexkitbuilddate`；该命令使用 LaTeX 内核的 `\two@digits` 为月份和日期补零，避免两份手册分别维护日期格式。

`ctex` 拆分为多个 `.dtx` 后，标题页读取的 `ctex.sty` 日期只对应 `ctex-kernel.dtx` 的 stamp，可能早于手册及其他拆分源文件。正式 PDF 目前统一由 GitHub Actions 生成，因此标题日期直接表示 PDF 构建日，版本号继续负责标识内容版本。

| 手册 | 修改前 | 修改后（本地 2026-07-25 构建） |
| --- | --- | --- |
| `ctex.pdf` | `2026/07/14 v2.6.4` | `2026/07/25 v2.6.4` |
| `xeCJK.pdf` | `2026/07/22 v3.10.4` | `2026/07/25 v3.10.4` |

修改后的具体日期取决于实际构建日。已经发布的 GitHub Release／CTAN 资产不会被这次 PR 回写；后续构建会采用新规则。

## 验证

- `cd ctex && l3build doc`
- `cd xeCJK && l3build doc`
- 提取两份生成 PDF 的首页文字，确认均显示 `2026/07/25`，版本号分别仍为 `v2.6.4`、`v3.10.4`
- `git diff --check`
