### PR TITLE
docs(xeCJK): 使用 `\tl_set_rescan:nnn` 将 `\mdcode` 参数中出现的 `-` 重新扫描为 `\textminus`

### DIFF
--- a/xeCJK/xeCJK.dtx
+++ b/xeCJK/xeCJK.dtx
@@ -248,6 +248,7 @@ Copyright and Licence
 \dim_new:N \l__codedoc_mdcode_depth_dim
 \DeclareDocumentCommand \mdcode { s m }
   {
+    \mode_leave_vertical:
     \hbox_set:Nn \l__codedoc_mdcode_tmpb_box { \menu {} }
     \fp_set:Nn \l__codedoc_mdcode_scale_fp
       {
@@ -265,10 +266,15 @@ Copyright and Licence
     \hbox_set:Nn \l__codedoc_mdcode_tmpb_box { 汉 }
     \dim_set:Nn \l__codedoc_mdcode_depth_dim
       { 1.131 \box_dp:N \l__codedoc_mdcode_tmpb_box }
-    \clist_map_inline:nn {#2}
+    \tl_set_rescan:Nnn \l__codedoc_mdcode_rescan_tl
+      {
+        \char_gset_active_eq:NN \- \textminus
+        \char_set_catcode_active:N \-
+      } { #2 }
+    \exp_args:No \clist_map_inline:nn {#2}
       {
         \hbox_set:Nn \l__codedoc_mdcode_tmpa_box
-          { \IfBooleanTF {#1} { \menu { \texttt { ##1 } } } { \menu { ##1 } } }
+          { \bool_if:NTF #1 { \menu { \texttt { ##1 } } } { \menu { ##1 } } }
         \box_scale:Nnn \l__codedoc_mdcode_tmpa_box
           { \l__codedoc_mdcode_scale_fp } { \l__codedoc_mdcode_scale_fp }
         \box_move_up:nn

--- a/xeCJK/xeCJK.dtx
+++ b/xeCJK/xeCJK.dtx
@@ -271,7 +271,7 @@ Copyright and Licence
         \char_gset_active_eq:NN \- \textminus
         \char_set_catcode_active:N \-
       } { #2 }
-    \exp_args:No \clist_map_inline:nn {#2}
+    \clist_map_inline:Nn \l__codedoc_mdcode_rescan_tl
       {
         \hbox_set:Nn \l__codedoc_mdcode_tmpa_box
           { \bool_if:NTF #1 { \menu { \texttt { ##1 } } } { \menu { ##1 } } }


### PR DESCRIPTION
fix #1060
- 同时添加 `\mode_leave_vertical:`, 否则如果此命令出现在行首会报错 (参考 `\xpinyin` 的做法)
- 改用 `\bool_if:NTF` 去接受 `xparse` 的 `s`-type 参数