### PR TITLE
fix(ci): Codex 走 priority 通道, 主链路失败不再让 job 显红

### DIFF
--- a/.github/actions/run-agent/action.yml
+++ b/.github/actions/run-agent/action.yml
@@ -89,7 +89,7 @@ runs:
             export OPENAI_API_KEY="$API_KEY"
             export CODEX_HOME="$RUNNER_TEMP/codex-home"
             mkdir -p "$CODEX_HOME"
-            endpoint="${BASE_URL:-https://llm.fantacy.live}"
+            endpoint="${BASE_URL:-https://api.openai.com}"
             endpoint="${endpoint%/}"
             case "$endpoint" in
               */v1) ;;
@@ -98,6 +98,8 @@ runs:
             cat > "$CODEX_HOME/config.toml" <<EOF
         model = "$MODEL"
         model_provider = "gateway"
+        service_tier = "priority"
+        model_reasoning_effort = "high"
 
         [model_providers.gateway]
         name = "gateway"

--- a/.github/workflows/agentic-issue-dispatch.yml
+++ b/.github/workflows/agentic-issue-dispatch.yml
@@ -54,6 +54,11 @@ jobs:
     needs: prepare
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    # 主链路失败由 claude fallback 兜住, 整体结论在 dispatch job 给出, 所以这个 job
+    # 不再以红叉示人。成败通过 outputs.status 传给下游 —— 带了 continue-on-error 之后
+    # needs.codex_analyze.result 恒为 success, 下游一律判 outputs.status。
+    outputs:
+      status: ${{ steps.status.outputs.status }}
     permissions:
       contents: read
     steps:
@@ -156,6 +161,8 @@ jobs:
             >> "$GITHUB_ENV"
 
       - name: Analyze with Codex
+        id: agent
+        continue-on-error: true
         uses: ./consumer/.github/actions/run-agent
         with:
           provider: codex
@@ -168,6 +175,9 @@ jobs:
           result_file: ${{ runner.temp }}/raw-result.json
 
       - name: Normalize Codex result
+        id: validate
+        if: steps.agent.outcome == 'success'
+        continue-on-error: true
         run: |
           test -x "$TRUSTED_ANSWER_NORMALIZER"
           mkdir -p "$RUNNER_TEMP/agent-result"
@@ -176,6 +186,7 @@ jobs:
             codex gpt-5.6-sol issue-dispatch
 
       - name: Upload Codex analysis
+        if: steps.validate.outcome == 'success'
         uses: actions/upload-artifact@v7
         with:
           name: issue-dispatch-result-codex
@@ -184,10 +195,34 @@ jobs:
           overwrite: true
           retention-days: 1
 
+      # 汇总两个带 continue-on-error 的步骤。失败时打 ::warning:: 而非 ::error::,
+      # job 保持绿色但异常仍可从 annotation 检索; 真正的红由 dispatch job 在两条链路
+      # 都失败时给出。
+      - name: Report Codex chain status
+        id: status
+        if: always()
+        run: |
+          set -euo pipefail
+          if [ "${{ steps.agent.outcome }}" != 'success' ]; then
+            reason='CLI 执行失败'
+          elif [ "${{ steps.validate.outcome }}" != 'success' ]; then
+            reason='输出未通过结果规范化或校验'
+          else
+            reason=''
+          fi
+          if [ -n "$reason" ]; then
+            echo "status=failure" >> "$GITHUB_OUTPUT"
+            echo "::warning title=Codex 主链路失败::${reason}；将由 Claude Code fallback 接手"
+            printf '### Codex 主链路失败\n\n%s\n\n将由 Claude Code fallback 接手。\n' \
+              "$reason" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "status=success" >> "$GITHUB_OUTPUT"
+          fi
+
   claude_analyze:
     name: Analyze with Claude Code (fallback)
     needs: [prepare, codex_analyze]
-    if: always() && github.repository == 'CTeX-org/ctex-kit' && needs.prepare.result == 'success' && needs.codex_analyze.result != 'success'
+    if: always() && github.repository == 'CTeX-org/ctex-kit' && needs.prepare.result == 'success' && needs.codex_analyze.outputs.status != 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
@@ -332,14 +367,14 @@ jobs:
       description: ${{ steps.publish.outputs.description }}
     steps:
       - name: Download Codex analysis
-        if: needs.codex_analyze.result == 'success'
+        if: needs.codex_analyze.outputs.status == 'success'
         uses: actions/download-artifact@v8
         with:
           name: issue-dispatch-result-codex
           path: ${{ runner.temp }}/agent-result
 
       - name: Download Claude analysis
-        if: needs.codex_analyze.result != 'success' && needs.claude_analyze.result == 'success'
+        if: needs.codex_analyze.outputs.status != 'success' && needs.claude_analyze.result == 'success'
         uses: actions/download-artifact@v8
         with:
           name: issue-dispatch-result-claude
@@ -347,7 +382,7 @@ jobs:
 
       - name: Validate and publish analysis
         id: publish
-        if: needs.codex_analyze.result == 'success' || needs.claude_analyze.result == 'success'
+        if: needs.codex_analyze.outputs.status == 'success' || needs.claude_analyze.result == 'success'
         env:
           GH_TOKEN: ${{ github.token }}
           REPOSITORY: ${{ github.repository }}
@@ -406,7 +441,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Fail when no analysis succeeded
-        if: always() && needs.codex_analyze.result != 'success' && needs.claude_analyze.result != 'success'
+        if: always() && needs.codex_analyze.outputs.status != 'success' && needs.claude_analyze.result != 'success'
         run: |
           echo "::error::Codex 主链路与 Claude Code fallback 均执行失败"
           exit 1

--- a/.github/workflows/agentic-llmdoc-updater.yml
+++ b/.github/workflows/agentic-llmdoc-updater.yml
@@ -78,6 +78,12 @@ jobs:
     timeout-minutes: 60
     permissions:
       contents: read
+    # 主链路失败由 claude fallback 兜住, 整体结论在 update job 给出, 所以这个 job 不再
+    # 以红叉示人。下游必须判 outputs.status —— 带了 continue-on-error 之后
+    # needs.codex_candidate.outputs.status 恒为 success。本 job 的 status 只覆盖候选生成,
+    # 校验由独立的 validate_codex job 负责, 下游要同时判两个 status。
+    outputs:
+      status: ${{ steps.status.outputs.status }}
     steps:
       - name: Checkout event-pinned consumer base
         uses: actions/checkout@v7
@@ -181,6 +187,8 @@ jobs:
           PROMPT
 
       - name: Update llmdoc with Codex
+        id: agent
+        continue-on-error: true
         uses: ./runtime/.github/actions/run-agent
         with:
           provider: codex
@@ -203,6 +211,8 @@ jobs:
           token: ${{ github.token }}
 
       - name: Import Agent llmdoc content into fresh packaging base
+        id: import
+        continue-on-error: true
         run: |
           test -d consumer/llmdoc
           test ! -L consumer/llmdoc
@@ -218,6 +228,8 @@ jobs:
             consumer/llmdoc/. package-base/llmdoc/
 
       - name: Package Codex candidate
+        id: package
+        continue-on-error: true
         run: |
           bash runtime/.github/scripts/agentic/package-change-result.sh \
             "$RUNNER_TEMP/raw-result.json" "$GITHUB_WORKSPACE/package-base" \
@@ -225,6 +237,7 @@ jobs:
             codex gpt-5.6-sol update-llmdoc
 
       - name: Upload Codex candidate
+        if: steps.package.outcome == 'success'
         uses: actions/upload-artifact@v7
         with:
           name: update-llmdoc-candidate-codex
@@ -233,13 +246,44 @@ jobs:
           overwrite: true
           retention-days: 1
 
+      # 汇总三个带 continue-on-error 的步骤。失败时打 ::warning:: 而非 ::error::,
+      # job 保持绿色但异常仍可从 annotation 检索; 真正的红由 update job 在两条链路都
+      # 失败时给出。注意本 job 的 status 只覆盖候选生成, 校验由独立的 validate_codex
+      # job 负责, 下游要同时判两个 status。
+      - name: Report Codex chain status
+        id: status
+        if: always()
+        run: |
+          set -euo pipefail
+          if [ "${{ steps.agent.outcome }}" != 'success' ]; then
+            reason='CLI 执行失败'
+          elif [ "${{ steps.import.outcome }}" != 'success' ]; then
+            reason='导入 llmdoc 内容到打包基线失败'
+          elif [ "${{ steps.package.outcome }}" != 'success' ]; then
+            reason='打包候选失败'
+          else
+            reason=''
+          fi
+          if [ -n "$reason" ]; then
+            echo "status=failure" >> "$GITHUB_OUTPUT"
+            echo "::warning title=Codex 主链路失败::${reason}；将由 Claude Code fallback 接手"
+            printf '### Codex 主链路失败\n\n%s\n\n将由 Claude Code fallback 接手。\n' \
+              "$reason" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "status=success" >> "$GITHUB_OUTPUT"
+          fi
+
   validate_codex:
     name: Validate Codex llmdoc update
     needs: [prepare, codex_candidate]
+    # 候选生成失败时无需再校验; 这里显式跳过, 避免下载不存在的 artifact 而红。
+    if: always() && needs.codex_candidate.outputs.status == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
       contents: read
+    outputs:
+      status: ${{ steps.status.outputs.status }}
     steps:
       - name: Checkout event-pinned consumer base
         uses: actions/checkout@v7
@@ -274,11 +318,14 @@ jobs:
           path: ${{ runner.temp }}/candidate
 
       - name: Validate Codex candidate
+        id: validate
+        continue-on-error: true
         run: |
           bash runtime/.github/scripts/agentic/validate-change-artifact.sh \
             "$RUNNER_TEMP/candidate" "$GITHUB_WORKSPACE/consumer" update-llmdoc
 
       - name: Upload validated Codex candidate
+        if: steps.validate.outcome == 'success'
         uses: actions/upload-artifact@v7
         with:
           name: update-llmdoc-validated-codex
@@ -287,10 +334,24 @@ jobs:
           overwrite: true
           retention-days: 1
 
+      - name: Report Codex validation status
+        id: status
+        if: always()
+        run: |
+          set -euo pipefail
+          if [ "${{ steps.validate.outcome }}" != 'success' ]; then
+            echo "status=failure" >> "$GITHUB_OUTPUT"
+            echo "::warning title=Codex 候选未通过校验::将由 Claude Code fallback 接手"
+            printf '### Codex 候选未通过校验\n\n将由 Claude Code fallback 接手。\n' \
+              >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "status=success" >> "$GITHUB_OUTPUT"
+          fi
+
   claude_candidate:
     name: Update llmdoc with Claude Code (fallback)
     needs: [prepare, codex_candidate, validate_codex]
-    if: always() && github.repository == 'CTeX-org/ctex-kit' && needs.prepare.result == 'success' && (needs.codex_candidate.result != 'success' || needs.validate_codex.result != 'success')
+    if: always() && github.repository == 'CTeX-org/ctex-kit' && needs.prepare.result == 'success' && (needs.codex_candidate.outputs.status != 'success' || needs.validate_codex.outputs.status != 'success')
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
@@ -518,21 +579,21 @@ jobs:
       status: ${{ steps.publish.outputs.status }}
     steps:
       - name: Download validated Codex candidate
-        if: needs.codex_candidate.result == 'success' && needs.validate_codex.result == 'success'
+        if: needs.codex_candidate.outputs.status == 'success' && needs.validate_codex.outputs.status == 'success'
         uses: actions/download-artifact@v8
         with:
           name: update-llmdoc-validated-codex
           path: ${{ runner.temp }}/validated-candidate
 
       - name: Download validated Claude candidate
-        if: (needs.codex_candidate.result != 'success' || needs.validate_codex.result != 'success') && needs.claude_candidate.result == 'success' && needs.validate_claude.result == 'success'
+        if: (needs.codex_candidate.outputs.status != 'success' || needs.validate_codex.outputs.status != 'success') && needs.claude_candidate.result == 'success' && needs.validate_claude.result == 'success'
         uses: actions/download-artifact@v8
         with:
           name: update-llmdoc-validated-claude
           path: ${{ runner.temp }}/validated-candidate
 
       - name: Checkout event-pinned publisher
-        if: (needs.codex_candidate.result == 'success' && needs.validate_codex.result == 'success') || (needs.claude_candidate.result == 'success' && needs.validate_claude.result == 'success')
+        if: (needs.codex_candidate.outputs.status == 'success' && needs.validate_codex.outputs.status == 'success') || (needs.claude_candidate.result == 'success' && needs.validate_claude.result == 'success')
         uses: actions/checkout@v7
         with:
           ref: ${{ needs.prepare.outputs.base_sha }}
@@ -544,7 +605,7 @@ jobs:
 
       - name: Validate and publish llmdoc update
         id: publish
-        if: (needs.codex_candidate.result == 'success' && needs.validate_codex.result == 'success') || (needs.claude_candidate.result == 'success' && needs.validate_claude.result == 'success')
+        if: (needs.codex_candidate.outputs.status == 'success' && needs.validate_codex.outputs.status == 'success') || (needs.claude_candidate.result == 'success' && needs.validate_claude.result == 'success')
         env:
           GH_TOKEN: ${{ secrets.PAT_TOKEN || github.token }}
           REPOSITORY: ${{ github.repository }}
@@ -573,7 +634,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Fail when no candidate succeeded
-        if: always() && !((needs.codex_candidate.result == 'success' && needs.validate_codex.result == 'success') || (needs.claude_candidate.result == 'success' && needs.validate_claude.result == 'success'))
+        if: always() && !((needs.codex_candidate.outputs.status == 'success' && needs.validate_codex.outputs.status == 'success') || (needs.claude_candidate.result == 'success' && needs.validate_claude.result == 'success'))
         run: |
           echo "::error::Codex 与 Claude Code 均未产出通过校验的 llmdoc 候选结果"
           exit 1

--- a/.github/workflows/agentic-pr-review.yml
+++ b/.github/workflows/agentic-pr-review.yml
@@ -23,6 +23,12 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
+    # 主链路失败由 fallback 兜住，整体结论在 publish job 里给出，所以这个 job 本身
+    # 不再以红叉示人：CLI 与校验步骤都带 continue-on-error，成败通过 outputs.status
+    # 传给下游。后续 job 一律判这个 output，不要判 needs.codex_review.result —— 带了
+    # continue-on-error 之后那个值恒为 success。
+    outputs:
+      status: ${{ steps.status.outputs.status }}
     steps:
       - name: Checkout PR head without persisted credentials
         uses: actions/checkout@v7
@@ -215,6 +221,8 @@ jobs:
           PROMPT_EOF
 
       - name: Review with Codex and GPT-5.6-sol
+        id: agent
+        continue-on-error: true
         uses: ./.trusted-base/.github/actions/run-agent
         with:
           provider: codex
@@ -227,6 +235,9 @@ jobs:
           result_file: ${{ runner.temp }}/review-raw.json
 
       - name: Normalize and validate Codex review
+        id: validate
+        if: steps.agent.outcome == 'success'
+        continue-on-error: true
         run: |
           mkdir -p review-output
           jq -c '. + {reviewer: "codex", model: "gpt-5.6-sol"}' \
@@ -250,6 +261,7 @@ jobs:
           jq -e '.review_status == "COMPLETE"' review-output/review.json > /dev/null
 
       - name: Upload Codex review result
+        if: steps.validate.outcome == 'success'
         uses: actions/upload-artifact@v7
         with:
           name: review-result-codex
@@ -258,11 +270,35 @@ jobs:
           overwrite: true
           retention-days: 1
 
+      # 汇总两个带 continue-on-error 的步骤，把成败落到 job output 上。失败时打
+      # ::warning:: 而不是 ::error::，这样 job 保持绿色但异常仍留在 annotation 里可检索；
+      # 真正的红由 publish job 在两条链路都失败时给出。
+      - name: Report Codex chain status
+        id: status
+        if: always()
+        run: |
+          set -euo pipefail
+          if [ "${{ steps.agent.outcome }}" != 'success' ]; then
+            reason='CLI 执行失败'
+          elif [ "${{ steps.validate.outcome }}" != 'success' ]; then
+            reason='输出未通过结构校验或 review_status 不是 COMPLETE'
+          else
+            reason=''
+          fi
+          if [ -n "$reason" ]; then
+            echo "status=failure" >> "$GITHUB_OUTPUT"
+            echo "::warning title=Codex 主链路失败::${reason}；将由 Claude Code fallback 接手，最终结论见 review job"
+            printf '### Codex 主链路失败\n\n%s\n\n将由 Claude Code fallback 接手。\n' \
+              "$reason" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "status=success" >> "$GITHUB_OUTPUT"
+          fi
+
   # 独立 runner 避免失败的 Codex 进程污染 fallback 的工作树、工具或输入。
   claude_review:
     name: Review with Claude Code (fallback)
     needs: codex_review
-    if: always() && needs.codex_review.result != 'success'
+    if: always() && needs.codex_review.outputs.status != 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
@@ -510,7 +546,7 @@ jobs:
       structured_output: ${{ steps.result.outputs.structured_output }}
     steps:
       - name: Download Codex review result
-        if: needs.codex_review.result == 'success'
+        if: needs.codex_review.outputs.status == 'success'
         uses: actions/download-artifact@v8
         with:
           name: review-result-codex
@@ -525,7 +561,7 @@ jobs:
 
       - name: Validate and publish review comment
         id: result
-        if: needs.codex_review.result == 'success' || needs.claude_review.result == 'success'
+        if: needs.codex_review.outputs.status == 'success' || needs.claude_review.result == 'success'
         env:
           GH_TOKEN: ${{ github.token }}
           REVIEW_FILE: .review-input/review.json
@@ -633,7 +669,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Fail when no reviewer succeeded
-        if: always() && needs.codex_review.result != 'success' && needs.claude_review.result != 'success'
+        if: always() && needs.codex_review.outputs.status != 'success' && needs.claude_review.result != 'success'
         run: |
           echo "::error::Codex 主链路与 Claude Code fallback 均执行失败"
           exit 1

--- a/scripts/test-agentic-workflow-contract.py
+++ b/scripts/test-agentic-workflow-contract.py
@@ -108,8 +108,24 @@ def assert_pr_review_draft_contract(source: str) -> None:
     jobs = document["jobs"]
     assert "if" not in jobs["codex_review"], "Codex 主审不得按 Draft 状态或其他条件恒定跳过"
     assert jobs["claude_review"].get("needs") == "codex_review", "Claude 兜底必须等待 Codex 主审"
-    assert jobs["claude_review"].get("if") == "always() && needs.codex_review.result != 'success'", (
-        "Claude 兜底条件必须只取决于 Codex 是否成功"
+    # codex_review 的关键步骤带 continue-on-error（让主链路失败时该 job 不显红），
+    # 因此 needs.codex_review.result 恒为 success，下游必须判 outputs.status。
+    # 这条断言同时守住两件事：兜底只依赖 Codex 成败，且判的是那个仍有判别力的信号。
+    assert jobs["claude_review"].get("if") == "always() && needs.codex_review.outputs.status != 'success'", (
+        "Claude 兜底条件必须只取决于 Codex 是否成功，且须判 outputs.status 而非 result"
+        "（result 在 continue-on-error 下恒为 success）"
+    )
+    assert jobs["codex_review"].get("outputs", {}).get("status"), (
+        "codex_review 必须导出 status output 供下游判断，否则 continue-on-error 会让失败无声通过"
+    )
+    codex_steps = unique_steps_by_name(jobs["codex_review"]["steps"], "Codex 主审")
+    for name in ("Review with Codex and GPT-5.6-sol", "Normalize and validate Codex review"):
+        assert name in codex_steps, f"Codex 主审缺少 step: {name}"
+        assert codex_steps[name].get("continue-on-error") is True, (
+            f"Codex 主审 step 必须带 continue-on-error 才能避免 job 显红: {name}"
+        )
+    assert "Report Codex chain status" in codex_steps, (
+        "Codex 主审必须有汇总 step 把成败写进 outputs.status"
     )
     assert jobs["publish"].get("needs") == ["codex_review", "claude_review"], (
         "PR publisher 必须等待两条审查链"
@@ -118,13 +134,14 @@ def assert_pr_review_draft_contract(source: str) -> None:
 
     publish_steps = unique_steps_by_name(jobs["publish"]["steps"], "PR publisher")
     expected_conditions = {
-        "Download Codex review result": "needs.codex_review.result == 'success'",
+        "Download Codex review result": "needs.codex_review.outputs.status == 'success'",
         "Download Claude review result": "needs.claude_review.result == 'success'",
         "Validate and publish review comment": (
-            "needs.codex_review.result == 'success' || needs.claude_review.result == 'success'"
+            "needs.codex_review.outputs.status == 'success' || needs.claude_review.result == 'success'"
         ),
         "Fail when no reviewer succeeded": (
-            "always() && needs.codex_review.result != 'success' && needs.claude_review.result != 'success'"
+            "always() && needs.codex_review.outputs.status != 'success' "
+            "&& needs.claude_review.result != 'success'"
         ),
     }
     for name, expected in expected_conditions.items():
@@ -1211,13 +1228,13 @@ def main() -> None:
     )
     assert_pr_review_draft_contract(review)
     duplicate_codex_download = review.replace(
-        "        if: needs.codex_review.result == 'success'\n",
+        "        if: needs.codex_review.outputs.status == 'success'\n",
         "        if: 0 == 1\n",
         1,
     ).replace(
         "      - name: Download Claude review result\n",
         "      - name: Download Codex review result\n"
-        "        if: needs.codex_review.result == 'success'\n"
+        "        if: needs.codex_review.outputs.status == 'success'\n"
         "        run: \"true\"\n\n"
         "      - name: Download Claude review result\n",
         1,
@@ -1233,16 +1250,16 @@ def main() -> None:
         ),
         (
             review.replace(
-                "    if: always() && needs.codex_review.result != 'success'\n",
-                "    if: always() && needs.codex_review.result != 'success' && 0 == 1\n",
+                "    if: always() && needs.codex_review.outputs.status != 'success'\n",
+                "    if: always() && needs.codex_review.outputs.status != 'success' && 0 == 1\n",
                 1,
             ),
             "Claude 兜底恒假条件",
         ),
         (
             review.replace(
-                "    if: always()\n",
-                "    if: always() && 0 == 1\n",
+                "    needs: [codex_review, claude_review]\n    if: always()\n",
+                "    needs: [codex_review, claude_review]\n    if: always() && 0 == 1\n",
                 1,
             ),
             "publisher 恒假条件",
@@ -1257,7 +1274,7 @@ def main() -> None:
         ),
         (
             review.replace(
-                "        if: needs.codex_review.result == 'success'\n",
+                "        if: needs.codex_review.outputs.status == 'success'\n",
                 "        if: 0 == 1\n",
                 1,
             ),
@@ -1273,7 +1290,7 @@ def main() -> None:
         ),
         (
             review.replace(
-                "        if: needs.codex_review.result == 'success' || needs.claude_review.result == 'success'\n",
+                "        if: needs.codex_review.outputs.status == 'success' || needs.claude_review.result == 'success'\n",
                 "        if: 0 == 1\n",
                 1,
             ),
@@ -1281,7 +1298,7 @@ def main() -> None:
         ),
         (
             review.replace(
-                "        if: always() && needs.codex_review.result != 'success' && needs.claude_review.result != 'success'\n",
+                "        if: always() && needs.codex_review.outputs.status != 'success' && needs.claude_review.result != 'success'\n",
                 "        if: 0 == 1\n",
                 1,
             ),
@@ -1294,12 +1311,12 @@ def main() -> None:
         (
             review.replace(
                 "      - name: Download Codex review result\n"
-                "        if: needs.codex_review.result == 'success'\n"
+                "        if: needs.codex_review.outputs.status == 'success'\n"
                 "        uses: actions/download-artifact@v8\n"
                 "        with:\n"
                 "          name: review-result-codex\n",
                 "      - name: Download Codex review result\n"
-                "        if: needs.codex_review.result == 'success'\n"
+                "        if: needs.codex_review.outputs.status == 'success'\n"
                 "        uses: actions/download-artifact@v8\n"
                 "        with:\n"
                 "          name: review-result-claude\n",

--- a/scripts/test-agentic-workflow-contract.py
+++ b/scripts/test-agentic-workflow-contract.py
@@ -180,6 +180,49 @@ def assert_pr_review_draft_contract(source: str) -> None:
     assert failure_result.returncode != 0, "两条审查链都失败时，publisher 必须以非零状态结束"
 
 
+def assert_codex_chain_not_red(source: str, label: str, chain: dict) -> None:
+    """主链路失败不得让 job 显红, 但失败信号必须仍可被下游判别。
+
+    codex 侧的关键步骤带 continue-on-error（这样 fallback 接手时主 job 不挂红叉），
+    代价是 needs.<job>.result 恒为 success。因此每个这样的 job 都必须导出
+    outputs.status，且全仓不得再有任何地方判它的 .result —— 那个值已经没有判别力了。
+
+    chain 形如 {"job 名": ["必须带 continue-on-error 的 step 名", ...]}。
+    """
+    document = parse_workflow(source)
+    jobs = document["jobs"]
+    for job_name, step_names in chain.items():
+        assert job_name in jobs, f"{label} 缺少 job: {job_name}"
+        job = jobs[job_name]
+        assert job.get("outputs", {}).get("status"), (
+            f"{label} 的 {job_name} 必须导出 status output，"
+            "否则 continue-on-error 会让失败无声通过"
+        )
+        steps = unique_steps_by_name(job["steps"], f"{label} {job_name}")
+        for step_name in step_names:
+            assert step_name in steps, f"{label} 的 {job_name} 缺少 step: {step_name}"
+            assert steps[step_name].get("continue-on-error") is True, (
+                f"{label} 的 {job_name} step 必须带 continue-on-error 才能避免 job 显红: "
+                f"{step_name}"
+            )
+        assert any(
+            isinstance(v, str) and v.startswith("${{ steps.")
+            for v in job["outputs"].values()
+        ), f"{label} 的 {job_name} 的 status 必须来自某个汇总 step 的 output"
+
+    # 判别力的关键：改成 continue-on-error 之后 .result 恒为 success，任何残留的
+    # .result 判断都是静默失效的门禁。
+    # 只看有效行：注释里出现这个串是在解释「不要判它」，不算违规。
+    effective = "\n".join(
+        line for line in source.split("\n") if not line.lstrip().startswith("#")
+    )
+    for job_name in chain:
+        assert f"needs.{job_name}.result" not in effective, (
+            f"{label} 仍有地方判 needs.{job_name}.result —— 该值在 continue-on-error 下"
+            "恒为 success，必须改判 outputs.status"
+        )
+
+
 def assert_contract_hook_coverage(source: str) -> None:
     document = parse_workflow(source)
     trigger_paths = document["on"]["pull_request"]["paths"]
@@ -1227,6 +1270,37 @@ def main() -> None:
         "PR Review trigger",
     )
     assert_pr_review_draft_contract(review)
+
+    # 三条 codex -> claude fallback 链路都不得在主链路失败时显红（见
+    # assert_codex_chain_not_red 的说明）。llmdoc 那条把候选生成与校验拆成两个 job，
+    # 所以两个都要检查。
+    assert_codex_chain_not_red(
+        review,
+        "PR Review",
+        {
+            "codex_review": (
+                "Review with Codex and GPT-5.6-sol",
+                "Normalize and validate Codex review",
+            )
+        },
+    )
+    assert_codex_chain_not_red(
+        issue,
+        "Issue Dispatch",
+        {"codex_analyze": ("Analyze with Codex", "Normalize Codex result")},
+    )
+    assert_codex_chain_not_red(
+        llmdoc,
+        "llmdoc Updater",
+        {
+            "codex_candidate": (
+                "Update llmdoc with Codex",
+                "Import Agent llmdoc content into fresh packaging base",
+                "Package Codex candidate",
+            ),
+            "validate_codex": ("Validate Codex candidate",),
+        },
+    )
     duplicate_codex_download = review.replace(
         "        if: needs.codex_review.outputs.status == 'success'\n",
         "        if: 0 == 1\n",


### PR DESCRIPTION
两件事：Codex 走 priority 通道提速，以及主链路失败时不再让 job 显红。

## 一、Codex 走 priority 通道并提高推理强度

给 `codex exec` 的 `config.toml` 补两项：

- `service_tier = "priority"` — 走优先队列减少排队。审查耗时的波动主要来自排队而非推理本身
  （近几次 Review with Codex 实测 2–13 分钟，其中 13 分钟那次是 PR #1073，它自己跑了 ctex
  全套 186 项）。
- `model_reasoning_effort = "high"` — 这类审查要跑 `l3build`、编译 MWE、比对 PDF 读数，推理
  强度不足容易漏掉需要多步验证才能发现的问题。

同时把默认 endpoint 从 `llm.fantacy.live` 改为 `api.openai.com`。三处调用都显式传
`secrets.OPENAI_BASE_URL`，该默认值只在 secret 为空时生效，改成官方端点作兜底更合理。

## 二、主链路失败不再让 job 显红

**问题**：codex 失败、claude fallback 成功时，整个 workflow 的结论是对的（最终 job 只在两条
链路都失败时 `exit 1`），但 `codex_review` 那个 job 仍挂红叉。结论正确而观感是失败，容易让人
以为 CI 有问题。

**改法**：关键步骤加 `continue-on-error`，新增汇总步骤把成败写进 job output。失败时打
`::warning::` 而非 `::error::` —— job 保持绿色，异常仍留在 annotation 与 job summary 里可
检索。真正的红仍由最终 job 在两条链路都失败时给出，这一点没变。

三条 codex → claude fallback 链路一并处理：

| 链路 | 加 `continue-on-error` 的步骤 | 改判 `outputs.status` 的依赖点 |
| --- | --- | --- |
| PR Review | CLI 调用、结构校验 | 4 处 |
| Issue Dispatch | CLI 调用、结果规范化 | 5 处 |
| llmdoc Updater | CLI 调用、导入、打包 + 独立的校验 job | 7 处 |

`llmdoc Updater` 结构特殊——它把候选生成与校验拆成两个 job，两个都要导出 status，下游判组合。
另外给 `validate_codex` 加了 `if`，候选生成失败时显式跳过，否则它会去下载不存在的 artifact
而红。

### 一个容易踩的坑

加了 `continue-on-error` 之后 `needs.<job>.result` **恒为 success**。所以所有下游判断必须改判
`outputs.status`——fallback 触发条件、artifact 下载、发布条件、以及「两条都失败才 `exit 1`」。
漏掉任何一处，后果是 fallback 不再触发，或者失败无声通过。

这正是下面那条新断言存在的理由。

## 契约校验

新增 `assert_codex_chain_not_red`，一次覆盖三条链路，检查四件事：

1. job 必须导出 `status` output；
2. 指定步骤必须带 `continue-on-error`；
3. `status` 必须来自某个汇总 step 的 output；
4. **全仓不得再有任何地方判该 job 的 `.result`** —— 那个值已经没有判别力，残留的判断都是
   静默失效的门禁。

第 4 条比对时排除注释行。第一版没排除，立刻把我自己写的「不要判 `.result`」说明当成了违规。

判别力已实测（每轮独立恢复后单跑）：

| 变异 | 结果 |
| --- | --- |
| 去掉 Issue Dispatch 的 `outputs` | 报「必须导出 status output」 |
| 去掉 llmdoc `validate_codex` 的 `continue-on-error` | 报「step 必须带 continue-on-error」 |
| 把某处 `outputs.status` 改回 `.result` | 报「仍有地方判 .result」 |

三次都被对应断言精确拦住，恢复后契约全绿。

同时更新了 `agentic-pr-review` 那部分原有的硬编码断言与**七处反例构造**——它们靠替换原字符串
构造坏样例，我改了 workflow 后替换会失效、反例反而通过。其中 `publisher 恒假条件` 那条原先匹配
`if: always()` 的首次出现，而我新加的 step 恰好也带 `if: always()` 且位置更靠前，已改为按
`needs` 行锚定。

## 验证

- `python3 scripts/test-agentic-workflow-contract.py` 通过，含它自带的全部反例测试。
- 三个 workflow 的 YAML 均解析成功。
- 本 PR 自身会跑一次 PR Review，正好验证改动后的主链路仍然正常。

## 一处仍待观察

`high` effort 可能拉长单次审查时间，与 priority 省下的排队时间方向相反。净效果要看几轮 CI
才知道；若总耗时反而变长，可以把 effort 降到 `medium` 让 priority 的收益显出来。
