### PR TITLE
ci(test): l3backend 下载改为多 mirror 兜底

### DIFF
--- a/.github/workflows/_test-package.yml
+++ b/.github/workflows/_test-package.yml
@@ -316,9 +316,30 @@ jobs:
         fi
         echo "::warning::l3kernel ($KERNEL_DATE) 与 l3backend ($BACKEND_DATE) 日期不一致, 从 CTAN 取匹配版本"
         WORK=$(mktemp -d)
-        curl -fsSL --retry 3 --retry-delay 5 \
-          -o "$WORK/l3backend.zip" \
-          "https://mirrors.ctan.org/macros/latex/required/l3backend.zip"
+        # 逐个换 mirror 重试. mirrors.ctan.org 是自动重定向, 偶尔会落到证书链
+        # 不完整的镜像上 —— 实测 test-CJKpunct/ubuntu 与 PR #977 都报
+        # `curl: (60) SSL certificate problem: unable to get local issuer
+        # certificate`, 而同一 run 里其他 20 个 job 用同一份脚本全部成功,
+        # 所以是镜像侧的偶发问题, 不是脚本缺陷. 单点失败不该让整个 job 红,
+        # 因此换用固定 mirror 兜底.
+        DOWNLOADED=
+        for url in \
+          "https://mirrors.ctan.org/macros/latex/required/l3backend.zip" \
+          "https://ctan.math.illinois.edu/macros/latex/required/l3backend.zip" \
+          "https://mirror.ctan.org/macros/latex/required/l3backend.zip" ; do
+          echo "尝试 $url"
+          if curl -fsSL --retry 3 --retry-delay 5 --connect-timeout 30 \
+               -o "$WORK/l3backend.zip" "$url"; then
+            DOWNLOADED=$url
+            break
+          fi
+          echo "::warning::$url 下载失败, 换下一个 mirror"
+        done
+        if [ -z "$DOWNLOADED" ]; then
+          echo "::error::所有 mirror 均无法下载 l3backend; 这是网络/镜像问题, 重跑本 job 即可"
+          exit 1
+        fi
+        echo "下载自 $DOWNLOADED"
         unzip -oq "$WORK/l3backend.zip" -d "$WORK"
         ( cd "$WORK/l3backend" && tex l3backend.ins >/dev/null )
         TEXMFHOME=$(kpsewhich -var-value TEXMFHOME)


### PR DESCRIPTION
## 问题

`master` 的 `522088f8`（上一个 PR 加的 l3backend workaround）CI 红，失败的是 workaround 步骤本身，不是测试：

```
l3kernel:  2026-07-20
l3backend: 2026-02-18
##[warning]l3kernel (2026-07-20) 与 l3backend (2026-02-18) 日期不一致, 从 CTAN 取匹配版本
curl: (60) SSL certificate problem: unable to get local issuer certificate
##[error]Process completed with exit code 60
```

`test-CJKpunct / ubuntu-latest` 和 PR #977 各中一次，`Test <pkg>` 因此被 skip。

## 这不是脚本缺陷

同一个 run 里 21 个 job 用的是同一份脚本，20 个成功、1 个失败。成功的那些确实完成了下载与安装，例如 `test-xeCJK / ubuntu-latest`：

```
resolved:  /home/runner/work/_temp/setup-texlive-action/texmf-local/tex/latex/l3backend/l3backend-pdftex.def (2026-07-20)
```

同一 OS、同一脚本、结果相反，所以是 `mirrors.ctan.org` 的自动重定向偶尔落到证书链不完整的镜像上，属镜像侧偶发问题。

## 改动

下载改为依次尝试三个 URL，任一成功即继续：

1. `mirrors.ctan.org`（自动重定向，通常最快）
2. `ctan.math.illinois.edu`（固定镜像，与 `_test-package.yml` 里 setup-texlive 的 try 2 同源）
3. `mirror.ctan.org`

全部失败才报错，并在错误信息里写明这是网络问题、重跑本 job 即可 —— 避免下次遇到时再从头查一遍。

本地验证：三个 URL 均返回 200 且是合法 zip；把首个 URL 故意替换成不可达地址，确认 fallback 生效并能正常解出 6 个 `.def`（日期 `2026-07-20`）。

## 与 workaround 本身的关系

这只修下载环节的健壮性，不改 workaround 的语义与撤除条件：l3kernel 与 l3backend 日期一致时本步骤仍然直接 `exit 0` 并打 `::notice::` 提示可以删除。撤除判据不变。
